### PR TITLE
Wrong parsing of public suffix

### DIFF
--- a/library/Pdp/Parser.php
+++ b/library/Pdp/Parser.php
@@ -129,6 +129,9 @@ class Parser
                 $publicSuffixList = $publicSuffixList['*'];
                 continue;
             }
+            
+            // unknown part 
+            break;
         }
 
         // Apply algorithm rule #2: If no rules match, the prevailing rule is "*".

--- a/tests/library/Pdp/ParserTest.php
+++ b/tests/library/Pdp/ParserTest.php
@@ -94,6 +94,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             array('a.b.test.om', 'test.om', 'b.test.om', 'a', 'a.b.test.om'),
             array('baez.songfest.om', 'om', 'songfest.om', 'baez', 'baez.songfest.om'),
             array('politics.news.omanpost.om', 'om', 'omanpost.om', 'politics.news', 'politics.news.omanpost.om'),
+            array('us.example.com', 'com', 'example.com', 'us', 'us.example.com'),
         );
     }
 	


### PR DESCRIPTION
Parsing the host `us.example.com` was resulting in public suffix `us.com`

The problem is that the loop in `Pdp\Parser#getPublicSuffix` (line 115) did not match `example` in public suffix list but it continues.

A `break` at the end of the loop solved it.
