### PR TITLE
Add a way to validate TLDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor
 docs
 *~
 build
+# Intellij
+.idea
+*.iml

--- a/tests/library/Pdp/ParserTest.php
+++ b/tests/library/Pdp/ParserTest.php
@@ -22,6 +22,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Pdp\Parser::getRawPublicSuffix()
+     */
+    public function testGetRawPublicSuffixReturnsFalseForHostsWithInvalidDomain()
+    {
+        $this->assertFalse($this->parser->getRawPublicSuffix('http://www.example.faketld'));
+        $this->assertFalse($this->parser->getRawPublicSuffix('http://www.example.faketld?x=y&a=b'));
+    }
+
+    /**
      * @covers Pdp\Parser::parseUrl()
      * @covers ::mb_parse_url
      */


### PR DESCRIPTION
Add a new function Pdp\Parser::getRawPublicSuffix() that can be used to check a host’s TLD for validity. The method returns `false` for invalid TLDs. Move most logic from Pdp\Parser::getPublicSuffix() into this new method. Ensure existing unit tests pass. Add unit tests for validating the one new logic rule introduced by the new method.
