### PR TITLE
Ensure scheme returns null rather than an empty string.

### DIFF
--- a/src/Pdp/Uri/Url.php
+++ b/src/Pdp/Uri/Url.php
@@ -80,7 +80,9 @@ class Url
         $query,
         $fragment
     ) {
-        $this->scheme = mb_strtolower($scheme, 'UTF-8');
+        // Ensure scheme is either a legit scheme or null, never an empty string.
+        // @see https://github.com/jeremykendall/php-domain-parser/issues/53
+        $this->scheme = mb_strtolower($scheme, 'UTF-8') ?: null;
         $this->user = $user;
         $this->pass = $pass;
         $this->host = $host;

--- a/tests/src/Pdp/Uri/UrlTest.php
+++ b/tests/src/Pdp/Uri/UrlTest.php
@@ -181,4 +181,18 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $url = $this->parser->parseUrl($spec);
         $this->assertEquals($expected, $url->__toString());
     }
+
+    /**
+     * Scheme should return null when scheme is not provided.
+     *
+     * @group issue53
+     *
+     * @see https://github.com/jeremykendall/php-domain-parser/issues/53
+     */
+    public function testSchemeReturnsNullIfNotProvidedToParser()
+    {
+        $spec = 'google.com';
+        $url = $this->parser->parseUrl($spec);
+        $this->assertNull($url->getScheme());
+    }
 }


### PR DESCRIPTION
Fixes #53.