### PR TITLE
Cleans up Exception message

### DIFF
--- a/src/Pdp/Exception/PdpException.php
+++ b/src/Pdp/Exception/PdpException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * PHP Domain Parser: Public Suffix List based URL parsing.
+ *
+ * @link      http://github.com/jeremykendall/php-domain-parser for the canonical source repository
+ *
+ * @copyright Copyright (c) 2014 Jeremy Kendall (http://about.me/jeremykendall)
+ * @license   http://github.com/jeremykendall/php-domain-parser/blob/master/LICENSE MIT License
+ */
+namespace Pdp\Exception;
+
+interface PdpException
+{
+}

--- a/src/Pdp/Exception/SeriouslyMalformedUrlException.php
+++ b/src/Pdp/Exception/SeriouslyMalformedUrlException.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * PHP Domain Parser: Public Suffix List based URL parsing.
+ *
+ * @link      http://github.com/jeremykendall/php-domain-parser for the canonical source repository
+ *
+ * @copyright Copyright (c) 2014 Jeremy Kendall (http://about.me/jeremykendall)
+ * @license   http://github.com/jeremykendall/php-domain-parser/blob/master/LICENSE MIT License
+ */
+namespace Pdp\Exception;
+
+/**
+ * Should be thrown when pdp_parse_url() return false.
+ *
+ * Exception name based on the PHP documentation: "On seriously malformed URLs, 
+ * parse_url() may return FALSE."
+ *
+ * @see http://php.net/parse_url
+ */
+class SeriouslyMalformedUrlException extends \InvalidArgumentException implements PdpException
+{
+    /**
+     * Public constructor
+     *
+     * @param string $malformedUrl URL that caused pdp_parse_url() to return false
+     * @param int $code The Exception code
+     * @param \Exception $previous The previous exception used for the exception chaining
+     */
+    public function __construct($malformedUrl = "", $code = 0, $previous = null)
+    {
+        $message = sprintf('"%s" is one seriously malformed url.', $malformedUrl);
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Pdp/Uri/Url.php
+++ b/src/Pdp/Uri/Url.php
@@ -80,7 +80,9 @@ class Url
         $query,
         $fragment
     ) {
-        $this->scheme = mb_strtolower($scheme, 'UTF-8');
+        // Ensure scheme is either a legit scheme or null, never an empty string.
+        // @see https://github.com/jeremykendall/php-domain-parser/issues/53
+        $this->scheme = mb_strtolower($scheme, 'UTF-8') ?: null;
         $this->user = $user;
         $this->pass = $pass;
         $this->host = $host;

--- a/tests/src/Pdp/Exception/SeriouslyMalformedUrlExceptionTest.php
+++ b/tests/src/Pdp/Exception/SeriouslyMalformedUrlExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pdp\Exception;
+
+class SeriouslyMalformedUrlExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInstanceOfPdpException()
+    {
+        $this->assertInstanceOf(
+            'Pdp\Exception\PdpException',
+            new SeriouslyMalformedUrlException()
+        );
+    }
+
+    public function testInstanceOfInvalidArgumentException()
+    {
+        $this->assertInstanceOf(
+            'InvalidArgumentException',
+            new SeriouslyMalformedUrlException()
+        );
+    }
+
+    public function testMessage()
+    {
+        $url = 'http:///example.com';
+        $this->setExpectedException(
+            'Pdp\Exception\SeriouslyMalformedUrlException',
+            sprintf('"%s" is one seriously malformed url.', $url)
+        );
+
+        throw new SeriouslyMalformedUrlException($url);
+    }
+}

--- a/tests/src/Pdp/Uri/UrlTest.php
+++ b/tests/src/Pdp/Uri/UrlTest.php
@@ -181,4 +181,18 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $url = $this->parser->parseUrl($spec);
         $this->assertEquals($expected, $url->__toString());
     }
+
+    /**
+     * Scheme should return null when scheme is not provided.
+     *
+     * @group issue53
+     *
+     * @see https://github.com/jeremykendall/php-domain-parser/issues/53
+     */
+    public function testSchemeReturnsNullIfNotProvidedToParser()
+    {
+        $spec = 'google.com';
+        $url = $this->parser->parseUrl($spec);
+        $this->assertNull($url->getScheme());
+    }
 }


### PR DESCRIPTION
* Adds `Pdp\Exception\SeriouslyMalformedUrlException`
* Original URL passed to `Parser::parseUrl()` is passed to the Exception constructor
* Exception message no longer includes meaningless, confusing fake schema from #49
* Fixes #54.