### PR TITLE
Typo on Registrable word

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class Pdp\Uri\Url#6 (8) {
     class Pdp\Uri\Url\Host#5 (3) {
         private $subdomain =>
         string(3) "www"
-        private $registrableDomain =>
+        private $registerableDomain =>
         string(15) "pref.okinawa.jp"
         private $publicSuffix =>
         string(10) "okinawa.jp"
@@ -139,7 +139,7 @@ class Pdp\Uri\Url#6 (8) {
   class Pdp\Uri\Url\Host#5 (4) {
     private $subdomain =>
     NULL
-    private $registrableDomain =>
+    private $registerableDomain =>
     string(17) "яндекс.рф"
     private $publicSuffix =>
     string(4) "рф"
@@ -175,7 +175,7 @@ class Pdp\Uri\Url#6 (8) {
   class Pdp\Uri\Url\Host#5 (4) {
     private $subdomain =>
     NULL
-    private $registrableDomain =>
+    private $registerableDomain =>
     string(22) "xn--d1acpjx3f.xn--p1ai"
     private $publicSuffix =>
     string(8) "xn--p1ai"
@@ -211,7 +211,7 @@ class Pdp\Uri\Url#6 (8) {
   class Pdp\Uri\Url\Host#5 (4) {
     private $subdomain =>
     NULL
-    private $registrableDomain =>
+    private $registerableDomain =>
     NULL
     private $publicSuffix =>
     NULL
@@ -257,7 +257,7 @@ The above will output:
 class Pdp\Uri\Url\Host#7 (3) {
     private $subdomain =>
     string(1) "a"
-    private $registrableDomain =>
+    private $registerableDomain =>
     string(6) "b.c.cy"
     private $publicSuffix =>
     string(4) "c.cy"
@@ -292,7 +292,7 @@ retrieve only the component you're interested in
 <?php
 
 var_dump($parser->getSubdomain('www.scottwills.co.uk'));
-var_dump($parser->getRegistrableDomain('www.scottwills.co.uk'));
+var_dump($parser->getRegisterableDomain('www.scottwills.co.uk'));
 var_dump($parser->getPublicSuffix('www.scottwills.co.uk'));
 ```
 
@@ -331,7 +331,7 @@ Array
     [pass] =>
     [host] => www.waxaudio.com.au
     [subdomain] => www
-    [registrableDomain] => waxaudio.com.au
+    [registerableDomain] => waxaudio.com.au
     [publicSuffix] => com.au
     [port] =>
     [path] => /


### PR DESCRIPTION
Changed the documentation to fit the real attributes and function in the library.

Registrable => Registerable