### PR TITLE
Implement file locking within PublicSuffixListManager class

### DIFF
--- a/src/Pdp/PublicSuffixListManager.php
+++ b/src/Pdp/PublicSuffixListManager.php
@@ -248,7 +248,7 @@ class PublicSuffixListManager
 
         $result = $fp
             && flock($fp, LOCK_EX)
-            && @ftruncate($fp, 0)
+            && ftruncate($fp, 0)
             && fwrite($fp, $data) !== false
             && fflush($fp);
 

--- a/tests/src/Pdp/PublicSuffixListManagerTest.php
+++ b/tests/src/Pdp/PublicSuffixListManagerTest.php
@@ -146,7 +146,7 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testWriteThrowsExceptionIfCanNotWrite()
     {
-        $this->setExpectedException('\Exception', "Cannot write '/does/not/exist/public-suffix-list.php'");
+        $this->setExpectedException('\Exception', "Cannot open '/does/not/exist/public-suffix-list.php' for writing");
         $manager = new PublicSuffixListManager('/does/not/exist');
         $manager->writePhpCache(array());
     }

--- a/tests/src/Pdp/PublicSuffixListManagerTest.php
+++ b/tests/src/Pdp/PublicSuffixListManagerTest.php
@@ -146,7 +146,7 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testWriteThrowsExceptionIfCanNotWrite()
     {
-        $this->setExpectedException('\Exception', "Cannot open '/does/not/exist/public-suffix-list.php' for writing");
+        $this->setExpectedException('\Exception', "Cannot write to '/does/not/exist/public-suffix-list.php'");
         $manager = new PublicSuffixListManager('/does/not/exist');
         $manager->writePhpCache(array());
     }
@@ -157,6 +157,14 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
             $this->dataDir . '/' . PublicSuffixListManager::PDP_PSL_TEXT_FILE
         );
         $this->assertInternalType('array', $publicSuffixList);
+    }
+
+    public function testParseListToArrayThrowsExceptionIfCanNotRead()
+    {
+        $this->setExpectedException('\Exception', "Cannot read '/does/not/exist/public-suffix-list.txt'");
+        $publicSuffixList = $this->listManager->parseListToArray(
+            '/does/not/exist/' . PublicSuffixListManager::PDP_PSL_TEXT_FILE
+        );
     }
 
     public function testGetList()
@@ -213,5 +221,13 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThanOrEqual(300, count($publicSuffixList));
         $this->assertTrue(array_key_exists('stuff-4-sale', $publicSuffixList['org']) !== false);
         $this->assertTrue(array_key_exists('net', $publicSuffixList['ac']) !== false);
+    }
+
+    public function testgetListFromFileThrowsExceptionIfCanNotRead()
+    {
+        $this->setExpectedException('\Exception', "Cannot read '/does/not/exist/public-suffix-list.php'");
+        $publicSuffixList = $this->listManager->getListFromFile(
+            '/does/not/exist/' . PublicSuffixListManager::PDP_PSL_PHP_FILE
+        );
     }
 }

--- a/tests/src/Pdp/PublicSuffixListManagerTest.php
+++ b/tests/src/Pdp/PublicSuffixListManagerTest.php
@@ -5,6 +5,12 @@ namespace Pdp;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 
+// work around PHP 5.3 quirky behavior with ftruncate() and streams
+// @see https://bugs.php.net/bug.php?id=53888
+if (version_compare(PHP_VERSION, '5.4.0') < 0) {
+    function ftruncate($fp, $size) { return @\ftruncate($fp, $size) || true; }
+}
+
 class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
Addresses issue #78 

To test concurrency, I inserted the following at [line 249](https://github.com/mikegreiling/php-domain-parser/blob/6454cf0ee215d8c1bf493c3da2e1cfeb8e2a6e43/src/Pdp/PublicSuffixListManager.php#L249):

``` php
echo "lock obtained for '$filepath'\n\n";
sleep(5);
```

Then ran the following commands within 5 seconds of eachother:

``` bash
$ time bin/update-psl 
Updating Public Suffix List.
lock obtained for /Users/mike/Projects/php-domain-parser/data/public-suffix-list.txt

lock obtained for /Users/mike/Projects/php-domain-parser/data/public-suffix-list.php

Update complete.

real    0m11.799s
user    0m0.388s
sys 0m0.028s
```

``` bash
$ time bin/parse
Array
(
    [scheme] => http
    [user] => user
    [pass] => pass
    [host] => www.pref.okinawa.jp
    [subdomain] => www
    [registrableDomain] => pref.okinawa.jp
    [publicSuffix] => okinawa.jp
    [port] => 8080
    [path] => /path/to/page.html
    [query] => query=string
    [fragment] => fragment
)
Host: http://user:pass@www.pref.okinawa.jp:8080/path/to/page.html?query=string#fragment
'okinawa.jp' IS a valid public suffix.

real    0m4.535s
user    0m0.071s
sys 0m0.013s
```

The blocking appears to be effective.

PHPUnit passes, but I did not achieve complete code coverage as I am not sure how to simulate a file which opens but cannot be written, a file which opens which cannot be read, or a file which opens but cannot be locked.  I also do not know how to properly test asynchronous I/O within PHPUnit, so these file locking tests were performed manually as above.  If you have a solution, please let me know.
