### PR TITLE
Add ability to load a specific section of the PSL

### DIFF
--- a/data/icann-public-suffix-list.php
+++ b/data/icann-public-suffix-list.php
@@ -1,0 +1,21983 @@
+<?php
+return array (
+  'ac' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'ad' => 
+  array (
+    'nom' => 
+    array (
+    ),
+  ),
+  'ae' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'aero' => 
+  array (
+    'accident-investigation' => 
+    array (
+    ),
+    'accident-prevention' => 
+    array (
+    ),
+    'aerobatic' => 
+    array (
+    ),
+    'aeroclub' => 
+    array (
+    ),
+    'aerodrome' => 
+    array (
+    ),
+    'agents' => 
+    array (
+    ),
+    'aircraft' => 
+    array (
+    ),
+    'airline' => 
+    array (
+    ),
+    'airport' => 
+    array (
+    ),
+    'air-surveillance' => 
+    array (
+    ),
+    'airtraffic' => 
+    array (
+    ),
+    'air-traffic-control' => 
+    array (
+    ),
+    'ambulance' => 
+    array (
+    ),
+    'amusement' => 
+    array (
+    ),
+    'association' => 
+    array (
+    ),
+    'author' => 
+    array (
+    ),
+    'ballooning' => 
+    array (
+    ),
+    'broker' => 
+    array (
+    ),
+    'caa' => 
+    array (
+    ),
+    'cargo' => 
+    array (
+    ),
+    'catering' => 
+    array (
+    ),
+    'certification' => 
+    array (
+    ),
+    'championship' => 
+    array (
+    ),
+    'charter' => 
+    array (
+    ),
+    'civilaviation' => 
+    array (
+    ),
+    'club' => 
+    array (
+    ),
+    'conference' => 
+    array (
+    ),
+    'consultant' => 
+    array (
+    ),
+    'consulting' => 
+    array (
+    ),
+    'control' => 
+    array (
+    ),
+    'council' => 
+    array (
+    ),
+    'crew' => 
+    array (
+    ),
+    'design' => 
+    array (
+    ),
+    'dgca' => 
+    array (
+    ),
+    'educator' => 
+    array (
+    ),
+    'emergency' => 
+    array (
+    ),
+    'engine' => 
+    array (
+    ),
+    'engineer' => 
+    array (
+    ),
+    'entertainment' => 
+    array (
+    ),
+    'equipment' => 
+    array (
+    ),
+    'exchange' => 
+    array (
+    ),
+    'express' => 
+    array (
+    ),
+    'federation' => 
+    array (
+    ),
+    'flight' => 
+    array (
+    ),
+    'freight' => 
+    array (
+    ),
+    'fuel' => 
+    array (
+    ),
+    'gliding' => 
+    array (
+    ),
+    'government' => 
+    array (
+    ),
+    'groundhandling' => 
+    array (
+    ),
+    'group' => 
+    array (
+    ),
+    'hanggliding' => 
+    array (
+    ),
+    'homebuilt' => 
+    array (
+    ),
+    'insurance' => 
+    array (
+    ),
+    'journal' => 
+    array (
+    ),
+    'journalist' => 
+    array (
+    ),
+    'leasing' => 
+    array (
+    ),
+    'logistics' => 
+    array (
+    ),
+    'magazine' => 
+    array (
+    ),
+    'maintenance' => 
+    array (
+    ),
+    'media' => 
+    array (
+    ),
+    'microlight' => 
+    array (
+    ),
+    'modelling' => 
+    array (
+    ),
+    'navigation' => 
+    array (
+    ),
+    'parachuting' => 
+    array (
+    ),
+    'paragliding' => 
+    array (
+    ),
+    'passenger-association' => 
+    array (
+    ),
+    'pilot' => 
+    array (
+    ),
+    'press' => 
+    array (
+    ),
+    'production' => 
+    array (
+    ),
+    'recreation' => 
+    array (
+    ),
+    'repbody' => 
+    array (
+    ),
+    'res' => 
+    array (
+    ),
+    'research' => 
+    array (
+    ),
+    'rotorcraft' => 
+    array (
+    ),
+    'safety' => 
+    array (
+    ),
+    'scientist' => 
+    array (
+    ),
+    'services' => 
+    array (
+    ),
+    'show' => 
+    array (
+    ),
+    'skydiving' => 
+    array (
+    ),
+    'software' => 
+    array (
+    ),
+    'student' => 
+    array (
+    ),
+    'trader' => 
+    array (
+    ),
+    'trading' => 
+    array (
+    ),
+    'trainer' => 
+    array (
+    ),
+    'union' => 
+    array (
+    ),
+    'workinggroup' => 
+    array (
+    ),
+    'works' => 
+    array (
+    ),
+  ),
+  'af' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'ag' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+  ),
+  'ai' => 
+  array (
+    'off' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'al' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'am' => 
+  array (
+  ),
+  'ao' => 
+  array (
+    'ed' => 
+    array (
+    ),
+    'gv' => 
+    array (
+    ),
+    'og' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'pb' => 
+    array (
+    ),
+    'it' => 
+    array (
+    ),
+  ),
+  'aq' => 
+  array (
+  ),
+  'ar' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'tur' => 
+    array (
+    ),
+  ),
+  'arpa' => 
+  array (
+    'e164' => 
+    array (
+    ),
+    'in-addr' => 
+    array (
+    ),
+    'ip6' => 
+    array (
+    ),
+    'iris' => 
+    array (
+    ),
+    'uri' => 
+    array (
+    ),
+    'urn' => 
+    array (
+    ),
+  ),
+  'as' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'asia' => 
+  array (
+  ),
+  'at' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'gv' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+  ),
+  'au' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+      'act' => 
+      array (
+      ),
+      'nsw' => 
+      array (
+      ),
+      'nt' => 
+      array (
+      ),
+      'qld' => 
+      array (
+      ),
+      'sa' => 
+      array (
+      ),
+      'tas' => 
+      array (
+      ),
+      'vic' => 
+      array (
+      ),
+      'wa' => 
+      array (
+      ),
+    ),
+    'gov' => 
+    array (
+      'qld' => 
+      array (
+      ),
+      'sa' => 
+      array (
+      ),
+      'tas' => 
+      array (
+      ),
+      'vic' => 
+      array (
+      ),
+      'wa' => 
+      array (
+      ),
+    ),
+    'asn' => 
+    array (
+    ),
+    'id' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'conf' => 
+    array (
+    ),
+    'oz' => 
+    array (
+    ),
+    'act' => 
+    array (
+    ),
+    'nsw' => 
+    array (
+    ),
+    'nt' => 
+    array (
+    ),
+    'qld' => 
+    array (
+    ),
+    'sa' => 
+    array (
+    ),
+    'tas' => 
+    array (
+    ),
+    'vic' => 
+    array (
+    ),
+    'wa' => 
+    array (
+    ),
+  ),
+  'aw' => 
+  array (
+    'com' => 
+    array (
+    ),
+  ),
+  'ax' => 
+  array (
+  ),
+  'az' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'pp' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+  ),
+  'ba' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'bb' => 
+  array (
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+  ),
+  'bd' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'be' => 
+  array (
+    'ac' => 
+    array (
+    ),
+  ),
+  'bf' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'bg' => 
+  array (
+    'a' => 
+    array (
+    ),
+    'b' => 
+    array (
+    ),
+    'c' => 
+    array (
+    ),
+    'd' => 
+    array (
+    ),
+    'e' => 
+    array (
+    ),
+    'f' => 
+    array (
+    ),
+    'g' => 
+    array (
+    ),
+    'h' => 
+    array (
+    ),
+    'i' => 
+    array (
+    ),
+    'j' => 
+    array (
+    ),
+    'k' => 
+    array (
+    ),
+    'l' => 
+    array (
+    ),
+    'm' => 
+    array (
+    ),
+    'n' => 
+    array (
+    ),
+    'o' => 
+    array (
+    ),
+    'p' => 
+    array (
+    ),
+    'q' => 
+    array (
+    ),
+    'r' => 
+    array (
+    ),
+    's' => 
+    array (
+    ),
+    't' => 
+    array (
+    ),
+    'u' => 
+    array (
+    ),
+    'v' => 
+    array (
+    ),
+    'w' => 
+    array (
+    ),
+    'x' => 
+    array (
+    ),
+    'y' => 
+    array (
+    ),
+    'z' => 
+    array (
+    ),
+    0 => 
+    array (
+    ),
+    1 => 
+    array (
+    ),
+    2 => 
+    array (
+    ),
+    3 => 
+    array (
+    ),
+    4 => 
+    array (
+    ),
+    5 => 
+    array (
+    ),
+    6 => 
+    array (
+    ),
+    7 => 
+    array (
+    ),
+    8 => 
+    array (
+    ),
+    9 => 
+    array (
+    ),
+  ),
+  'bh' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'bi' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'biz' => 
+  array (
+  ),
+  'bj' => 
+  array (
+    'asso' => 
+    array (
+    ),
+    'barreau' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+  ),
+  'bm' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'bn' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'bo' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+  ),
+  'br' => 
+  array (
+    'adm' => 
+    array (
+    ),
+    'adv' => 
+    array (
+    ),
+    'agr' => 
+    array (
+    ),
+    'am' => 
+    array (
+    ),
+    'arq' => 
+    array (
+    ),
+    'art' => 
+    array (
+    ),
+    'ato' => 
+    array (
+    ),
+    'b' => 
+    array (
+    ),
+    'bio' => 
+    array (
+    ),
+    'blog' => 
+    array (
+    ),
+    'bmd' => 
+    array (
+    ),
+    'cim' => 
+    array (
+    ),
+    'cng' => 
+    array (
+    ),
+    'cnt' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'ecn' => 
+    array (
+    ),
+    'eco' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'emp' => 
+    array (
+    ),
+    'eng' => 
+    array (
+    ),
+    'esp' => 
+    array (
+    ),
+    'etc' => 
+    array (
+    ),
+    'eti' => 
+    array (
+    ),
+    'far' => 
+    array (
+    ),
+    'flog' => 
+    array (
+    ),
+    'fm' => 
+    array (
+    ),
+    'fnd' => 
+    array (
+    ),
+    'fot' => 
+    array (
+    ),
+    'fst' => 
+    array (
+    ),
+    'g12' => 
+    array (
+    ),
+    'ggf' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'imb' => 
+    array (
+    ),
+    'ind' => 
+    array (
+    ),
+    'inf' => 
+    array (
+    ),
+    'jor' => 
+    array (
+    ),
+    'jus' => 
+    array (
+    ),
+    'leg' => 
+    array (
+    ),
+    'lel' => 
+    array (
+    ),
+    'mat' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'mp' => 
+    array (
+    ),
+    'mus' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'nom' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+    'not' => 
+    array (
+    ),
+    'ntr' => 
+    array (
+    ),
+    'odo' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'ppg' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'psc' => 
+    array (
+    ),
+    'psi' => 
+    array (
+    ),
+    'qsl' => 
+    array (
+    ),
+    'radio' => 
+    array (
+    ),
+    'rec' => 
+    array (
+    ),
+    'slg' => 
+    array (
+    ),
+    'srv' => 
+    array (
+    ),
+    'taxi' => 
+    array (
+    ),
+    'teo' => 
+    array (
+    ),
+    'tmp' => 
+    array (
+    ),
+    'trd' => 
+    array (
+    ),
+    'tur' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+    'vet' => 
+    array (
+    ),
+    'vlog' => 
+    array (
+    ),
+    'wiki' => 
+    array (
+    ),
+    'zlg' => 
+    array (
+    ),
+  ),
+  'bs' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'bt' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'bv' => 
+  array (
+  ),
+  'bw' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'by' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'of' => 
+    array (
+    ),
+  ),
+  'bz' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'ca' => 
+  array (
+    'ab' => 
+    array (
+    ),
+    'bc' => 
+    array (
+    ),
+    'mb' => 
+    array (
+    ),
+    'nb' => 
+    array (
+    ),
+    'nf' => 
+    array (
+    ),
+    'nl' => 
+    array (
+    ),
+    'ns' => 
+    array (
+    ),
+    'nt' => 
+    array (
+    ),
+    'nu' => 
+    array (
+    ),
+    'on' => 
+    array (
+    ),
+    'pe' => 
+    array (
+    ),
+    'qc' => 
+    array (
+    ),
+    'sk' => 
+    array (
+    ),
+    'yk' => 
+    array (
+    ),
+    'gc' => 
+    array (
+    ),
+  ),
+  'cat' => 
+  array (
+  ),
+  'cc' => 
+  array (
+  ),
+  'cd' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'cf' => 
+  array (
+  ),
+  'cg' => 
+  array (
+  ),
+  'ch' => 
+  array (
+  ),
+  'ci' => 
+  array (
+    'org' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'ed' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+    'xn--aroport-bya' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'presse' => 
+    array (
+    ),
+    'md' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+  ),
+  'ck' => 
+  array (
+    '*' => 
+    array (
+    ),
+    'www' => 
+    array (
+      '!' => '',
+    ),
+  ),
+  'cl' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'cm' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'cn' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'xn--55qx5d' => 
+    array (
+    ),
+    'xn--io0a7i' => 
+    array (
+    ),
+    'xn--od0alg' => 
+    array (
+    ),
+    'ah' => 
+    array (
+    ),
+    'bj' => 
+    array (
+    ),
+    'cq' => 
+    array (
+    ),
+    'fj' => 
+    array (
+    ),
+    'gd' => 
+    array (
+    ),
+    'gs' => 
+    array (
+    ),
+    'gz' => 
+    array (
+    ),
+    'gx' => 
+    array (
+    ),
+    'ha' => 
+    array (
+    ),
+    'hb' => 
+    array (
+    ),
+    'he' => 
+    array (
+    ),
+    'hi' => 
+    array (
+    ),
+    'hl' => 
+    array (
+    ),
+    'hn' => 
+    array (
+    ),
+    'jl' => 
+    array (
+    ),
+    'js' => 
+    array (
+    ),
+    'jx' => 
+    array (
+    ),
+    'ln' => 
+    array (
+    ),
+    'nm' => 
+    array (
+    ),
+    'nx' => 
+    array (
+    ),
+    'qh' => 
+    array (
+    ),
+    'sc' => 
+    array (
+    ),
+    'sd' => 
+    array (
+    ),
+    'sh' => 
+    array (
+    ),
+    'sn' => 
+    array (
+    ),
+    'sx' => 
+    array (
+    ),
+    'tj' => 
+    array (
+    ),
+    'xj' => 
+    array (
+    ),
+    'xz' => 
+    array (
+    ),
+    'yn' => 
+    array (
+    ),
+    'zj' => 
+    array (
+    ),
+    'hk' => 
+    array (
+    ),
+    'mo' => 
+    array (
+    ),
+    'tw' => 
+    array (
+    ),
+  ),
+  'co' => 
+  array (
+    'arts' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'rec' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'com' => 
+  array (
+  ),
+  'coop' => 
+  array (
+  ),
+  'cr' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'ed' => 
+    array (
+    ),
+    'fi' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'sa' => 
+    array (
+    ),
+  ),
+  'cu' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'inf' => 
+    array (
+    ),
+  ),
+  'cv' => 
+  array (
+  ),
+  'cw' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'cx' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'cy' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'ekloges' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'ltd' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'parliament' => 
+    array (
+    ),
+    'press' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+  ),
+  'cz' => 
+  array (
+  ),
+  'de' => 
+  array (
+  ),
+  'dj' => 
+  array (
+  ),
+  'dk' => 
+  array (
+  ),
+  'dm' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'do' => 
+  array (
+    'art' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sld' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'dz' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+    'pol' => 
+    array (
+    ),
+    'art' => 
+    array (
+    ),
+  ),
+  'ec' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'fin' => 
+    array (
+    ),
+    'k12' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'edu' => 
+  array (
+  ),
+  'ee' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'riik' => 
+    array (
+    ),
+    'lib' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'pri' => 
+    array (
+    ),
+    'aip' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'fie' => 
+    array (
+    ),
+  ),
+  'eg' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'eun' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sci' => 
+    array (
+    ),
+  ),
+  'er' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'es' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'et' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'eu' => 
+  array (
+  ),
+  'fi' => 
+  array (
+    'aland' => 
+    array (
+    ),
+  ),
+  'fj' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'fk' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'fm' => 
+  array (
+  ),
+  'fo' => 
+  array (
+  ),
+  'fr' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'prd' => 
+    array (
+    ),
+    'presse' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'aeroport' => 
+    array (
+    ),
+    'assedic' => 
+    array (
+    ),
+    'avocat' => 
+    array (
+    ),
+    'avoues' => 
+    array (
+    ),
+    'cci' => 
+    array (
+    ),
+    'chambagri' => 
+    array (
+    ),
+    'chirurgiens-dentistes' => 
+    array (
+    ),
+    'experts-comptables' => 
+    array (
+    ),
+    'geometre-expert' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+    'greta' => 
+    array (
+    ),
+    'huissier-justice' => 
+    array (
+    ),
+    'medecin' => 
+    array (
+    ),
+    'notaires' => 
+    array (
+    ),
+    'pharmacien' => 
+    array (
+    ),
+    'port' => 
+    array (
+    ),
+    'veterinaire' => 
+    array (
+    ),
+  ),
+  'ga' => 
+  array (
+  ),
+  'gb' => 
+  array (
+  ),
+  'gd' => 
+  array (
+  ),
+  'ge' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'pvt' => 
+    array (
+    ),
+  ),
+  'gf' => 
+  array (
+  ),
+  'gg' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'gh' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'gi' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'ltd' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mod' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'gl' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'gm' => 
+  array (
+  ),
+  'gn' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'gov' => 
+  array (
+  ),
+  'gp' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mobi' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+  ),
+  'gq' => 
+  array (
+  ),
+  'gr' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'gs' => 
+  array (
+  ),
+  'gt' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'ind' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'gu' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'gw' => 
+  array (
+  ),
+  'gy' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'hk' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'idv' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'xn--55qx5d' => 
+    array (
+    ),
+    'xn--wcvs22d' => 
+    array (
+    ),
+    'xn--lcvr32d' => 
+    array (
+    ),
+    'xn--mxtq1m' => 
+    array (
+    ),
+    'xn--gmqw5a' => 
+    array (
+    ),
+    'xn--ciqpn' => 
+    array (
+    ),
+    'xn--gmq050i' => 
+    array (
+    ),
+    'xn--zf0avx' => 
+    array (
+    ),
+    'xn--io0a7i' => 
+    array (
+    ),
+    'xn--mk0axi' => 
+    array (
+    ),
+    'xn--od0alg' => 
+    array (
+    ),
+    'xn--od0aq3b' => 
+    array (
+    ),
+    'xn--tn0ag' => 
+    array (
+    ),
+    'xn--uc0atv' => 
+    array (
+    ),
+    'xn--uc0ay4a' => 
+    array (
+    ),
+  ),
+  'hm' => 
+  array (
+  ),
+  'hn' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+  ),
+  'hr' => 
+  array (
+    'iz' => 
+    array (
+    ),
+    'from' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+  ),
+  'ht' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'shop' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'adult' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'art' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'pol' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'rel' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+    'perso' => 
+    array (
+    ),
+  ),
+  'hu' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'priv' => 
+    array (
+    ),
+    'sport' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    2000 => 
+    array (
+    ),
+    'agrar' => 
+    array (
+    ),
+    'bolt' => 
+    array (
+    ),
+    'casino' => 
+    array (
+    ),
+    'city' => 
+    array (
+    ),
+    'erotica' => 
+    array (
+    ),
+    'erotika' => 
+    array (
+    ),
+    'film' => 
+    array (
+    ),
+    'forum' => 
+    array (
+    ),
+    'games' => 
+    array (
+    ),
+    'hotel' => 
+    array (
+    ),
+    'ingatlan' => 
+    array (
+    ),
+    'jogasz' => 
+    array (
+    ),
+    'konyvelo' => 
+    array (
+    ),
+    'lakas' => 
+    array (
+    ),
+    'media' => 
+    array (
+    ),
+    'news' => 
+    array (
+    ),
+    'reklam' => 
+    array (
+    ),
+    'sex' => 
+    array (
+    ),
+    'shop' => 
+    array (
+    ),
+    'suli' => 
+    array (
+    ),
+    'szex' => 
+    array (
+    ),
+    'tozsde' => 
+    array (
+    ),
+    'utazas' => 
+    array (
+    ),
+    'video' => 
+    array (
+    ),
+  ),
+  'id' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'desa' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'my' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'ie' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'il' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'idf' => 
+    array (
+    ),
+    'k12' => 
+    array (
+    ),
+    'muni' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'im' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+      'ltd' => 
+      array (
+      ),
+      'plc' => 
+      array (
+      ),
+    ),
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'tt' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+  ),
+  'in' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gen' => 
+    array (
+    ),
+    'ind' => 
+    array (
+    ),
+    'nic' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'res' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'info' => 
+  array (
+  ),
+  'int' => 
+  array (
+    'eu' => 
+    array (
+    ),
+  ),
+  'io' => 
+  array (
+    'com' => 
+    array (
+    ),
+  ),
+  'iq' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'ir' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'id' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'xn--mgba3a4f16a' => 
+    array (
+    ),
+    'xn--mgba3a4fra' => 
+    array (
+    ),
+  ),
+  'is' => 
+  array (
+    'net' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+  ),
+  'it' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'abr' => 
+    array (
+    ),
+    'abruzzo' => 
+    array (
+    ),
+    'aosta-valley' => 
+    array (
+    ),
+    'aostavalley' => 
+    array (
+    ),
+    'bas' => 
+    array (
+    ),
+    'basilicata' => 
+    array (
+    ),
+    'cal' => 
+    array (
+    ),
+    'calabria' => 
+    array (
+    ),
+    'cam' => 
+    array (
+    ),
+    'campania' => 
+    array (
+    ),
+    'emilia-romagna' => 
+    array (
+    ),
+    'emiliaromagna' => 
+    array (
+    ),
+    'emr' => 
+    array (
+    ),
+    'friuli-v-giulia' => 
+    array (
+    ),
+    'friuli-ve-giulia' => 
+    array (
+    ),
+    'friuli-vegiulia' => 
+    array (
+    ),
+    'friuli-venezia-giulia' => 
+    array (
+    ),
+    'friuli-veneziagiulia' => 
+    array (
+    ),
+    'friuli-vgiulia' => 
+    array (
+    ),
+    'friuliv-giulia' => 
+    array (
+    ),
+    'friulive-giulia' => 
+    array (
+    ),
+    'friulivegiulia' => 
+    array (
+    ),
+    'friulivenezia-giulia' => 
+    array (
+    ),
+    'friuliveneziagiulia' => 
+    array (
+    ),
+    'friulivgiulia' => 
+    array (
+    ),
+    'fvg' => 
+    array (
+    ),
+    'laz' => 
+    array (
+    ),
+    'lazio' => 
+    array (
+    ),
+    'lig' => 
+    array (
+    ),
+    'liguria' => 
+    array (
+    ),
+    'lom' => 
+    array (
+    ),
+    'lombardia' => 
+    array (
+    ),
+    'lombardy' => 
+    array (
+    ),
+    'lucania' => 
+    array (
+    ),
+    'mar' => 
+    array (
+    ),
+    'marche' => 
+    array (
+    ),
+    'mol' => 
+    array (
+    ),
+    'molise' => 
+    array (
+    ),
+    'piedmont' => 
+    array (
+    ),
+    'piemonte' => 
+    array (
+    ),
+    'pmn' => 
+    array (
+    ),
+    'pug' => 
+    array (
+    ),
+    'puglia' => 
+    array (
+    ),
+    'sar' => 
+    array (
+    ),
+    'sardegna' => 
+    array (
+    ),
+    'sardinia' => 
+    array (
+    ),
+    'sic' => 
+    array (
+    ),
+    'sicilia' => 
+    array (
+    ),
+    'sicily' => 
+    array (
+    ),
+    'taa' => 
+    array (
+    ),
+    'tos' => 
+    array (
+    ),
+    'toscana' => 
+    array (
+    ),
+    'trentino-a-adige' => 
+    array (
+    ),
+    'trentino-aadige' => 
+    array (
+    ),
+    'trentino-alto-adige' => 
+    array (
+    ),
+    'trentino-altoadige' => 
+    array (
+    ),
+    'trentino-s-tirol' => 
+    array (
+    ),
+    'trentino-stirol' => 
+    array (
+    ),
+    'trentino-sud-tirol' => 
+    array (
+    ),
+    'trentino-sudtirol' => 
+    array (
+    ),
+    'trentino-sued-tirol' => 
+    array (
+    ),
+    'trentino-suedtirol' => 
+    array (
+    ),
+    'trentinoa-adige' => 
+    array (
+    ),
+    'trentinoaadige' => 
+    array (
+    ),
+    'trentinoalto-adige' => 
+    array (
+    ),
+    'trentinoaltoadige' => 
+    array (
+    ),
+    'trentinos-tirol' => 
+    array (
+    ),
+    'trentinostirol' => 
+    array (
+    ),
+    'trentinosud-tirol' => 
+    array (
+    ),
+    'trentinosudtirol' => 
+    array (
+    ),
+    'trentinosued-tirol' => 
+    array (
+    ),
+    'trentinosuedtirol' => 
+    array (
+    ),
+    'tuscany' => 
+    array (
+    ),
+    'umb' => 
+    array (
+    ),
+    'umbria' => 
+    array (
+    ),
+    'val-d-aosta' => 
+    array (
+    ),
+    'val-daosta' => 
+    array (
+    ),
+    'vald-aosta' => 
+    array (
+    ),
+    'valdaosta' => 
+    array (
+    ),
+    'valle-aosta' => 
+    array (
+    ),
+    'valle-d-aosta' => 
+    array (
+    ),
+    'valle-daosta' => 
+    array (
+    ),
+    'valleaosta' => 
+    array (
+    ),
+    'valled-aosta' => 
+    array (
+    ),
+    'valledaosta' => 
+    array (
+    ),
+    'vallee-aoste' => 
+    array (
+    ),
+    'valleeaoste' => 
+    array (
+    ),
+    'vao' => 
+    array (
+    ),
+    'vda' => 
+    array (
+    ),
+    'ven' => 
+    array (
+    ),
+    'veneto' => 
+    array (
+    ),
+    'ag' => 
+    array (
+    ),
+    'agrigento' => 
+    array (
+    ),
+    'al' => 
+    array (
+    ),
+    'alessandria' => 
+    array (
+    ),
+    'alto-adige' => 
+    array (
+    ),
+    'altoadige' => 
+    array (
+    ),
+    'an' => 
+    array (
+    ),
+    'ancona' => 
+    array (
+    ),
+    'andria-barletta-trani' => 
+    array (
+    ),
+    'andria-trani-barletta' => 
+    array (
+    ),
+    'andriabarlettatrani' => 
+    array (
+    ),
+    'andriatranibarletta' => 
+    array (
+    ),
+    'ao' => 
+    array (
+    ),
+    'aosta' => 
+    array (
+    ),
+    'aoste' => 
+    array (
+    ),
+    'ap' => 
+    array (
+    ),
+    'aq' => 
+    array (
+    ),
+    'aquila' => 
+    array (
+    ),
+    'ar' => 
+    array (
+    ),
+    'arezzo' => 
+    array (
+    ),
+    'ascoli-piceno' => 
+    array (
+    ),
+    'ascolipiceno' => 
+    array (
+    ),
+    'asti' => 
+    array (
+    ),
+    'at' => 
+    array (
+    ),
+    'av' => 
+    array (
+    ),
+    'avellino' => 
+    array (
+    ),
+    'ba' => 
+    array (
+    ),
+    'balsan' => 
+    array (
+    ),
+    'bari' => 
+    array (
+    ),
+    'barletta-trani-andria' => 
+    array (
+    ),
+    'barlettatraniandria' => 
+    array (
+    ),
+    'belluno' => 
+    array (
+    ),
+    'benevento' => 
+    array (
+    ),
+    'bergamo' => 
+    array (
+    ),
+    'bg' => 
+    array (
+    ),
+    'bi' => 
+    array (
+    ),
+    'biella' => 
+    array (
+    ),
+    'bl' => 
+    array (
+    ),
+    'bn' => 
+    array (
+    ),
+    'bo' => 
+    array (
+    ),
+    'bologna' => 
+    array (
+    ),
+    'bolzano' => 
+    array (
+    ),
+    'bozen' => 
+    array (
+    ),
+    'br' => 
+    array (
+    ),
+    'brescia' => 
+    array (
+    ),
+    'brindisi' => 
+    array (
+    ),
+    'bs' => 
+    array (
+    ),
+    'bt' => 
+    array (
+    ),
+    'bz' => 
+    array (
+    ),
+    'ca' => 
+    array (
+    ),
+    'cagliari' => 
+    array (
+    ),
+    'caltanissetta' => 
+    array (
+    ),
+    'campidano-medio' => 
+    array (
+    ),
+    'campidanomedio' => 
+    array (
+    ),
+    'campobasso' => 
+    array (
+    ),
+    'carbonia-iglesias' => 
+    array (
+    ),
+    'carboniaiglesias' => 
+    array (
+    ),
+    'carrara-massa' => 
+    array (
+    ),
+    'carraramassa' => 
+    array (
+    ),
+    'caserta' => 
+    array (
+    ),
+    'catania' => 
+    array (
+    ),
+    'catanzaro' => 
+    array (
+    ),
+    'cb' => 
+    array (
+    ),
+    'ce' => 
+    array (
+    ),
+    'cesena-forli' => 
+    array (
+    ),
+    'cesenaforli' => 
+    array (
+    ),
+    'ch' => 
+    array (
+    ),
+    'chieti' => 
+    array (
+    ),
+    'ci' => 
+    array (
+    ),
+    'cl' => 
+    array (
+    ),
+    'cn' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'como' => 
+    array (
+    ),
+    'cosenza' => 
+    array (
+    ),
+    'cr' => 
+    array (
+    ),
+    'cremona' => 
+    array (
+    ),
+    'crotone' => 
+    array (
+    ),
+    'cs' => 
+    array (
+    ),
+    'ct' => 
+    array (
+    ),
+    'cuneo' => 
+    array (
+    ),
+    'cz' => 
+    array (
+    ),
+    'dell-ogliastra' => 
+    array (
+    ),
+    'dellogliastra' => 
+    array (
+    ),
+    'en' => 
+    array (
+    ),
+    'enna' => 
+    array (
+    ),
+    'fc' => 
+    array (
+    ),
+    'fe' => 
+    array (
+    ),
+    'fermo' => 
+    array (
+    ),
+    'ferrara' => 
+    array (
+    ),
+    'fg' => 
+    array (
+    ),
+    'fi' => 
+    array (
+    ),
+    'firenze' => 
+    array (
+    ),
+    'florence' => 
+    array (
+    ),
+    'fm' => 
+    array (
+    ),
+    'foggia' => 
+    array (
+    ),
+    'forli-cesena' => 
+    array (
+    ),
+    'forlicesena' => 
+    array (
+    ),
+    'fr' => 
+    array (
+    ),
+    'frosinone' => 
+    array (
+    ),
+    'ge' => 
+    array (
+    ),
+    'genoa' => 
+    array (
+    ),
+    'genova' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'gorizia' => 
+    array (
+    ),
+    'gr' => 
+    array (
+    ),
+    'grosseto' => 
+    array (
+    ),
+    'iglesias-carbonia' => 
+    array (
+    ),
+    'iglesiascarbonia' => 
+    array (
+    ),
+    'im' => 
+    array (
+    ),
+    'imperia' => 
+    array (
+    ),
+    'is' => 
+    array (
+    ),
+    'isernia' => 
+    array (
+    ),
+    'kr' => 
+    array (
+    ),
+    'la-spezia' => 
+    array (
+    ),
+    'laquila' => 
+    array (
+    ),
+    'laspezia' => 
+    array (
+    ),
+    'latina' => 
+    array (
+    ),
+    'lc' => 
+    array (
+    ),
+    'le' => 
+    array (
+    ),
+    'lecce' => 
+    array (
+    ),
+    'lecco' => 
+    array (
+    ),
+    'li' => 
+    array (
+    ),
+    'livorno' => 
+    array (
+    ),
+    'lo' => 
+    array (
+    ),
+    'lodi' => 
+    array (
+    ),
+    'lt' => 
+    array (
+    ),
+    'lu' => 
+    array (
+    ),
+    'lucca' => 
+    array (
+    ),
+    'macerata' => 
+    array (
+    ),
+    'mantova' => 
+    array (
+    ),
+    'massa-carrara' => 
+    array (
+    ),
+    'massacarrara' => 
+    array (
+    ),
+    'matera' => 
+    array (
+    ),
+    'mb' => 
+    array (
+    ),
+    'mc' => 
+    array (
+    ),
+    'me' => 
+    array (
+    ),
+    'medio-campidano' => 
+    array (
+    ),
+    'mediocampidano' => 
+    array (
+    ),
+    'messina' => 
+    array (
+    ),
+    'mi' => 
+    array (
+    ),
+    'milan' => 
+    array (
+    ),
+    'milano' => 
+    array (
+    ),
+    'mn' => 
+    array (
+    ),
+    'mo' => 
+    array (
+    ),
+    'modena' => 
+    array (
+    ),
+    'monza-brianza' => 
+    array (
+    ),
+    'monza-e-della-brianza' => 
+    array (
+    ),
+    'monza' => 
+    array (
+    ),
+    'monzabrianza' => 
+    array (
+    ),
+    'monzaebrianza' => 
+    array (
+    ),
+    'monzaedellabrianza' => 
+    array (
+    ),
+    'ms' => 
+    array (
+    ),
+    'mt' => 
+    array (
+    ),
+    'na' => 
+    array (
+    ),
+    'naples' => 
+    array (
+    ),
+    'napoli' => 
+    array (
+    ),
+    'no' => 
+    array (
+    ),
+    'novara' => 
+    array (
+    ),
+    'nu' => 
+    array (
+    ),
+    'nuoro' => 
+    array (
+    ),
+    'og' => 
+    array (
+    ),
+    'ogliastra' => 
+    array (
+    ),
+    'olbia-tempio' => 
+    array (
+    ),
+    'olbiatempio' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'oristano' => 
+    array (
+    ),
+    'ot' => 
+    array (
+    ),
+    'pa' => 
+    array (
+    ),
+    'padova' => 
+    array (
+    ),
+    'padua' => 
+    array (
+    ),
+    'palermo' => 
+    array (
+    ),
+    'parma' => 
+    array (
+    ),
+    'pavia' => 
+    array (
+    ),
+    'pc' => 
+    array (
+    ),
+    'pd' => 
+    array (
+    ),
+    'pe' => 
+    array (
+    ),
+    'perugia' => 
+    array (
+    ),
+    'pesaro-urbino' => 
+    array (
+    ),
+    'pesarourbino' => 
+    array (
+    ),
+    'pescara' => 
+    array (
+    ),
+    'pg' => 
+    array (
+    ),
+    'pi' => 
+    array (
+    ),
+    'piacenza' => 
+    array (
+    ),
+    'pisa' => 
+    array (
+    ),
+    'pistoia' => 
+    array (
+    ),
+    'pn' => 
+    array (
+    ),
+    'po' => 
+    array (
+    ),
+    'pordenone' => 
+    array (
+    ),
+    'potenza' => 
+    array (
+    ),
+    'pr' => 
+    array (
+    ),
+    'prato' => 
+    array (
+    ),
+    'pt' => 
+    array (
+    ),
+    'pu' => 
+    array (
+    ),
+    'pv' => 
+    array (
+    ),
+    'pz' => 
+    array (
+    ),
+    'ra' => 
+    array (
+    ),
+    'ragusa' => 
+    array (
+    ),
+    'ravenna' => 
+    array (
+    ),
+    'rc' => 
+    array (
+    ),
+    're' => 
+    array (
+    ),
+    'reggio-calabria' => 
+    array (
+    ),
+    'reggio-emilia' => 
+    array (
+    ),
+    'reggiocalabria' => 
+    array (
+    ),
+    'reggioemilia' => 
+    array (
+    ),
+    'rg' => 
+    array (
+    ),
+    'ri' => 
+    array (
+    ),
+    'rieti' => 
+    array (
+    ),
+    'rimini' => 
+    array (
+    ),
+    'rm' => 
+    array (
+    ),
+    'rn' => 
+    array (
+    ),
+    'ro' => 
+    array (
+    ),
+    'roma' => 
+    array (
+    ),
+    'rome' => 
+    array (
+    ),
+    'rovigo' => 
+    array (
+    ),
+    'sa' => 
+    array (
+    ),
+    'salerno' => 
+    array (
+    ),
+    'sassari' => 
+    array (
+    ),
+    'savona' => 
+    array (
+    ),
+    'si' => 
+    array (
+    ),
+    'siena' => 
+    array (
+    ),
+    'siracusa' => 
+    array (
+    ),
+    'so' => 
+    array (
+    ),
+    'sondrio' => 
+    array (
+    ),
+    'sp' => 
+    array (
+    ),
+    'sr' => 
+    array (
+    ),
+    'ss' => 
+    array (
+    ),
+    'suedtirol' => 
+    array (
+    ),
+    'sv' => 
+    array (
+    ),
+    'ta' => 
+    array (
+    ),
+    'taranto' => 
+    array (
+    ),
+    'te' => 
+    array (
+    ),
+    'tempio-olbia' => 
+    array (
+    ),
+    'tempioolbia' => 
+    array (
+    ),
+    'teramo' => 
+    array (
+    ),
+    'terni' => 
+    array (
+    ),
+    'tn' => 
+    array (
+    ),
+    'to' => 
+    array (
+    ),
+    'torino' => 
+    array (
+    ),
+    'tp' => 
+    array (
+    ),
+    'tr' => 
+    array (
+    ),
+    'trani-andria-barletta' => 
+    array (
+    ),
+    'trani-barletta-andria' => 
+    array (
+    ),
+    'traniandriabarletta' => 
+    array (
+    ),
+    'tranibarlettaandria' => 
+    array (
+    ),
+    'trapani' => 
+    array (
+    ),
+    'trentino' => 
+    array (
+    ),
+    'trento' => 
+    array (
+    ),
+    'treviso' => 
+    array (
+    ),
+    'trieste' => 
+    array (
+    ),
+    'ts' => 
+    array (
+    ),
+    'turin' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+    'ud' => 
+    array (
+    ),
+    'udine' => 
+    array (
+    ),
+    'urbino-pesaro' => 
+    array (
+    ),
+    'urbinopesaro' => 
+    array (
+    ),
+    'va' => 
+    array (
+    ),
+    'varese' => 
+    array (
+    ),
+    'vb' => 
+    array (
+    ),
+    'vc' => 
+    array (
+    ),
+    've' => 
+    array (
+    ),
+    'venezia' => 
+    array (
+    ),
+    'venice' => 
+    array (
+    ),
+    'verbania' => 
+    array (
+    ),
+    'vercelli' => 
+    array (
+    ),
+    'verona' => 
+    array (
+    ),
+    'vi' => 
+    array (
+    ),
+    'vibo-valentia' => 
+    array (
+    ),
+    'vibovalentia' => 
+    array (
+    ),
+    'vicenza' => 
+    array (
+    ),
+    'viterbo' => 
+    array (
+    ),
+    'vr' => 
+    array (
+    ),
+    'vs' => 
+    array (
+    ),
+    'vt' => 
+    array (
+    ),
+    'vv' => 
+    array (
+    ),
+  ),
+  'je' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'jm' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'jo' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+  ),
+  'jobs' => 
+  array (
+  ),
+  'jp' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'ad' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'ed' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'gr' => 
+    array (
+    ),
+    'lg' => 
+    array (
+    ),
+    'ne' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'aichi' => 
+    array (
+      'aisai' => 
+      array (
+      ),
+      'ama' => 
+      array (
+      ),
+      'anjo' => 
+      array (
+      ),
+      'asuke' => 
+      array (
+      ),
+      'chiryu' => 
+      array (
+      ),
+      'chita' => 
+      array (
+      ),
+      'fuso' => 
+      array (
+      ),
+      'gamagori' => 
+      array (
+      ),
+      'handa' => 
+      array (
+      ),
+      'hazu' => 
+      array (
+      ),
+      'hekinan' => 
+      array (
+      ),
+      'higashiura' => 
+      array (
+      ),
+      'ichinomiya' => 
+      array (
+      ),
+      'inazawa' => 
+      array (
+      ),
+      'inuyama' => 
+      array (
+      ),
+      'isshiki' => 
+      array (
+      ),
+      'iwakura' => 
+      array (
+      ),
+      'kanie' => 
+      array (
+      ),
+      'kariya' => 
+      array (
+      ),
+      'kasugai' => 
+      array (
+      ),
+      'kira' => 
+      array (
+      ),
+      'kiyosu' => 
+      array (
+      ),
+      'komaki' => 
+      array (
+      ),
+      'konan' => 
+      array (
+      ),
+      'kota' => 
+      array (
+      ),
+      'mihama' => 
+      array (
+      ),
+      'miyoshi' => 
+      array (
+      ),
+      'nishio' => 
+      array (
+      ),
+      'nisshin' => 
+      array (
+      ),
+      'obu' => 
+      array (
+      ),
+      'oguchi' => 
+      array (
+      ),
+      'oharu' => 
+      array (
+      ),
+      'okazaki' => 
+      array (
+      ),
+      'owariasahi' => 
+      array (
+      ),
+      'seto' => 
+      array (
+      ),
+      'shikatsu' => 
+      array (
+      ),
+      'shinshiro' => 
+      array (
+      ),
+      'shitara' => 
+      array (
+      ),
+      'tahara' => 
+      array (
+      ),
+      'takahama' => 
+      array (
+      ),
+      'tobishima' => 
+      array (
+      ),
+      'toei' => 
+      array (
+      ),
+      'togo' => 
+      array (
+      ),
+      'tokai' => 
+      array (
+      ),
+      'tokoname' => 
+      array (
+      ),
+      'toyoake' => 
+      array (
+      ),
+      'toyohashi' => 
+      array (
+      ),
+      'toyokawa' => 
+      array (
+      ),
+      'toyone' => 
+      array (
+      ),
+      'toyota' => 
+      array (
+      ),
+      'tsushima' => 
+      array (
+      ),
+      'yatomi' => 
+      array (
+      ),
+    ),
+    'akita' => 
+    array (
+      'akita' => 
+      array (
+      ),
+      'daisen' => 
+      array (
+      ),
+      'fujisato' => 
+      array (
+      ),
+      'gojome' => 
+      array (
+      ),
+      'hachirogata' => 
+      array (
+      ),
+      'happou' => 
+      array (
+      ),
+      'higashinaruse' => 
+      array (
+      ),
+      'honjo' => 
+      array (
+      ),
+      'honjyo' => 
+      array (
+      ),
+      'ikawa' => 
+      array (
+      ),
+      'kamikoani' => 
+      array (
+      ),
+      'kamioka' => 
+      array (
+      ),
+      'katagami' => 
+      array (
+      ),
+      'kazuno' => 
+      array (
+      ),
+      'kitaakita' => 
+      array (
+      ),
+      'kosaka' => 
+      array (
+      ),
+      'kyowa' => 
+      array (
+      ),
+      'misato' => 
+      array (
+      ),
+      'mitane' => 
+      array (
+      ),
+      'moriyoshi' => 
+      array (
+      ),
+      'nikaho' => 
+      array (
+      ),
+      'noshiro' => 
+      array (
+      ),
+      'odate' => 
+      array (
+      ),
+      'oga' => 
+      array (
+      ),
+      'ogata' => 
+      array (
+      ),
+      'semboku' => 
+      array (
+      ),
+      'yokote' => 
+      array (
+      ),
+      'yurihonjo' => 
+      array (
+      ),
+    ),
+    'aomori' => 
+    array (
+      'aomori' => 
+      array (
+      ),
+      'gonohe' => 
+      array (
+      ),
+      'hachinohe' => 
+      array (
+      ),
+      'hashikami' => 
+      array (
+      ),
+      'hiranai' => 
+      array (
+      ),
+      'hirosaki' => 
+      array (
+      ),
+      'itayanagi' => 
+      array (
+      ),
+      'kuroishi' => 
+      array (
+      ),
+      'misawa' => 
+      array (
+      ),
+      'mutsu' => 
+      array (
+      ),
+      'nakadomari' => 
+      array (
+      ),
+      'noheji' => 
+      array (
+      ),
+      'oirase' => 
+      array (
+      ),
+      'owani' => 
+      array (
+      ),
+      'rokunohe' => 
+      array (
+      ),
+      'sannohe' => 
+      array (
+      ),
+      'shichinohe' => 
+      array (
+      ),
+      'shingo' => 
+      array (
+      ),
+      'takko' => 
+      array (
+      ),
+      'towada' => 
+      array (
+      ),
+      'tsugaru' => 
+      array (
+      ),
+      'tsuruta' => 
+      array (
+      ),
+    ),
+    'chiba' => 
+    array (
+      'abiko' => 
+      array (
+      ),
+      'asahi' => 
+      array (
+      ),
+      'chonan' => 
+      array (
+      ),
+      'chosei' => 
+      array (
+      ),
+      'choshi' => 
+      array (
+      ),
+      'chuo' => 
+      array (
+      ),
+      'funabashi' => 
+      array (
+      ),
+      'futtsu' => 
+      array (
+      ),
+      'hanamigawa' => 
+      array (
+      ),
+      'ichihara' => 
+      array (
+      ),
+      'ichikawa' => 
+      array (
+      ),
+      'ichinomiya' => 
+      array (
+      ),
+      'inzai' => 
+      array (
+      ),
+      'isumi' => 
+      array (
+      ),
+      'kamagaya' => 
+      array (
+      ),
+      'kamogawa' => 
+      array (
+      ),
+      'kashiwa' => 
+      array (
+      ),
+      'katori' => 
+      array (
+      ),
+      'katsuura' => 
+      array (
+      ),
+      'kimitsu' => 
+      array (
+      ),
+      'kisarazu' => 
+      array (
+      ),
+      'kozaki' => 
+      array (
+      ),
+      'kujukuri' => 
+      array (
+      ),
+      'kyonan' => 
+      array (
+      ),
+      'matsudo' => 
+      array (
+      ),
+      'midori' => 
+      array (
+      ),
+      'mihama' => 
+      array (
+      ),
+      'minamiboso' => 
+      array (
+      ),
+      'mobara' => 
+      array (
+      ),
+      'mutsuzawa' => 
+      array (
+      ),
+      'nagara' => 
+      array (
+      ),
+      'nagareyama' => 
+      array (
+      ),
+      'narashino' => 
+      array (
+      ),
+      'narita' => 
+      array (
+      ),
+      'noda' => 
+      array (
+      ),
+      'oamishirasato' => 
+      array (
+      ),
+      'omigawa' => 
+      array (
+      ),
+      'onjuku' => 
+      array (
+      ),
+      'otaki' => 
+      array (
+      ),
+      'sakae' => 
+      array (
+      ),
+      'sakura' => 
+      array (
+      ),
+      'shimofusa' => 
+      array (
+      ),
+      'shirako' => 
+      array (
+      ),
+      'shiroi' => 
+      array (
+      ),
+      'shisui' => 
+      array (
+      ),
+      'sodegaura' => 
+      array (
+      ),
+      'sosa' => 
+      array (
+      ),
+      'tako' => 
+      array (
+      ),
+      'tateyama' => 
+      array (
+      ),
+      'togane' => 
+      array (
+      ),
+      'tohnosho' => 
+      array (
+      ),
+      'tomisato' => 
+      array (
+      ),
+      'urayasu' => 
+      array (
+      ),
+      'yachimata' => 
+      array (
+      ),
+      'yachiyo' => 
+      array (
+      ),
+      'yokaichiba' => 
+      array (
+      ),
+      'yokoshibahikari' => 
+      array (
+      ),
+      'yotsukaido' => 
+      array (
+      ),
+    ),
+    'ehime' => 
+    array (
+      'ainan' => 
+      array (
+      ),
+      'honai' => 
+      array (
+      ),
+      'ikata' => 
+      array (
+      ),
+      'imabari' => 
+      array (
+      ),
+      'iyo' => 
+      array (
+      ),
+      'kamijima' => 
+      array (
+      ),
+      'kihoku' => 
+      array (
+      ),
+      'kumakogen' => 
+      array (
+      ),
+      'masaki' => 
+      array (
+      ),
+      'matsuno' => 
+      array (
+      ),
+      'matsuyama' => 
+      array (
+      ),
+      'namikata' => 
+      array (
+      ),
+      'niihama' => 
+      array (
+      ),
+      'ozu' => 
+      array (
+      ),
+      'saijo' => 
+      array (
+      ),
+      'seiyo' => 
+      array (
+      ),
+      'shikokuchuo' => 
+      array (
+      ),
+      'tobe' => 
+      array (
+      ),
+      'toon' => 
+      array (
+      ),
+      'uchiko' => 
+      array (
+      ),
+      'uwajima' => 
+      array (
+      ),
+      'yawatahama' => 
+      array (
+      ),
+    ),
+    'fukui' => 
+    array (
+      'echizen' => 
+      array (
+      ),
+      'eiheiji' => 
+      array (
+      ),
+      'fukui' => 
+      array (
+      ),
+      'ikeda' => 
+      array (
+      ),
+      'katsuyama' => 
+      array (
+      ),
+      'mihama' => 
+      array (
+      ),
+      'minamiechizen' => 
+      array (
+      ),
+      'obama' => 
+      array (
+      ),
+      'ohi' => 
+      array (
+      ),
+      'ono' => 
+      array (
+      ),
+      'sabae' => 
+      array (
+      ),
+      'sakai' => 
+      array (
+      ),
+      'takahama' => 
+      array (
+      ),
+      'tsuruga' => 
+      array (
+      ),
+      'wakasa' => 
+      array (
+      ),
+    ),
+    'fukuoka' => 
+    array (
+      'ashiya' => 
+      array (
+      ),
+      'buzen' => 
+      array (
+      ),
+      'chikugo' => 
+      array (
+      ),
+      'chikuho' => 
+      array (
+      ),
+      'chikujo' => 
+      array (
+      ),
+      'chikushino' => 
+      array (
+      ),
+      'chikuzen' => 
+      array (
+      ),
+      'chuo' => 
+      array (
+      ),
+      'dazaifu' => 
+      array (
+      ),
+      'fukuchi' => 
+      array (
+      ),
+      'hakata' => 
+      array (
+      ),
+      'higashi' => 
+      array (
+      ),
+      'hirokawa' => 
+      array (
+      ),
+      'hisayama' => 
+      array (
+      ),
+      'iizuka' => 
+      array (
+      ),
+      'inatsuki' => 
+      array (
+      ),
+      'kaho' => 
+      array (
+      ),
+      'kasuga' => 
+      array (
+      ),
+      'kasuya' => 
+      array (
+      ),
+      'kawara' => 
+      array (
+      ),
+      'keisen' => 
+      array (
+      ),
+      'koga' => 
+      array (
+      ),
+      'kurate' => 
+      array (
+      ),
+      'kurogi' => 
+      array (
+      ),
+      'kurume' => 
+      array (
+      ),
+      'minami' => 
+      array (
+      ),
+      'miyako' => 
+      array (
+      ),
+      'miyama' => 
+      array (
+      ),
+      'miyawaka' => 
+      array (
+      ),
+      'mizumaki' => 
+      array (
+      ),
+      'munakata' => 
+      array (
+      ),
+      'nakagawa' => 
+      array (
+      ),
+      'nakama' => 
+      array (
+      ),
+      'nishi' => 
+      array (
+      ),
+      'nogata' => 
+      array (
+      ),
+      'ogori' => 
+      array (
+      ),
+      'okagaki' => 
+      array (
+      ),
+      'okawa' => 
+      array (
+      ),
+      'oki' => 
+      array (
+      ),
+      'omuta' => 
+      array (
+      ),
+      'onga' => 
+      array (
+      ),
+      'onojo' => 
+      array (
+      ),
+      'oto' => 
+      array (
+      ),
+      'saigawa' => 
+      array (
+      ),
+      'sasaguri' => 
+      array (
+      ),
+      'shingu' => 
+      array (
+      ),
+      'shinyoshitomi' => 
+      array (
+      ),
+      'shonai' => 
+      array (
+      ),
+      'soeda' => 
+      array (
+      ),
+      'sue' => 
+      array (
+      ),
+      'tachiarai' => 
+      array (
+      ),
+      'tagawa' => 
+      array (
+      ),
+      'takata' => 
+      array (
+      ),
+      'toho' => 
+      array (
+      ),
+      'toyotsu' => 
+      array (
+      ),
+      'tsuiki' => 
+      array (
+      ),
+      'ukiha' => 
+      array (
+      ),
+      'umi' => 
+      array (
+      ),
+      'usui' => 
+      array (
+      ),
+      'yamada' => 
+      array (
+      ),
+      'yame' => 
+      array (
+      ),
+      'yanagawa' => 
+      array (
+      ),
+      'yukuhashi' => 
+      array (
+      ),
+    ),
+    'fukushima' => 
+    array (
+      'aizubange' => 
+      array (
+      ),
+      'aizumisato' => 
+      array (
+      ),
+      'aizuwakamatsu' => 
+      array (
+      ),
+      'asakawa' => 
+      array (
+      ),
+      'bandai' => 
+      array (
+      ),
+      'date' => 
+      array (
+      ),
+      'fukushima' => 
+      array (
+      ),
+      'furudono' => 
+      array (
+      ),
+      'futaba' => 
+      array (
+      ),
+      'hanawa' => 
+      array (
+      ),
+      'higashi' => 
+      array (
+      ),
+      'hirata' => 
+      array (
+      ),
+      'hirono' => 
+      array (
+      ),
+      'iitate' => 
+      array (
+      ),
+      'inawashiro' => 
+      array (
+      ),
+      'ishikawa' => 
+      array (
+      ),
+      'iwaki' => 
+      array (
+      ),
+      'izumizaki' => 
+      array (
+      ),
+      'kagamiishi' => 
+      array (
+      ),
+      'kaneyama' => 
+      array (
+      ),
+      'kawamata' => 
+      array (
+      ),
+      'kitakata' => 
+      array (
+      ),
+      'kitashiobara' => 
+      array (
+      ),
+      'koori' => 
+      array (
+      ),
+      'koriyama' => 
+      array (
+      ),
+      'kunimi' => 
+      array (
+      ),
+      'miharu' => 
+      array (
+      ),
+      'mishima' => 
+      array (
+      ),
+      'namie' => 
+      array (
+      ),
+      'nango' => 
+      array (
+      ),
+      'nishiaizu' => 
+      array (
+      ),
+      'nishigo' => 
+      array (
+      ),
+      'okuma' => 
+      array (
+      ),
+      'omotego' => 
+      array (
+      ),
+      'ono' => 
+      array (
+      ),
+      'otama' => 
+      array (
+      ),
+      'samegawa' => 
+      array (
+      ),
+      'shimogo' => 
+      array (
+      ),
+      'shirakawa' => 
+      array (
+      ),
+      'showa' => 
+      array (
+      ),
+      'soma' => 
+      array (
+      ),
+      'sukagawa' => 
+      array (
+      ),
+      'taishin' => 
+      array (
+      ),
+      'tamakawa' => 
+      array (
+      ),
+      'tanagura' => 
+      array (
+      ),
+      'tenei' => 
+      array (
+      ),
+      'yabuki' => 
+      array (
+      ),
+      'yamato' => 
+      array (
+      ),
+      'yamatsuri' => 
+      array (
+      ),
+      'yanaizu' => 
+      array (
+      ),
+      'yugawa' => 
+      array (
+      ),
+    ),
+    'gifu' => 
+    array (
+      'anpachi' => 
+      array (
+      ),
+      'ena' => 
+      array (
+      ),
+      'gifu' => 
+      array (
+      ),
+      'ginan' => 
+      array (
+      ),
+      'godo' => 
+      array (
+      ),
+      'gujo' => 
+      array (
+      ),
+      'hashima' => 
+      array (
+      ),
+      'hichiso' => 
+      array (
+      ),
+      'hida' => 
+      array (
+      ),
+      'higashishirakawa' => 
+      array (
+      ),
+      'ibigawa' => 
+      array (
+      ),
+      'ikeda' => 
+      array (
+      ),
+      'kakamigahara' => 
+      array (
+      ),
+      'kani' => 
+      array (
+      ),
+      'kasahara' => 
+      array (
+      ),
+      'kasamatsu' => 
+      array (
+      ),
+      'kawaue' => 
+      array (
+      ),
+      'kitagata' => 
+      array (
+      ),
+      'mino' => 
+      array (
+      ),
+      'minokamo' => 
+      array (
+      ),
+      'mitake' => 
+      array (
+      ),
+      'mizunami' => 
+      array (
+      ),
+      'motosu' => 
+      array (
+      ),
+      'nakatsugawa' => 
+      array (
+      ),
+      'ogaki' => 
+      array (
+      ),
+      'sakahogi' => 
+      array (
+      ),
+      'seki' => 
+      array (
+      ),
+      'sekigahara' => 
+      array (
+      ),
+      'shirakawa' => 
+      array (
+      ),
+      'tajimi' => 
+      array (
+      ),
+      'takayama' => 
+      array (
+      ),
+      'tarui' => 
+      array (
+      ),
+      'toki' => 
+      array (
+      ),
+      'tomika' => 
+      array (
+      ),
+      'wanouchi' => 
+      array (
+      ),
+      'yamagata' => 
+      array (
+      ),
+      'yaotsu' => 
+      array (
+      ),
+      'yoro' => 
+      array (
+      ),
+    ),
+    'gunma' => 
+    array (
+      'annaka' => 
+      array (
+      ),
+      'chiyoda' => 
+      array (
+      ),
+      'fujioka' => 
+      array (
+      ),
+      'higashiagatsuma' => 
+      array (
+      ),
+      'isesaki' => 
+      array (
+      ),
+      'itakura' => 
+      array (
+      ),
+      'kanna' => 
+      array (
+      ),
+      'kanra' => 
+      array (
+      ),
+      'katashina' => 
+      array (
+      ),
+      'kawaba' => 
+      array (
+      ),
+      'kiryu' => 
+      array (
+      ),
+      'kusatsu' => 
+      array (
+      ),
+      'maebashi' => 
+      array (
+      ),
+      'meiwa' => 
+      array (
+      ),
+      'midori' => 
+      array (
+      ),
+      'minakami' => 
+      array (
+      ),
+      'naganohara' => 
+      array (
+      ),
+      'nakanojo' => 
+      array (
+      ),
+      'nanmoku' => 
+      array (
+      ),
+      'numata' => 
+      array (
+      ),
+      'oizumi' => 
+      array (
+      ),
+      'ora' => 
+      array (
+      ),
+      'ota' => 
+      array (
+      ),
+      'shibukawa' => 
+      array (
+      ),
+      'shimonita' => 
+      array (
+      ),
+      'shinto' => 
+      array (
+      ),
+      'showa' => 
+      array (
+      ),
+      'takasaki' => 
+      array (
+      ),
+      'takayama' => 
+      array (
+      ),
+      'tamamura' => 
+      array (
+      ),
+      'tatebayashi' => 
+      array (
+      ),
+      'tomioka' => 
+      array (
+      ),
+      'tsukiyono' => 
+      array (
+      ),
+      'tsumagoi' => 
+      array (
+      ),
+      'ueno' => 
+      array (
+      ),
+      'yoshioka' => 
+      array (
+      ),
+    ),
+    'hiroshima' => 
+    array (
+      'asaminami' => 
+      array (
+      ),
+      'daiwa' => 
+      array (
+      ),
+      'etajima' => 
+      array (
+      ),
+      'fuchu' => 
+      array (
+      ),
+      'fukuyama' => 
+      array (
+      ),
+      'hatsukaichi' => 
+      array (
+      ),
+      'higashihiroshima' => 
+      array (
+      ),
+      'hongo' => 
+      array (
+      ),
+      'jinsekikogen' => 
+      array (
+      ),
+      'kaita' => 
+      array (
+      ),
+      'kui' => 
+      array (
+      ),
+      'kumano' => 
+      array (
+      ),
+      'kure' => 
+      array (
+      ),
+      'mihara' => 
+      array (
+      ),
+      'miyoshi' => 
+      array (
+      ),
+      'naka' => 
+      array (
+      ),
+      'onomichi' => 
+      array (
+      ),
+      'osakikamijima' => 
+      array (
+      ),
+      'otake' => 
+      array (
+      ),
+      'saka' => 
+      array (
+      ),
+      'sera' => 
+      array (
+      ),
+      'seranishi' => 
+      array (
+      ),
+      'shinichi' => 
+      array (
+      ),
+      'shobara' => 
+      array (
+      ),
+      'takehara' => 
+      array (
+      ),
+    ),
+    'hokkaido' => 
+    array (
+      'abashiri' => 
+      array (
+      ),
+      'abira' => 
+      array (
+      ),
+      'aibetsu' => 
+      array (
+      ),
+      'akabira' => 
+      array (
+      ),
+      'akkeshi' => 
+      array (
+      ),
+      'asahikawa' => 
+      array (
+      ),
+      'ashibetsu' => 
+      array (
+      ),
+      'ashoro' => 
+      array (
+      ),
+      'assabu' => 
+      array (
+      ),
+      'atsuma' => 
+      array (
+      ),
+      'bibai' => 
+      array (
+      ),
+      'biei' => 
+      array (
+      ),
+      'bifuka' => 
+      array (
+      ),
+      'bihoro' => 
+      array (
+      ),
+      'biratori' => 
+      array (
+      ),
+      'chippubetsu' => 
+      array (
+      ),
+      'chitose' => 
+      array (
+      ),
+      'date' => 
+      array (
+      ),
+      'ebetsu' => 
+      array (
+      ),
+      'embetsu' => 
+      array (
+      ),
+      'eniwa' => 
+      array (
+      ),
+      'erimo' => 
+      array (
+      ),
+      'esan' => 
+      array (
+      ),
+      'esashi' => 
+      array (
+      ),
+      'fukagawa' => 
+      array (
+      ),
+      'fukushima' => 
+      array (
+      ),
+      'furano' => 
+      array (
+      ),
+      'furubira' => 
+      array (
+      ),
+      'haboro' => 
+      array (
+      ),
+      'hakodate' => 
+      array (
+      ),
+      'hamatonbetsu' => 
+      array (
+      ),
+      'hidaka' => 
+      array (
+      ),
+      'higashikagura' => 
+      array (
+      ),
+      'higashikawa' => 
+      array (
+      ),
+      'hiroo' => 
+      array (
+      ),
+      'hokuryu' => 
+      array (
+      ),
+      'hokuto' => 
+      array (
+      ),
+      'honbetsu' => 
+      array (
+      ),
+      'horokanai' => 
+      array (
+      ),
+      'horonobe' => 
+      array (
+      ),
+      'ikeda' => 
+      array (
+      ),
+      'imakane' => 
+      array (
+      ),
+      'ishikari' => 
+      array (
+      ),
+      'iwamizawa' => 
+      array (
+      ),
+      'iwanai' => 
+      array (
+      ),
+      'kamifurano' => 
+      array (
+      ),
+      'kamikawa' => 
+      array (
+      ),
+      'kamishihoro' => 
+      array (
+      ),
+      'kamisunagawa' => 
+      array (
+      ),
+      'kamoenai' => 
+      array (
+      ),
+      'kayabe' => 
+      array (
+      ),
+      'kembuchi' => 
+      array (
+      ),
+      'kikonai' => 
+      array (
+      ),
+      'kimobetsu' => 
+      array (
+      ),
+      'kitahiroshima' => 
+      array (
+      ),
+      'kitami' => 
+      array (
+      ),
+      'kiyosato' => 
+      array (
+      ),
+      'koshimizu' => 
+      array (
+      ),
+      'kunneppu' => 
+      array (
+      ),
+      'kuriyama' => 
+      array (
+      ),
+      'kuromatsunai' => 
+      array (
+      ),
+      'kushiro' => 
+      array (
+      ),
+      'kutchan' => 
+      array (
+      ),
+      'kyowa' => 
+      array (
+      ),
+      'mashike' => 
+      array (
+      ),
+      'matsumae' => 
+      array (
+      ),
+      'mikasa' => 
+      array (
+      ),
+      'minamifurano' => 
+      array (
+      ),
+      'mombetsu' => 
+      array (
+      ),
+      'moseushi' => 
+      array (
+      ),
+      'mukawa' => 
+      array (
+      ),
+      'muroran' => 
+      array (
+      ),
+      'naie' => 
+      array (
+      ),
+      'nakagawa' => 
+      array (
+      ),
+      'nakasatsunai' => 
+      array (
+      ),
+      'nakatombetsu' => 
+      array (
+      ),
+      'nanae' => 
+      array (
+      ),
+      'nanporo' => 
+      array (
+      ),
+      'nayoro' => 
+      array (
+      ),
+      'nemuro' => 
+      array (
+      ),
+      'niikappu' => 
+      array (
+      ),
+      'niki' => 
+      array (
+      ),
+      'nishiokoppe' => 
+      array (
+      ),
+      'noboribetsu' => 
+      array (
+      ),
+      'numata' => 
+      array (
+      ),
+      'obihiro' => 
+      array (
+      ),
+      'obira' => 
+      array (
+      ),
+      'oketo' => 
+      array (
+      ),
+      'okoppe' => 
+      array (
+      ),
+      'otaru' => 
+      array (
+      ),
+      'otobe' => 
+      array (
+      ),
+      'otofuke' => 
+      array (
+      ),
+      'otoineppu' => 
+      array (
+      ),
+      'oumu' => 
+      array (
+      ),
+      'ozora' => 
+      array (
+      ),
+      'pippu' => 
+      array (
+      ),
+      'rankoshi' => 
+      array (
+      ),
+      'rebun' => 
+      array (
+      ),
+      'rikubetsu' => 
+      array (
+      ),
+      'rishiri' => 
+      array (
+      ),
+      'rishirifuji' => 
+      array (
+      ),
+      'saroma' => 
+      array (
+      ),
+      'sarufutsu' => 
+      array (
+      ),
+      'shakotan' => 
+      array (
+      ),
+      'shari' => 
+      array (
+      ),
+      'shibecha' => 
+      array (
+      ),
+      'shibetsu' => 
+      array (
+      ),
+      'shikabe' => 
+      array (
+      ),
+      'shikaoi' => 
+      array (
+      ),
+      'shimamaki' => 
+      array (
+      ),
+      'shimizu' => 
+      array (
+      ),
+      'shimokawa' => 
+      array (
+      ),
+      'shinshinotsu' => 
+      array (
+      ),
+      'shintoku' => 
+      array (
+      ),
+      'shiranuka' => 
+      array (
+      ),
+      'shiraoi' => 
+      array (
+      ),
+      'shiriuchi' => 
+      array (
+      ),
+      'sobetsu' => 
+      array (
+      ),
+      'sunagawa' => 
+      array (
+      ),
+      'taiki' => 
+      array (
+      ),
+      'takasu' => 
+      array (
+      ),
+      'takikawa' => 
+      array (
+      ),
+      'takinoue' => 
+      array (
+      ),
+      'teshikaga' => 
+      array (
+      ),
+      'tobetsu' => 
+      array (
+      ),
+      'tohma' => 
+      array (
+      ),
+      'tomakomai' => 
+      array (
+      ),
+      'tomari' => 
+      array (
+      ),
+      'toya' => 
+      array (
+      ),
+      'toyako' => 
+      array (
+      ),
+      'toyotomi' => 
+      array (
+      ),
+      'toyoura' => 
+      array (
+      ),
+      'tsubetsu' => 
+      array (
+      ),
+      'tsukigata' => 
+      array (
+      ),
+      'urakawa' => 
+      array (
+      ),
+      'urausu' => 
+      array (
+      ),
+      'uryu' => 
+      array (
+      ),
+      'utashinai' => 
+      array (
+      ),
+      'wakkanai' => 
+      array (
+      ),
+      'wassamu' => 
+      array (
+      ),
+      'yakumo' => 
+      array (
+      ),
+      'yoichi' => 
+      array (
+      ),
+    ),
+    'hyogo' => 
+    array (
+      'aioi' => 
+      array (
+      ),
+      'akashi' => 
+      array (
+      ),
+      'ako' => 
+      array (
+      ),
+      'amagasaki' => 
+      array (
+      ),
+      'aogaki' => 
+      array (
+      ),
+      'asago' => 
+      array (
+      ),
+      'ashiya' => 
+      array (
+      ),
+      'awaji' => 
+      array (
+      ),
+      'fukusaki' => 
+      array (
+      ),
+      'goshiki' => 
+      array (
+      ),
+      'harima' => 
+      array (
+      ),
+      'himeji' => 
+      array (
+      ),
+      'ichikawa' => 
+      array (
+      ),
+      'inagawa' => 
+      array (
+      ),
+      'itami' => 
+      array (
+      ),
+      'kakogawa' => 
+      array (
+      ),
+      'kamigori' => 
+      array (
+      ),
+      'kamikawa' => 
+      array (
+      ),
+      'kasai' => 
+      array (
+      ),
+      'kasuga' => 
+      array (
+      ),
+      'kawanishi' => 
+      array (
+      ),
+      'miki' => 
+      array (
+      ),
+      'minamiawaji' => 
+      array (
+      ),
+      'nishinomiya' => 
+      array (
+      ),
+      'nishiwaki' => 
+      array (
+      ),
+      'ono' => 
+      array (
+      ),
+      'sanda' => 
+      array (
+      ),
+      'sannan' => 
+      array (
+      ),
+      'sasayama' => 
+      array (
+      ),
+      'sayo' => 
+      array (
+      ),
+      'shingu' => 
+      array (
+      ),
+      'shinonsen' => 
+      array (
+      ),
+      'shiso' => 
+      array (
+      ),
+      'sumoto' => 
+      array (
+      ),
+      'taishi' => 
+      array (
+      ),
+      'taka' => 
+      array (
+      ),
+      'takarazuka' => 
+      array (
+      ),
+      'takasago' => 
+      array (
+      ),
+      'takino' => 
+      array (
+      ),
+      'tamba' => 
+      array (
+      ),
+      'tatsuno' => 
+      array (
+      ),
+      'toyooka' => 
+      array (
+      ),
+      'yabu' => 
+      array (
+      ),
+      'yashiro' => 
+      array (
+      ),
+      'yoka' => 
+      array (
+      ),
+      'yokawa' => 
+      array (
+      ),
+    ),
+    'ibaraki' => 
+    array (
+      'ami' => 
+      array (
+      ),
+      'asahi' => 
+      array (
+      ),
+      'bando' => 
+      array (
+      ),
+      'chikusei' => 
+      array (
+      ),
+      'daigo' => 
+      array (
+      ),
+      'fujishiro' => 
+      array (
+      ),
+      'hitachi' => 
+      array (
+      ),
+      'hitachinaka' => 
+      array (
+      ),
+      'hitachiomiya' => 
+      array (
+      ),
+      'hitachiota' => 
+      array (
+      ),
+      'ibaraki' => 
+      array (
+      ),
+      'ina' => 
+      array (
+      ),
+      'inashiki' => 
+      array (
+      ),
+      'itako' => 
+      array (
+      ),
+      'iwama' => 
+      array (
+      ),
+      'joso' => 
+      array (
+      ),
+      'kamisu' => 
+      array (
+      ),
+      'kasama' => 
+      array (
+      ),
+      'kashima' => 
+      array (
+      ),
+      'kasumigaura' => 
+      array (
+      ),
+      'koga' => 
+      array (
+      ),
+      'miho' => 
+      array (
+      ),
+      'mito' => 
+      array (
+      ),
+      'moriya' => 
+      array (
+      ),
+      'naka' => 
+      array (
+      ),
+      'namegata' => 
+      array (
+      ),
+      'oarai' => 
+      array (
+      ),
+      'ogawa' => 
+      array (
+      ),
+      'omitama' => 
+      array (
+      ),
+      'ryugasaki' => 
+      array (
+      ),
+      'sakai' => 
+      array (
+      ),
+      'sakuragawa' => 
+      array (
+      ),
+      'shimodate' => 
+      array (
+      ),
+      'shimotsuma' => 
+      array (
+      ),
+      'shirosato' => 
+      array (
+      ),
+      'sowa' => 
+      array (
+      ),
+      'suifu' => 
+      array (
+      ),
+      'takahagi' => 
+      array (
+      ),
+      'tamatsukuri' => 
+      array (
+      ),
+      'tokai' => 
+      array (
+      ),
+      'tomobe' => 
+      array (
+      ),
+      'tone' => 
+      array (
+      ),
+      'toride' => 
+      array (
+      ),
+      'tsuchiura' => 
+      array (
+      ),
+      'tsukuba' => 
+      array (
+      ),
+      'uchihara' => 
+      array (
+      ),
+      'ushiku' => 
+      array (
+      ),
+      'yachiyo' => 
+      array (
+      ),
+      'yamagata' => 
+      array (
+      ),
+      'yawara' => 
+      array (
+      ),
+      'yuki' => 
+      array (
+      ),
+    ),
+    'ishikawa' => 
+    array (
+      'anamizu' => 
+      array (
+      ),
+      'hakui' => 
+      array (
+      ),
+      'hakusan' => 
+      array (
+      ),
+      'kaga' => 
+      array (
+      ),
+      'kahoku' => 
+      array (
+      ),
+      'kanazawa' => 
+      array (
+      ),
+      'kawakita' => 
+      array (
+      ),
+      'komatsu' => 
+      array (
+      ),
+      'nakanoto' => 
+      array (
+      ),
+      'nanao' => 
+      array (
+      ),
+      'nomi' => 
+      array (
+      ),
+      'nonoichi' => 
+      array (
+      ),
+      'noto' => 
+      array (
+      ),
+      'shika' => 
+      array (
+      ),
+      'suzu' => 
+      array (
+      ),
+      'tsubata' => 
+      array (
+      ),
+      'tsurugi' => 
+      array (
+      ),
+      'uchinada' => 
+      array (
+      ),
+      'wajima' => 
+      array (
+      ),
+    ),
+    'iwate' => 
+    array (
+      'fudai' => 
+      array (
+      ),
+      'fujisawa' => 
+      array (
+      ),
+      'hanamaki' => 
+      array (
+      ),
+      'hiraizumi' => 
+      array (
+      ),
+      'hirono' => 
+      array (
+      ),
+      'ichinohe' => 
+      array (
+      ),
+      'ichinoseki' => 
+      array (
+      ),
+      'iwaizumi' => 
+      array (
+      ),
+      'iwate' => 
+      array (
+      ),
+      'joboji' => 
+      array (
+      ),
+      'kamaishi' => 
+      array (
+      ),
+      'kanegasaki' => 
+      array (
+      ),
+      'karumai' => 
+      array (
+      ),
+      'kawai' => 
+      array (
+      ),
+      'kitakami' => 
+      array (
+      ),
+      'kuji' => 
+      array (
+      ),
+      'kunohe' => 
+      array (
+      ),
+      'kuzumaki' => 
+      array (
+      ),
+      'miyako' => 
+      array (
+      ),
+      'mizusawa' => 
+      array (
+      ),
+      'morioka' => 
+      array (
+      ),
+      'ninohe' => 
+      array (
+      ),
+      'noda' => 
+      array (
+      ),
+      'ofunato' => 
+      array (
+      ),
+      'oshu' => 
+      array (
+      ),
+      'otsuchi' => 
+      array (
+      ),
+      'rikuzentakata' => 
+      array (
+      ),
+      'shiwa' => 
+      array (
+      ),
+      'shizukuishi' => 
+      array (
+      ),
+      'sumita' => 
+      array (
+      ),
+      'tanohata' => 
+      array (
+      ),
+      'tono' => 
+      array (
+      ),
+      'yahaba' => 
+      array (
+      ),
+      'yamada' => 
+      array (
+      ),
+    ),
+    'kagawa' => 
+    array (
+      'ayagawa' => 
+      array (
+      ),
+      'higashikagawa' => 
+      array (
+      ),
+      'kanonji' => 
+      array (
+      ),
+      'kotohira' => 
+      array (
+      ),
+      'manno' => 
+      array (
+      ),
+      'marugame' => 
+      array (
+      ),
+      'mitoyo' => 
+      array (
+      ),
+      'naoshima' => 
+      array (
+      ),
+      'sanuki' => 
+      array (
+      ),
+      'tadotsu' => 
+      array (
+      ),
+      'takamatsu' => 
+      array (
+      ),
+      'tonosho' => 
+      array (
+      ),
+      'uchinomi' => 
+      array (
+      ),
+      'utazu' => 
+      array (
+      ),
+      'zentsuji' => 
+      array (
+      ),
+    ),
+    'kagoshima' => 
+    array (
+      'akune' => 
+      array (
+      ),
+      'amami' => 
+      array (
+      ),
+      'hioki' => 
+      array (
+      ),
+      'isa' => 
+      array (
+      ),
+      'isen' => 
+      array (
+      ),
+      'izumi' => 
+      array (
+      ),
+      'kagoshima' => 
+      array (
+      ),
+      'kanoya' => 
+      array (
+      ),
+      'kawanabe' => 
+      array (
+      ),
+      'kinko' => 
+      array (
+      ),
+      'kouyama' => 
+      array (
+      ),
+      'makurazaki' => 
+      array (
+      ),
+      'matsumoto' => 
+      array (
+      ),
+      'minamitane' => 
+      array (
+      ),
+      'nakatane' => 
+      array (
+      ),
+      'nishinoomote' => 
+      array (
+      ),
+      'satsumasendai' => 
+      array (
+      ),
+      'soo' => 
+      array (
+      ),
+      'tarumizu' => 
+      array (
+      ),
+      'yusui' => 
+      array (
+      ),
+    ),
+    'kanagawa' => 
+    array (
+      'aikawa' => 
+      array (
+      ),
+      'atsugi' => 
+      array (
+      ),
+      'ayase' => 
+      array (
+      ),
+      'chigasaki' => 
+      array (
+      ),
+      'ebina' => 
+      array (
+      ),
+      'fujisawa' => 
+      array (
+      ),
+      'hadano' => 
+      array (
+      ),
+      'hakone' => 
+      array (
+      ),
+      'hiratsuka' => 
+      array (
+      ),
+      'isehara' => 
+      array (
+      ),
+      'kaisei' => 
+      array (
+      ),
+      'kamakura' => 
+      array (
+      ),
+      'kiyokawa' => 
+      array (
+      ),
+      'matsuda' => 
+      array (
+      ),
+      'minamiashigara' => 
+      array (
+      ),
+      'miura' => 
+      array (
+      ),
+      'nakai' => 
+      array (
+      ),
+      'ninomiya' => 
+      array (
+      ),
+      'odawara' => 
+      array (
+      ),
+      'oi' => 
+      array (
+      ),
+      'oiso' => 
+      array (
+      ),
+      'sagamihara' => 
+      array (
+      ),
+      'samukawa' => 
+      array (
+      ),
+      'tsukui' => 
+      array (
+      ),
+      'yamakita' => 
+      array (
+      ),
+      'yamato' => 
+      array (
+      ),
+      'yokosuka' => 
+      array (
+      ),
+      'yugawara' => 
+      array (
+      ),
+      'zama' => 
+      array (
+      ),
+      'zushi' => 
+      array (
+      ),
+    ),
+    'kochi' => 
+    array (
+      'aki' => 
+      array (
+      ),
+      'geisei' => 
+      array (
+      ),
+      'hidaka' => 
+      array (
+      ),
+      'higashitsuno' => 
+      array (
+      ),
+      'ino' => 
+      array (
+      ),
+      'kagami' => 
+      array (
+      ),
+      'kami' => 
+      array (
+      ),
+      'kitagawa' => 
+      array (
+      ),
+      'kochi' => 
+      array (
+      ),
+      'mihara' => 
+      array (
+      ),
+      'motoyama' => 
+      array (
+      ),
+      'muroto' => 
+      array (
+      ),
+      'nahari' => 
+      array (
+      ),
+      'nakamura' => 
+      array (
+      ),
+      'nankoku' => 
+      array (
+      ),
+      'nishitosa' => 
+      array (
+      ),
+      'niyodogawa' => 
+      array (
+      ),
+      'ochi' => 
+      array (
+      ),
+      'okawa' => 
+      array (
+      ),
+      'otoyo' => 
+      array (
+      ),
+      'otsuki' => 
+      array (
+      ),
+      'sakawa' => 
+      array (
+      ),
+      'sukumo' => 
+      array (
+      ),
+      'susaki' => 
+      array (
+      ),
+      'tosa' => 
+      array (
+      ),
+      'tosashimizu' => 
+      array (
+      ),
+      'toyo' => 
+      array (
+      ),
+      'tsuno' => 
+      array (
+      ),
+      'umaji' => 
+      array (
+      ),
+      'yasuda' => 
+      array (
+      ),
+      'yusuhara' => 
+      array (
+      ),
+    ),
+    'kumamoto' => 
+    array (
+      'amakusa' => 
+      array (
+      ),
+      'arao' => 
+      array (
+      ),
+      'aso' => 
+      array (
+      ),
+      'choyo' => 
+      array (
+      ),
+      'gyokuto' => 
+      array (
+      ),
+      'hitoyoshi' => 
+      array (
+      ),
+      'kamiamakusa' => 
+      array (
+      ),
+      'kashima' => 
+      array (
+      ),
+      'kikuchi' => 
+      array (
+      ),
+      'kumamoto' => 
+      array (
+      ),
+      'mashiki' => 
+      array (
+      ),
+      'mifune' => 
+      array (
+      ),
+      'minamata' => 
+      array (
+      ),
+      'minamioguni' => 
+      array (
+      ),
+      'nagasu' => 
+      array (
+      ),
+      'nishihara' => 
+      array (
+      ),
+      'oguni' => 
+      array (
+      ),
+      'ozu' => 
+      array (
+      ),
+      'sumoto' => 
+      array (
+      ),
+      'takamori' => 
+      array (
+      ),
+      'uki' => 
+      array (
+      ),
+      'uto' => 
+      array (
+      ),
+      'yamaga' => 
+      array (
+      ),
+      'yamato' => 
+      array (
+      ),
+      'yatsushiro' => 
+      array (
+      ),
+    ),
+    'kyoto' => 
+    array (
+      'ayabe' => 
+      array (
+      ),
+      'fukuchiyama' => 
+      array (
+      ),
+      'higashiyama' => 
+      array (
+      ),
+      'ide' => 
+      array (
+      ),
+      'ine' => 
+      array (
+      ),
+      'joyo' => 
+      array (
+      ),
+      'kameoka' => 
+      array (
+      ),
+      'kamo' => 
+      array (
+      ),
+      'kita' => 
+      array (
+      ),
+      'kizu' => 
+      array (
+      ),
+      'kumiyama' => 
+      array (
+      ),
+      'kyotamba' => 
+      array (
+      ),
+      'kyotanabe' => 
+      array (
+      ),
+      'kyotango' => 
+      array (
+      ),
+      'maizuru' => 
+      array (
+      ),
+      'minami' => 
+      array (
+      ),
+      'minamiyamashiro' => 
+      array (
+      ),
+      'miyazu' => 
+      array (
+      ),
+      'muko' => 
+      array (
+      ),
+      'nagaokakyo' => 
+      array (
+      ),
+      'nakagyo' => 
+      array (
+      ),
+      'nantan' => 
+      array (
+      ),
+      'oyamazaki' => 
+      array (
+      ),
+      'sakyo' => 
+      array (
+      ),
+      'seika' => 
+      array (
+      ),
+      'tanabe' => 
+      array (
+      ),
+      'uji' => 
+      array (
+      ),
+      'ujitawara' => 
+      array (
+      ),
+      'wazuka' => 
+      array (
+      ),
+      'yamashina' => 
+      array (
+      ),
+      'yawata' => 
+      array (
+      ),
+    ),
+    'mie' => 
+    array (
+      'asahi' => 
+      array (
+      ),
+      'inabe' => 
+      array (
+      ),
+      'ise' => 
+      array (
+      ),
+      'kameyama' => 
+      array (
+      ),
+      'kawagoe' => 
+      array (
+      ),
+      'kiho' => 
+      array (
+      ),
+      'kisosaki' => 
+      array (
+      ),
+      'kiwa' => 
+      array (
+      ),
+      'komono' => 
+      array (
+      ),
+      'kumano' => 
+      array (
+      ),
+      'kuwana' => 
+      array (
+      ),
+      'matsusaka' => 
+      array (
+      ),
+      'meiwa' => 
+      array (
+      ),
+      'mihama' => 
+      array (
+      ),
+      'minamiise' => 
+      array (
+      ),
+      'misugi' => 
+      array (
+      ),
+      'miyama' => 
+      array (
+      ),
+      'nabari' => 
+      array (
+      ),
+      'shima' => 
+      array (
+      ),
+      'suzuka' => 
+      array (
+      ),
+      'tado' => 
+      array (
+      ),
+      'taiki' => 
+      array (
+      ),
+      'taki' => 
+      array (
+      ),
+      'tamaki' => 
+      array (
+      ),
+      'toba' => 
+      array (
+      ),
+      'tsu' => 
+      array (
+      ),
+      'udono' => 
+      array (
+      ),
+      'ureshino' => 
+      array (
+      ),
+      'watarai' => 
+      array (
+      ),
+      'yokkaichi' => 
+      array (
+      ),
+    ),
+    'miyagi' => 
+    array (
+      'furukawa' => 
+      array (
+      ),
+      'higashimatsushima' => 
+      array (
+      ),
+      'ishinomaki' => 
+      array (
+      ),
+      'iwanuma' => 
+      array (
+      ),
+      'kakuda' => 
+      array (
+      ),
+      'kami' => 
+      array (
+      ),
+      'kawasaki' => 
+      array (
+      ),
+      'marumori' => 
+      array (
+      ),
+      'matsushima' => 
+      array (
+      ),
+      'minamisanriku' => 
+      array (
+      ),
+      'misato' => 
+      array (
+      ),
+      'murata' => 
+      array (
+      ),
+      'natori' => 
+      array (
+      ),
+      'ogawara' => 
+      array (
+      ),
+      'ohira' => 
+      array (
+      ),
+      'onagawa' => 
+      array (
+      ),
+      'osaki' => 
+      array (
+      ),
+      'rifu' => 
+      array (
+      ),
+      'semine' => 
+      array (
+      ),
+      'shibata' => 
+      array (
+      ),
+      'shichikashuku' => 
+      array (
+      ),
+      'shikama' => 
+      array (
+      ),
+      'shiogama' => 
+      array (
+      ),
+      'shiroishi' => 
+      array (
+      ),
+      'tagajo' => 
+      array (
+      ),
+      'taiwa' => 
+      array (
+      ),
+      'tome' => 
+      array (
+      ),
+      'tomiya' => 
+      array (
+      ),
+      'wakuya' => 
+      array (
+      ),
+      'watari' => 
+      array (
+      ),
+      'yamamoto' => 
+      array (
+      ),
+      'zao' => 
+      array (
+      ),
+    ),
+    'miyazaki' => 
+    array (
+      'aya' => 
+      array (
+      ),
+      'ebino' => 
+      array (
+      ),
+      'gokase' => 
+      array (
+      ),
+      'hyuga' => 
+      array (
+      ),
+      'kadogawa' => 
+      array (
+      ),
+      'kawaminami' => 
+      array (
+      ),
+      'kijo' => 
+      array (
+      ),
+      'kitagawa' => 
+      array (
+      ),
+      'kitakata' => 
+      array (
+      ),
+      'kitaura' => 
+      array (
+      ),
+      'kobayashi' => 
+      array (
+      ),
+      'kunitomi' => 
+      array (
+      ),
+      'kushima' => 
+      array (
+      ),
+      'mimata' => 
+      array (
+      ),
+      'miyakonojo' => 
+      array (
+      ),
+      'miyazaki' => 
+      array (
+      ),
+      'morotsuka' => 
+      array (
+      ),
+      'nichinan' => 
+      array (
+      ),
+      'nishimera' => 
+      array (
+      ),
+      'nobeoka' => 
+      array (
+      ),
+      'saito' => 
+      array (
+      ),
+      'shiiba' => 
+      array (
+      ),
+      'shintomi' => 
+      array (
+      ),
+      'takaharu' => 
+      array (
+      ),
+      'takanabe' => 
+      array (
+      ),
+      'takazaki' => 
+      array (
+      ),
+      'tsuno' => 
+      array (
+      ),
+    ),
+    'nagano' => 
+    array (
+      'achi' => 
+      array (
+      ),
+      'agematsu' => 
+      array (
+      ),
+      'anan' => 
+      array (
+      ),
+      'aoki' => 
+      array (
+      ),
+      'asahi' => 
+      array (
+      ),
+      'azumino' => 
+      array (
+      ),
+      'chikuhoku' => 
+      array (
+      ),
+      'chikuma' => 
+      array (
+      ),
+      'chino' => 
+      array (
+      ),
+      'fujimi' => 
+      array (
+      ),
+      'hakuba' => 
+      array (
+      ),
+      'hara' => 
+      array (
+      ),
+      'hiraya' => 
+      array (
+      ),
+      'iida' => 
+      array (
+      ),
+      'iijima' => 
+      array (
+      ),
+      'iiyama' => 
+      array (
+      ),
+      'iizuna' => 
+      array (
+      ),
+      'ikeda' => 
+      array (
+      ),
+      'ikusaka' => 
+      array (
+      ),
+      'ina' => 
+      array (
+      ),
+      'karuizawa' => 
+      array (
+      ),
+      'kawakami' => 
+      array (
+      ),
+      'kiso' => 
+      array (
+      ),
+      'kisofukushima' => 
+      array (
+      ),
+      'kitaaiki' => 
+      array (
+      ),
+      'komagane' => 
+      array (
+      ),
+      'komoro' => 
+      array (
+      ),
+      'matsukawa' => 
+      array (
+      ),
+      'matsumoto' => 
+      array (
+      ),
+      'miasa' => 
+      array (
+      ),
+      'minamiaiki' => 
+      array (
+      ),
+      'minamimaki' => 
+      array (
+      ),
+      'minamiminowa' => 
+      array (
+      ),
+      'minowa' => 
+      array (
+      ),
+      'miyada' => 
+      array (
+      ),
+      'miyota' => 
+      array (
+      ),
+      'mochizuki' => 
+      array (
+      ),
+      'nagano' => 
+      array (
+      ),
+      'nagawa' => 
+      array (
+      ),
+      'nagiso' => 
+      array (
+      ),
+      'nakagawa' => 
+      array (
+      ),
+      'nakano' => 
+      array (
+      ),
+      'nozawaonsen' => 
+      array (
+      ),
+      'obuse' => 
+      array (
+      ),
+      'ogawa' => 
+      array (
+      ),
+      'okaya' => 
+      array (
+      ),
+      'omachi' => 
+      array (
+      ),
+      'omi' => 
+      array (
+      ),
+      'ookuwa' => 
+      array (
+      ),
+      'ooshika' => 
+      array (
+      ),
+      'otaki' => 
+      array (
+      ),
+      'otari' => 
+      array (
+      ),
+      'sakae' => 
+      array (
+      ),
+      'sakaki' => 
+      array (
+      ),
+      'saku' => 
+      array (
+      ),
+      'sakuho' => 
+      array (
+      ),
+      'shimosuwa' => 
+      array (
+      ),
+      'shinanomachi' => 
+      array (
+      ),
+      'shiojiri' => 
+      array (
+      ),
+      'suwa' => 
+      array (
+      ),
+      'suzaka' => 
+      array (
+      ),
+      'takagi' => 
+      array (
+      ),
+      'takamori' => 
+      array (
+      ),
+      'takayama' => 
+      array (
+      ),
+      'tateshina' => 
+      array (
+      ),
+      'tatsuno' => 
+      array (
+      ),
+      'togakushi' => 
+      array (
+      ),
+      'togura' => 
+      array (
+      ),
+      'tomi' => 
+      array (
+      ),
+      'ueda' => 
+      array (
+      ),
+      'wada' => 
+      array (
+      ),
+      'yamagata' => 
+      array (
+      ),
+      'yamanouchi' => 
+      array (
+      ),
+      'yasaka' => 
+      array (
+      ),
+      'yasuoka' => 
+      array (
+      ),
+    ),
+    'nagasaki' => 
+    array (
+      'chijiwa' => 
+      array (
+      ),
+      'futsu' => 
+      array (
+      ),
+      'goto' => 
+      array (
+      ),
+      'hasami' => 
+      array (
+      ),
+      'hirado' => 
+      array (
+      ),
+      'iki' => 
+      array (
+      ),
+      'isahaya' => 
+      array (
+      ),
+      'kawatana' => 
+      array (
+      ),
+      'kuchinotsu' => 
+      array (
+      ),
+      'matsuura' => 
+      array (
+      ),
+      'nagasaki' => 
+      array (
+      ),
+      'obama' => 
+      array (
+      ),
+      'omura' => 
+      array (
+      ),
+      'oseto' => 
+      array (
+      ),
+      'saikai' => 
+      array (
+      ),
+      'sasebo' => 
+      array (
+      ),
+      'seihi' => 
+      array (
+      ),
+      'shimabara' => 
+      array (
+      ),
+      'shinkamigoto' => 
+      array (
+      ),
+      'togitsu' => 
+      array (
+      ),
+      'tsushima' => 
+      array (
+      ),
+      'unzen' => 
+      array (
+      ),
+    ),
+    'nara' => 
+    array (
+      'ando' => 
+      array (
+      ),
+      'gose' => 
+      array (
+      ),
+      'heguri' => 
+      array (
+      ),
+      'higashiyoshino' => 
+      array (
+      ),
+      'ikaruga' => 
+      array (
+      ),
+      'ikoma' => 
+      array (
+      ),
+      'kamikitayama' => 
+      array (
+      ),
+      'kanmaki' => 
+      array (
+      ),
+      'kashiba' => 
+      array (
+      ),
+      'kashihara' => 
+      array (
+      ),
+      'katsuragi' => 
+      array (
+      ),
+      'kawai' => 
+      array (
+      ),
+      'kawakami' => 
+      array (
+      ),
+      'kawanishi' => 
+      array (
+      ),
+      'koryo' => 
+      array (
+      ),
+      'kurotaki' => 
+      array (
+      ),
+      'mitsue' => 
+      array (
+      ),
+      'miyake' => 
+      array (
+      ),
+      'nara' => 
+      array (
+      ),
+      'nosegawa' => 
+      array (
+      ),
+      'oji' => 
+      array (
+      ),
+      'ouda' => 
+      array (
+      ),
+      'oyodo' => 
+      array (
+      ),
+      'sakurai' => 
+      array (
+      ),
+      'sango' => 
+      array (
+      ),
+      'shimoichi' => 
+      array (
+      ),
+      'shimokitayama' => 
+      array (
+      ),
+      'shinjo' => 
+      array (
+      ),
+      'soni' => 
+      array (
+      ),
+      'takatori' => 
+      array (
+      ),
+      'tawaramoto' => 
+      array (
+      ),
+      'tenkawa' => 
+      array (
+      ),
+      'tenri' => 
+      array (
+      ),
+      'uda' => 
+      array (
+      ),
+      'yamatokoriyama' => 
+      array (
+      ),
+      'yamatotakada' => 
+      array (
+      ),
+      'yamazoe' => 
+      array (
+      ),
+      'yoshino' => 
+      array (
+      ),
+    ),
+    'niigata' => 
+    array (
+      'aga' => 
+      array (
+      ),
+      'agano' => 
+      array (
+      ),
+      'gosen' => 
+      array (
+      ),
+      'itoigawa' => 
+      array (
+      ),
+      'izumozaki' => 
+      array (
+      ),
+      'joetsu' => 
+      array (
+      ),
+      'kamo' => 
+      array (
+      ),
+      'kariwa' => 
+      array (
+      ),
+      'kashiwazaki' => 
+      array (
+      ),
+      'minamiuonuma' => 
+      array (
+      ),
+      'mitsuke' => 
+      array (
+      ),
+      'muika' => 
+      array (
+      ),
+      'murakami' => 
+      array (
+      ),
+      'myoko' => 
+      array (
+      ),
+      'nagaoka' => 
+      array (
+      ),
+      'niigata' => 
+      array (
+      ),
+      'ojiya' => 
+      array (
+      ),
+      'omi' => 
+      array (
+      ),
+      'sado' => 
+      array (
+      ),
+      'sanjo' => 
+      array (
+      ),
+      'seiro' => 
+      array (
+      ),
+      'seirou' => 
+      array (
+      ),
+      'sekikawa' => 
+      array (
+      ),
+      'shibata' => 
+      array (
+      ),
+      'tagami' => 
+      array (
+      ),
+      'tainai' => 
+      array (
+      ),
+      'tochio' => 
+      array (
+      ),
+      'tokamachi' => 
+      array (
+      ),
+      'tsubame' => 
+      array (
+      ),
+      'tsunan' => 
+      array (
+      ),
+      'uonuma' => 
+      array (
+      ),
+      'yahiko' => 
+      array (
+      ),
+      'yoita' => 
+      array (
+      ),
+      'yuzawa' => 
+      array (
+      ),
+    ),
+    'oita' => 
+    array (
+      'beppu' => 
+      array (
+      ),
+      'bungoono' => 
+      array (
+      ),
+      'bungotakada' => 
+      array (
+      ),
+      'hasama' => 
+      array (
+      ),
+      'hiji' => 
+      array (
+      ),
+      'himeshima' => 
+      array (
+      ),
+      'hita' => 
+      array (
+      ),
+      'kamitsue' => 
+      array (
+      ),
+      'kokonoe' => 
+      array (
+      ),
+      'kuju' => 
+      array (
+      ),
+      'kunisaki' => 
+      array (
+      ),
+      'kusu' => 
+      array (
+      ),
+      'oita' => 
+      array (
+      ),
+      'saiki' => 
+      array (
+      ),
+      'taketa' => 
+      array (
+      ),
+      'tsukumi' => 
+      array (
+      ),
+      'usa' => 
+      array (
+      ),
+      'usuki' => 
+      array (
+      ),
+      'yufu' => 
+      array (
+      ),
+    ),
+    'okayama' => 
+    array (
+      'akaiwa' => 
+      array (
+      ),
+      'asakuchi' => 
+      array (
+      ),
+      'bizen' => 
+      array (
+      ),
+      'hayashima' => 
+      array (
+      ),
+      'ibara' => 
+      array (
+      ),
+      'kagamino' => 
+      array (
+      ),
+      'kasaoka' => 
+      array (
+      ),
+      'kibichuo' => 
+      array (
+      ),
+      'kumenan' => 
+      array (
+      ),
+      'kurashiki' => 
+      array (
+      ),
+      'maniwa' => 
+      array (
+      ),
+      'misaki' => 
+      array (
+      ),
+      'nagi' => 
+      array (
+      ),
+      'niimi' => 
+      array (
+      ),
+      'nishiawakura' => 
+      array (
+      ),
+      'okayama' => 
+      array (
+      ),
+      'satosho' => 
+      array (
+      ),
+      'setouchi' => 
+      array (
+      ),
+      'shinjo' => 
+      array (
+      ),
+      'shoo' => 
+      array (
+      ),
+      'soja' => 
+      array (
+      ),
+      'takahashi' => 
+      array (
+      ),
+      'tamano' => 
+      array (
+      ),
+      'tsuyama' => 
+      array (
+      ),
+      'wake' => 
+      array (
+      ),
+      'yakage' => 
+      array (
+      ),
+    ),
+    'okinawa' => 
+    array (
+      'aguni' => 
+      array (
+      ),
+      'ginowan' => 
+      array (
+      ),
+      'ginoza' => 
+      array (
+      ),
+      'gushikami' => 
+      array (
+      ),
+      'haebaru' => 
+      array (
+      ),
+      'higashi' => 
+      array (
+      ),
+      'hirara' => 
+      array (
+      ),
+      'iheya' => 
+      array (
+      ),
+      'ishigaki' => 
+      array (
+      ),
+      'ishikawa' => 
+      array (
+      ),
+      'itoman' => 
+      array (
+      ),
+      'izena' => 
+      array (
+      ),
+      'kadena' => 
+      array (
+      ),
+      'kin' => 
+      array (
+      ),
+      'kitadaito' => 
+      array (
+      ),
+      'kitanakagusuku' => 
+      array (
+      ),
+      'kumejima' => 
+      array (
+      ),
+      'kunigami' => 
+      array (
+      ),
+      'minamidaito' => 
+      array (
+      ),
+      'motobu' => 
+      array (
+      ),
+      'nago' => 
+      array (
+      ),
+      'naha' => 
+      array (
+      ),
+      'nakagusuku' => 
+      array (
+      ),
+      'nakijin' => 
+      array (
+      ),
+      'nanjo' => 
+      array (
+      ),
+      'nishihara' => 
+      array (
+      ),
+      'ogimi' => 
+      array (
+      ),
+      'okinawa' => 
+      array (
+      ),
+      'onna' => 
+      array (
+      ),
+      'shimoji' => 
+      array (
+      ),
+      'taketomi' => 
+      array (
+      ),
+      'tarama' => 
+      array (
+      ),
+      'tokashiki' => 
+      array (
+      ),
+      'tomigusuku' => 
+      array (
+      ),
+      'tonaki' => 
+      array (
+      ),
+      'urasoe' => 
+      array (
+      ),
+      'uruma' => 
+      array (
+      ),
+      'yaese' => 
+      array (
+      ),
+      'yomitan' => 
+      array (
+      ),
+      'yonabaru' => 
+      array (
+      ),
+      'yonaguni' => 
+      array (
+      ),
+      'zamami' => 
+      array (
+      ),
+    ),
+    'osaka' => 
+    array (
+      'abeno' => 
+      array (
+      ),
+      'chihayaakasaka' => 
+      array (
+      ),
+      'chuo' => 
+      array (
+      ),
+      'daito' => 
+      array (
+      ),
+      'fujiidera' => 
+      array (
+      ),
+      'habikino' => 
+      array (
+      ),
+      'hannan' => 
+      array (
+      ),
+      'higashiosaka' => 
+      array (
+      ),
+      'higashisumiyoshi' => 
+      array (
+      ),
+      'higashiyodogawa' => 
+      array (
+      ),
+      'hirakata' => 
+      array (
+      ),
+      'ibaraki' => 
+      array (
+      ),
+      'ikeda' => 
+      array (
+      ),
+      'izumi' => 
+      array (
+      ),
+      'izumiotsu' => 
+      array (
+      ),
+      'izumisano' => 
+      array (
+      ),
+      'kadoma' => 
+      array (
+      ),
+      'kaizuka' => 
+      array (
+      ),
+      'kanan' => 
+      array (
+      ),
+      'kashiwara' => 
+      array (
+      ),
+      'katano' => 
+      array (
+      ),
+      'kawachinagano' => 
+      array (
+      ),
+      'kishiwada' => 
+      array (
+      ),
+      'kita' => 
+      array (
+      ),
+      'kumatori' => 
+      array (
+      ),
+      'matsubara' => 
+      array (
+      ),
+      'minato' => 
+      array (
+      ),
+      'minoh' => 
+      array (
+      ),
+      'misaki' => 
+      array (
+      ),
+      'moriguchi' => 
+      array (
+      ),
+      'neyagawa' => 
+      array (
+      ),
+      'nishi' => 
+      array (
+      ),
+      'nose' => 
+      array (
+      ),
+      'osakasayama' => 
+      array (
+      ),
+      'sakai' => 
+      array (
+      ),
+      'sayama' => 
+      array (
+      ),
+      'sennan' => 
+      array (
+      ),
+      'settsu' => 
+      array (
+      ),
+      'shijonawate' => 
+      array (
+      ),
+      'shimamoto' => 
+      array (
+      ),
+      'suita' => 
+      array (
+      ),
+      'tadaoka' => 
+      array (
+      ),
+      'taishi' => 
+      array (
+      ),
+      'tajiri' => 
+      array (
+      ),
+      'takaishi' => 
+      array (
+      ),
+      'takatsuki' => 
+      array (
+      ),
+      'tondabayashi' => 
+      array (
+      ),
+      'toyonaka' => 
+      array (
+      ),
+      'toyono' => 
+      array (
+      ),
+      'yao' => 
+      array (
+      ),
+    ),
+    'saga' => 
+    array (
+      'ariake' => 
+      array (
+      ),
+      'arita' => 
+      array (
+      ),
+      'fukudomi' => 
+      array (
+      ),
+      'genkai' => 
+      array (
+      ),
+      'hamatama' => 
+      array (
+      ),
+      'hizen' => 
+      array (
+      ),
+      'imari' => 
+      array (
+      ),
+      'kamimine' => 
+      array (
+      ),
+      'kanzaki' => 
+      array (
+      ),
+      'karatsu' => 
+      array (
+      ),
+      'kashima' => 
+      array (
+      ),
+      'kitagata' => 
+      array (
+      ),
+      'kitahata' => 
+      array (
+      ),
+      'kiyama' => 
+      array (
+      ),
+      'kouhoku' => 
+      array (
+      ),
+      'kyuragi' => 
+      array (
+      ),
+      'nishiarita' => 
+      array (
+      ),
+      'ogi' => 
+      array (
+      ),
+      'omachi' => 
+      array (
+      ),
+      'ouchi' => 
+      array (
+      ),
+      'saga' => 
+      array (
+      ),
+      'shiroishi' => 
+      array (
+      ),
+      'taku' => 
+      array (
+      ),
+      'tara' => 
+      array (
+      ),
+      'tosu' => 
+      array (
+      ),
+      'yoshinogari' => 
+      array (
+      ),
+    ),
+    'saitama' => 
+    array (
+      'arakawa' => 
+      array (
+      ),
+      'asaka' => 
+      array (
+      ),
+      'chichibu' => 
+      array (
+      ),
+      'fujimi' => 
+      array (
+      ),
+      'fujimino' => 
+      array (
+      ),
+      'fukaya' => 
+      array (
+      ),
+      'hanno' => 
+      array (
+      ),
+      'hanyu' => 
+      array (
+      ),
+      'hasuda' => 
+      array (
+      ),
+      'hatogaya' => 
+      array (
+      ),
+      'hatoyama' => 
+      array (
+      ),
+      'hidaka' => 
+      array (
+      ),
+      'higashichichibu' => 
+      array (
+      ),
+      'higashimatsuyama' => 
+      array (
+      ),
+      'honjo' => 
+      array (
+      ),
+      'ina' => 
+      array (
+      ),
+      'iruma' => 
+      array (
+      ),
+      'iwatsuki' => 
+      array (
+      ),
+      'kamiizumi' => 
+      array (
+      ),
+      'kamikawa' => 
+      array (
+      ),
+      'kamisato' => 
+      array (
+      ),
+      'kasukabe' => 
+      array (
+      ),
+      'kawagoe' => 
+      array (
+      ),
+      'kawaguchi' => 
+      array (
+      ),
+      'kawajima' => 
+      array (
+      ),
+      'kazo' => 
+      array (
+      ),
+      'kitamoto' => 
+      array (
+      ),
+      'koshigaya' => 
+      array (
+      ),
+      'kounosu' => 
+      array (
+      ),
+      'kuki' => 
+      array (
+      ),
+      'kumagaya' => 
+      array (
+      ),
+      'matsubushi' => 
+      array (
+      ),
+      'minano' => 
+      array (
+      ),
+      'misato' => 
+      array (
+      ),
+      'miyashiro' => 
+      array (
+      ),
+      'miyoshi' => 
+      array (
+      ),
+      'moroyama' => 
+      array (
+      ),
+      'nagatoro' => 
+      array (
+      ),
+      'namegawa' => 
+      array (
+      ),
+      'niiza' => 
+      array (
+      ),
+      'ogano' => 
+      array (
+      ),
+      'ogawa' => 
+      array (
+      ),
+      'ogose' => 
+      array (
+      ),
+      'okegawa' => 
+      array (
+      ),
+      'omiya' => 
+      array (
+      ),
+      'otaki' => 
+      array (
+      ),
+      'ranzan' => 
+      array (
+      ),
+      'ryokami' => 
+      array (
+      ),
+      'saitama' => 
+      array (
+      ),
+      'sakado' => 
+      array (
+      ),
+      'satte' => 
+      array (
+      ),
+      'sayama' => 
+      array (
+      ),
+      'shiki' => 
+      array (
+      ),
+      'shiraoka' => 
+      array (
+      ),
+      'soka' => 
+      array (
+      ),
+      'sugito' => 
+      array (
+      ),
+      'toda' => 
+      array (
+      ),
+      'tokigawa' => 
+      array (
+      ),
+      'tokorozawa' => 
+      array (
+      ),
+      'tsurugashima' => 
+      array (
+      ),
+      'urawa' => 
+      array (
+      ),
+      'warabi' => 
+      array (
+      ),
+      'yashio' => 
+      array (
+      ),
+      'yokoze' => 
+      array (
+      ),
+      'yono' => 
+      array (
+      ),
+      'yorii' => 
+      array (
+      ),
+      'yoshida' => 
+      array (
+      ),
+      'yoshikawa' => 
+      array (
+      ),
+      'yoshimi' => 
+      array (
+      ),
+    ),
+    'shiga' => 
+    array (
+      'aisho' => 
+      array (
+      ),
+      'gamo' => 
+      array (
+      ),
+      'higashiomi' => 
+      array (
+      ),
+      'hikone' => 
+      array (
+      ),
+      'koka' => 
+      array (
+      ),
+      'konan' => 
+      array (
+      ),
+      'kosei' => 
+      array (
+      ),
+      'koto' => 
+      array (
+      ),
+      'kusatsu' => 
+      array (
+      ),
+      'maibara' => 
+      array (
+      ),
+      'moriyama' => 
+      array (
+      ),
+      'nagahama' => 
+      array (
+      ),
+      'nishiazai' => 
+      array (
+      ),
+      'notogawa' => 
+      array (
+      ),
+      'omihachiman' => 
+      array (
+      ),
+      'otsu' => 
+      array (
+      ),
+      'ritto' => 
+      array (
+      ),
+      'ryuoh' => 
+      array (
+      ),
+      'takashima' => 
+      array (
+      ),
+      'takatsuki' => 
+      array (
+      ),
+      'torahime' => 
+      array (
+      ),
+      'toyosato' => 
+      array (
+      ),
+      'yasu' => 
+      array (
+      ),
+    ),
+    'shimane' => 
+    array (
+      'akagi' => 
+      array (
+      ),
+      'ama' => 
+      array (
+      ),
+      'gotsu' => 
+      array (
+      ),
+      'hamada' => 
+      array (
+      ),
+      'higashiizumo' => 
+      array (
+      ),
+      'hikawa' => 
+      array (
+      ),
+      'hikimi' => 
+      array (
+      ),
+      'izumo' => 
+      array (
+      ),
+      'kakinoki' => 
+      array (
+      ),
+      'masuda' => 
+      array (
+      ),
+      'matsue' => 
+      array (
+      ),
+      'misato' => 
+      array (
+      ),
+      'nishinoshima' => 
+      array (
+      ),
+      'ohda' => 
+      array (
+      ),
+      'okinoshima' => 
+      array (
+      ),
+      'okuizumo' => 
+      array (
+      ),
+      'shimane' => 
+      array (
+      ),
+      'tamayu' => 
+      array (
+      ),
+      'tsuwano' => 
+      array (
+      ),
+      'unnan' => 
+      array (
+      ),
+      'yakumo' => 
+      array (
+      ),
+      'yasugi' => 
+      array (
+      ),
+      'yatsuka' => 
+      array (
+      ),
+    ),
+    'shizuoka' => 
+    array (
+      'arai' => 
+      array (
+      ),
+      'atami' => 
+      array (
+      ),
+      'fuji' => 
+      array (
+      ),
+      'fujieda' => 
+      array (
+      ),
+      'fujikawa' => 
+      array (
+      ),
+      'fujinomiya' => 
+      array (
+      ),
+      'fukuroi' => 
+      array (
+      ),
+      'gotemba' => 
+      array (
+      ),
+      'haibara' => 
+      array (
+      ),
+      'hamamatsu' => 
+      array (
+      ),
+      'higashiizu' => 
+      array (
+      ),
+      'ito' => 
+      array (
+      ),
+      'iwata' => 
+      array (
+      ),
+      'izu' => 
+      array (
+      ),
+      'izunokuni' => 
+      array (
+      ),
+      'kakegawa' => 
+      array (
+      ),
+      'kannami' => 
+      array (
+      ),
+      'kawanehon' => 
+      array (
+      ),
+      'kawazu' => 
+      array (
+      ),
+      'kikugawa' => 
+      array (
+      ),
+      'kosai' => 
+      array (
+      ),
+      'makinohara' => 
+      array (
+      ),
+      'matsuzaki' => 
+      array (
+      ),
+      'minamiizu' => 
+      array (
+      ),
+      'mishima' => 
+      array (
+      ),
+      'morimachi' => 
+      array (
+      ),
+      'nishiizu' => 
+      array (
+      ),
+      'numazu' => 
+      array (
+      ),
+      'omaezaki' => 
+      array (
+      ),
+      'shimada' => 
+      array (
+      ),
+      'shimizu' => 
+      array (
+      ),
+      'shimoda' => 
+      array (
+      ),
+      'shizuoka' => 
+      array (
+      ),
+      'susono' => 
+      array (
+      ),
+      'yaizu' => 
+      array (
+      ),
+      'yoshida' => 
+      array (
+      ),
+    ),
+    'tochigi' => 
+    array (
+      'ashikaga' => 
+      array (
+      ),
+      'bato' => 
+      array (
+      ),
+      'haga' => 
+      array (
+      ),
+      'ichikai' => 
+      array (
+      ),
+      'iwafune' => 
+      array (
+      ),
+      'kaminokawa' => 
+      array (
+      ),
+      'kanuma' => 
+      array (
+      ),
+      'karasuyama' => 
+      array (
+      ),
+      'kuroiso' => 
+      array (
+      ),
+      'mashiko' => 
+      array (
+      ),
+      'mibu' => 
+      array (
+      ),
+      'moka' => 
+      array (
+      ),
+      'motegi' => 
+      array (
+      ),
+      'nasu' => 
+      array (
+      ),
+      'nasushiobara' => 
+      array (
+      ),
+      'nikko' => 
+      array (
+      ),
+      'nishikata' => 
+      array (
+      ),
+      'nogi' => 
+      array (
+      ),
+      'ohira' => 
+      array (
+      ),
+      'ohtawara' => 
+      array (
+      ),
+      'oyama' => 
+      array (
+      ),
+      'sakura' => 
+      array (
+      ),
+      'sano' => 
+      array (
+      ),
+      'shimotsuke' => 
+      array (
+      ),
+      'shioya' => 
+      array (
+      ),
+      'takanezawa' => 
+      array (
+      ),
+      'tochigi' => 
+      array (
+      ),
+      'tsuga' => 
+      array (
+      ),
+      'ujiie' => 
+      array (
+      ),
+      'utsunomiya' => 
+      array (
+      ),
+      'yaita' => 
+      array (
+      ),
+    ),
+    'tokushima' => 
+    array (
+      'aizumi' => 
+      array (
+      ),
+      'anan' => 
+      array (
+      ),
+      'ichiba' => 
+      array (
+      ),
+      'itano' => 
+      array (
+      ),
+      'kainan' => 
+      array (
+      ),
+      'komatsushima' => 
+      array (
+      ),
+      'matsushige' => 
+      array (
+      ),
+      'mima' => 
+      array (
+      ),
+      'minami' => 
+      array (
+      ),
+      'miyoshi' => 
+      array (
+      ),
+      'mugi' => 
+      array (
+      ),
+      'nakagawa' => 
+      array (
+      ),
+      'naruto' => 
+      array (
+      ),
+      'sanagochi' => 
+      array (
+      ),
+      'shishikui' => 
+      array (
+      ),
+      'tokushima' => 
+      array (
+      ),
+      'wajiki' => 
+      array (
+      ),
+    ),
+    'tokyo' => 
+    array (
+      'adachi' => 
+      array (
+      ),
+      'akiruno' => 
+      array (
+      ),
+      'akishima' => 
+      array (
+      ),
+      'aogashima' => 
+      array (
+      ),
+      'arakawa' => 
+      array (
+      ),
+      'bunkyo' => 
+      array (
+      ),
+      'chiyoda' => 
+      array (
+      ),
+      'chofu' => 
+      array (
+      ),
+      'chuo' => 
+      array (
+      ),
+      'edogawa' => 
+      array (
+      ),
+      'fuchu' => 
+      array (
+      ),
+      'fussa' => 
+      array (
+      ),
+      'hachijo' => 
+      array (
+      ),
+      'hachioji' => 
+      array (
+      ),
+      'hamura' => 
+      array (
+      ),
+      'higashikurume' => 
+      array (
+      ),
+      'higashimurayama' => 
+      array (
+      ),
+      'higashiyamato' => 
+      array (
+      ),
+      'hino' => 
+      array (
+      ),
+      'hinode' => 
+      array (
+      ),
+      'hinohara' => 
+      array (
+      ),
+      'inagi' => 
+      array (
+      ),
+      'itabashi' => 
+      array (
+      ),
+      'katsushika' => 
+      array (
+      ),
+      'kita' => 
+      array (
+      ),
+      'kiyose' => 
+      array (
+      ),
+      'kodaira' => 
+      array (
+      ),
+      'koganei' => 
+      array (
+      ),
+      'kokubunji' => 
+      array (
+      ),
+      'komae' => 
+      array (
+      ),
+      'koto' => 
+      array (
+      ),
+      'kouzushima' => 
+      array (
+      ),
+      'kunitachi' => 
+      array (
+      ),
+      'machida' => 
+      array (
+      ),
+      'meguro' => 
+      array (
+      ),
+      'minato' => 
+      array (
+      ),
+      'mitaka' => 
+      array (
+      ),
+      'mizuho' => 
+      array (
+      ),
+      'musashimurayama' => 
+      array (
+      ),
+      'musashino' => 
+      array (
+      ),
+      'nakano' => 
+      array (
+      ),
+      'nerima' => 
+      array (
+      ),
+      'ogasawara' => 
+      array (
+      ),
+      'okutama' => 
+      array (
+      ),
+      'ome' => 
+      array (
+      ),
+      'oshima' => 
+      array (
+      ),
+      'ota' => 
+      array (
+      ),
+      'setagaya' => 
+      array (
+      ),
+      'shibuya' => 
+      array (
+      ),
+      'shinagawa' => 
+      array (
+      ),
+      'shinjuku' => 
+      array (
+      ),
+      'suginami' => 
+      array (
+      ),
+      'sumida' => 
+      array (
+      ),
+      'tachikawa' => 
+      array (
+      ),
+      'taito' => 
+      array (
+      ),
+      'tama' => 
+      array (
+      ),
+      'toshima' => 
+      array (
+      ),
+    ),
+    'tottori' => 
+    array (
+      'chizu' => 
+      array (
+      ),
+      'hino' => 
+      array (
+      ),
+      'kawahara' => 
+      array (
+      ),
+      'koge' => 
+      array (
+      ),
+      'kotoura' => 
+      array (
+      ),
+      'misasa' => 
+      array (
+      ),
+      'nanbu' => 
+      array (
+      ),
+      'nichinan' => 
+      array (
+      ),
+      'sakaiminato' => 
+      array (
+      ),
+      'tottori' => 
+      array (
+      ),
+      'wakasa' => 
+      array (
+      ),
+      'yazu' => 
+      array (
+      ),
+      'yonago' => 
+      array (
+      ),
+    ),
+    'toyama' => 
+    array (
+      'asahi' => 
+      array (
+      ),
+      'fuchu' => 
+      array (
+      ),
+      'fukumitsu' => 
+      array (
+      ),
+      'funahashi' => 
+      array (
+      ),
+      'himi' => 
+      array (
+      ),
+      'imizu' => 
+      array (
+      ),
+      'inami' => 
+      array (
+      ),
+      'johana' => 
+      array (
+      ),
+      'kamiichi' => 
+      array (
+      ),
+      'kurobe' => 
+      array (
+      ),
+      'nakaniikawa' => 
+      array (
+      ),
+      'namerikawa' => 
+      array (
+      ),
+      'nanto' => 
+      array (
+      ),
+      'nyuzen' => 
+      array (
+      ),
+      'oyabe' => 
+      array (
+      ),
+      'taira' => 
+      array (
+      ),
+      'takaoka' => 
+      array (
+      ),
+      'tateyama' => 
+      array (
+      ),
+      'toga' => 
+      array (
+      ),
+      'tonami' => 
+      array (
+      ),
+      'toyama' => 
+      array (
+      ),
+      'unazuki' => 
+      array (
+      ),
+      'uozu' => 
+      array (
+      ),
+      'yamada' => 
+      array (
+      ),
+    ),
+    'wakayama' => 
+    array (
+      'arida' => 
+      array (
+      ),
+      'aridagawa' => 
+      array (
+      ),
+      'gobo' => 
+      array (
+      ),
+      'hashimoto' => 
+      array (
+      ),
+      'hidaka' => 
+      array (
+      ),
+      'hirogawa' => 
+      array (
+      ),
+      'inami' => 
+      array (
+      ),
+      'iwade' => 
+      array (
+      ),
+      'kainan' => 
+      array (
+      ),
+      'kamitonda' => 
+      array (
+      ),
+      'katsuragi' => 
+      array (
+      ),
+      'kimino' => 
+      array (
+      ),
+      'kinokawa' => 
+      array (
+      ),
+      'kitayama' => 
+      array (
+      ),
+      'koya' => 
+      array (
+      ),
+      'koza' => 
+      array (
+      ),
+      'kozagawa' => 
+      array (
+      ),
+      'kudoyama' => 
+      array (
+      ),
+      'kushimoto' => 
+      array (
+      ),
+      'mihama' => 
+      array (
+      ),
+      'misato' => 
+      array (
+      ),
+      'nachikatsuura' => 
+      array (
+      ),
+      'shingu' => 
+      array (
+      ),
+      'shirahama' => 
+      array (
+      ),
+      'taiji' => 
+      array (
+      ),
+      'tanabe' => 
+      array (
+      ),
+      'wakayama' => 
+      array (
+      ),
+      'yuasa' => 
+      array (
+      ),
+      'yura' => 
+      array (
+      ),
+    ),
+    'yamagata' => 
+    array (
+      'asahi' => 
+      array (
+      ),
+      'funagata' => 
+      array (
+      ),
+      'higashine' => 
+      array (
+      ),
+      'iide' => 
+      array (
+      ),
+      'kahoku' => 
+      array (
+      ),
+      'kaminoyama' => 
+      array (
+      ),
+      'kaneyama' => 
+      array (
+      ),
+      'kawanishi' => 
+      array (
+      ),
+      'mamurogawa' => 
+      array (
+      ),
+      'mikawa' => 
+      array (
+      ),
+      'murayama' => 
+      array (
+      ),
+      'nagai' => 
+      array (
+      ),
+      'nakayama' => 
+      array (
+      ),
+      'nanyo' => 
+      array (
+      ),
+      'nishikawa' => 
+      array (
+      ),
+      'obanazawa' => 
+      array (
+      ),
+      'oe' => 
+      array (
+      ),
+      'oguni' => 
+      array (
+      ),
+      'ohkura' => 
+      array (
+      ),
+      'oishida' => 
+      array (
+      ),
+      'sagae' => 
+      array (
+      ),
+      'sakata' => 
+      array (
+      ),
+      'sakegawa' => 
+      array (
+      ),
+      'shinjo' => 
+      array (
+      ),
+      'shirataka' => 
+      array (
+      ),
+      'shonai' => 
+      array (
+      ),
+      'takahata' => 
+      array (
+      ),
+      'tendo' => 
+      array (
+      ),
+      'tozawa' => 
+      array (
+      ),
+      'tsuruoka' => 
+      array (
+      ),
+      'yamagata' => 
+      array (
+      ),
+      'yamanobe' => 
+      array (
+      ),
+      'yonezawa' => 
+      array (
+      ),
+      'yuza' => 
+      array (
+      ),
+    ),
+    'yamaguchi' => 
+    array (
+      'abu' => 
+      array (
+      ),
+      'hagi' => 
+      array (
+      ),
+      'hikari' => 
+      array (
+      ),
+      'hofu' => 
+      array (
+      ),
+      'iwakuni' => 
+      array (
+      ),
+      'kudamatsu' => 
+      array (
+      ),
+      'mitou' => 
+      array (
+      ),
+      'nagato' => 
+      array (
+      ),
+      'oshima' => 
+      array (
+      ),
+      'shimonoseki' => 
+      array (
+      ),
+      'shunan' => 
+      array (
+      ),
+      'tabuse' => 
+      array (
+      ),
+      'tokuyama' => 
+      array (
+      ),
+      'toyota' => 
+      array (
+      ),
+      'ube' => 
+      array (
+      ),
+      'yuu' => 
+      array (
+      ),
+    ),
+    'yamanashi' => 
+    array (
+      'chuo' => 
+      array (
+      ),
+      'doshi' => 
+      array (
+      ),
+      'fuefuki' => 
+      array (
+      ),
+      'fujikawa' => 
+      array (
+      ),
+      'fujikawaguchiko' => 
+      array (
+      ),
+      'fujiyoshida' => 
+      array (
+      ),
+      'hayakawa' => 
+      array (
+      ),
+      'hokuto' => 
+      array (
+      ),
+      'ichikawamisato' => 
+      array (
+      ),
+      'kai' => 
+      array (
+      ),
+      'kofu' => 
+      array (
+      ),
+      'koshu' => 
+      array (
+      ),
+      'kosuge' => 
+      array (
+      ),
+      'minami-alps' => 
+      array (
+      ),
+      'minobu' => 
+      array (
+      ),
+      'nakamichi' => 
+      array (
+      ),
+      'nanbu' => 
+      array (
+      ),
+      'narusawa' => 
+      array (
+      ),
+      'nirasaki' => 
+      array (
+      ),
+      'nishikatsura' => 
+      array (
+      ),
+      'oshino' => 
+      array (
+      ),
+      'otsuki' => 
+      array (
+      ),
+      'showa' => 
+      array (
+      ),
+      'tabayama' => 
+      array (
+      ),
+      'tsuru' => 
+      array (
+      ),
+      'uenohara' => 
+      array (
+      ),
+      'yamanakako' => 
+      array (
+      ),
+      'yamanashi' => 
+      array (
+      ),
+    ),
+    'xn--4pvxs' => 
+    array (
+    ),
+    'xn--vgu402c' => 
+    array (
+    ),
+    'xn--c3s14m' => 
+    array (
+    ),
+    'xn--f6qx53a' => 
+    array (
+    ),
+    'xn--8pvr4u' => 
+    array (
+    ),
+    'xn--uist22h' => 
+    array (
+    ),
+    'xn--djrs72d6uy' => 
+    array (
+    ),
+    'xn--mkru45i' => 
+    array (
+    ),
+    'xn--0trq7p7nn' => 
+    array (
+    ),
+    'xn--8ltr62k' => 
+    array (
+    ),
+    'xn--2m4a15e' => 
+    array (
+    ),
+    'xn--efvn9s' => 
+    array (
+    ),
+    'xn--32vp30h' => 
+    array (
+    ),
+    'xn--4it797k' => 
+    array (
+    ),
+    'xn--1lqs71d' => 
+    array (
+    ),
+    'xn--5rtp49c' => 
+    array (
+    ),
+    'xn--5js045d' => 
+    array (
+    ),
+    'xn--ehqz56n' => 
+    array (
+    ),
+    'xn--1lqs03n' => 
+    array (
+    ),
+    'xn--qqqt11m' => 
+    array (
+    ),
+    'xn--kbrq7o' => 
+    array (
+    ),
+    'xn--pssu33l' => 
+    array (
+    ),
+    'xn--ntsq17g' => 
+    array (
+    ),
+    'xn--uisz3g' => 
+    array (
+    ),
+    'xn--6btw5a' => 
+    array (
+    ),
+    'xn--1ctwo' => 
+    array (
+    ),
+    'xn--6orx2r' => 
+    array (
+    ),
+    'xn--rht61e' => 
+    array (
+    ),
+    'xn--rht27z' => 
+    array (
+    ),
+    'xn--djty4k' => 
+    array (
+    ),
+    'xn--nit225k' => 
+    array (
+    ),
+    'xn--rht3d' => 
+    array (
+    ),
+    'xn--klty5x' => 
+    array (
+    ),
+    'xn--kltx9a' => 
+    array (
+    ),
+    'xn--kltp7d' => 
+    array (
+    ),
+    'xn--uuwu58a' => 
+    array (
+    ),
+    'xn--zbx025d' => 
+    array (
+    ),
+    'xn--ntso0iqx3a' => 
+    array (
+    ),
+    'xn--elqq16h' => 
+    array (
+    ),
+    'xn--4it168d' => 
+    array (
+    ),
+    'xn--klt787d' => 
+    array (
+    ),
+    'xn--rny31h' => 
+    array (
+    ),
+    'xn--7t0a264c' => 
+    array (
+    ),
+    'xn--5rtq34k' => 
+    array (
+    ),
+    'xn--k7yn95e' => 
+    array (
+    ),
+    'xn--tor131o' => 
+    array (
+    ),
+    'xn--d5qv7z876c' => 
+    array (
+    ),
+    'kawasaki' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'kitakyushu' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'kobe' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'nagoya' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'sapporo' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'sendai' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+    'yokohama' => 
+    array (
+      '*' => 
+      array (
+      ),
+      'city' => 
+      array (
+        '!' => '',
+      ),
+    ),
+  ),
+  'ke' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'kg' => 
+  array (
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'kh' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'ki' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+  ),
+  'km' => 
+  array (
+    'org' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'prd' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'ass' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+    'presse' => 
+    array (
+    ),
+    'medecin' => 
+    array (
+    ),
+    'notaires' => 
+    array (
+    ),
+    'pharmaciens' => 
+    array (
+    ),
+    'veterinaire' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+  ),
+  'kn' => 
+  array (
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'kp' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'rep' => 
+    array (
+    ),
+    'tra' => 
+    array (
+    ),
+  ),
+  'kr' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'es' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'hs' => 
+    array (
+    ),
+    'kg' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'ms' => 
+    array (
+    ),
+    'ne' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'pe' => 
+    array (
+    ),
+    're' => 
+    array (
+    ),
+    'sc' => 
+    array (
+    ),
+    'busan' => 
+    array (
+    ),
+    'chungbuk' => 
+    array (
+    ),
+    'chungnam' => 
+    array (
+    ),
+    'daegu' => 
+    array (
+    ),
+    'daejeon' => 
+    array (
+    ),
+    'gangwon' => 
+    array (
+    ),
+    'gwangju' => 
+    array (
+    ),
+    'gyeongbuk' => 
+    array (
+    ),
+    'gyeonggi' => 
+    array (
+    ),
+    'gyeongnam' => 
+    array (
+    ),
+    'incheon' => 
+    array (
+    ),
+    'jeju' => 
+    array (
+    ),
+    'jeonbuk' => 
+    array (
+    ),
+    'jeonnam' => 
+    array (
+    ),
+    'seoul' => 
+    array (
+    ),
+    'ulsan' => 
+    array (
+    ),
+  ),
+  'kw' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'ky' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'kz' => 
+  array (
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+  ),
+  'la' => 
+  array (
+    'int' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'per' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'lb' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'lc' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'li' => 
+  array (
+  ),
+  'lk' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'ngo' => 
+    array (
+    ),
+    'soc' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+    'ltd' => 
+    array (
+    ),
+    'assn' => 
+    array (
+    ),
+    'grp' => 
+    array (
+    ),
+    'hotel' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+  ),
+  'lr' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'ls' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'lt' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'lu' => 
+  array (
+  ),
+  'lv' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'id' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'asn' => 
+    array (
+    ),
+    'conf' => 
+    array (
+    ),
+  ),
+  'ly' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'plc' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'id' => 
+    array (
+    ),
+  ),
+  'ma' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'press' => 
+    array (
+    ),
+  ),
+  'mc' => 
+  array (
+    'tm' => 
+    array (
+    ),
+    'asso' => 
+    array (
+    ),
+  ),
+  'md' => 
+  array (
+  ),
+  'me' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'its' => 
+    array (
+    ),
+    'priv' => 
+    array (
+    ),
+  ),
+  'mg' => 
+  array (
+    'org' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'prd' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+  ),
+  'mh' => 
+  array (
+  ),
+  'mil' => 
+  array (
+  ),
+  'mk' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'inf' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+  ),
+  'ml' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'presse' => 
+    array (
+    ),
+  ),
+  'mm' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'mn' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'mo' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+  ),
+  'mobi' => 
+  array (
+  ),
+  'mp' => 
+  array (
+  ),
+  'mq' => 
+  array (
+  ),
+  'mr' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'ms' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'mt' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'mu' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+  ),
+  'museum' => 
+  array (
+    'academy' => 
+    array (
+    ),
+    'agriculture' => 
+    array (
+    ),
+    'air' => 
+    array (
+    ),
+    'airguard' => 
+    array (
+    ),
+    'alabama' => 
+    array (
+    ),
+    'alaska' => 
+    array (
+    ),
+    'amber' => 
+    array (
+    ),
+    'ambulance' => 
+    array (
+    ),
+    'american' => 
+    array (
+    ),
+    'americana' => 
+    array (
+    ),
+    'americanantiques' => 
+    array (
+    ),
+    'americanart' => 
+    array (
+    ),
+    'amsterdam' => 
+    array (
+    ),
+    'and' => 
+    array (
+    ),
+    'annefrank' => 
+    array (
+    ),
+    'anthro' => 
+    array (
+    ),
+    'anthropology' => 
+    array (
+    ),
+    'antiques' => 
+    array (
+    ),
+    'aquarium' => 
+    array (
+    ),
+    'arboretum' => 
+    array (
+    ),
+    'archaeological' => 
+    array (
+    ),
+    'archaeology' => 
+    array (
+    ),
+    'architecture' => 
+    array (
+    ),
+    'art' => 
+    array (
+    ),
+    'artanddesign' => 
+    array (
+    ),
+    'artcenter' => 
+    array (
+    ),
+    'artdeco' => 
+    array (
+    ),
+    'arteducation' => 
+    array (
+    ),
+    'artgallery' => 
+    array (
+    ),
+    'arts' => 
+    array (
+    ),
+    'artsandcrafts' => 
+    array (
+    ),
+    'asmatart' => 
+    array (
+    ),
+    'assassination' => 
+    array (
+    ),
+    'assisi' => 
+    array (
+    ),
+    'association' => 
+    array (
+    ),
+    'astronomy' => 
+    array (
+    ),
+    'atlanta' => 
+    array (
+    ),
+    'austin' => 
+    array (
+    ),
+    'australia' => 
+    array (
+    ),
+    'automotive' => 
+    array (
+    ),
+    'aviation' => 
+    array (
+    ),
+    'axis' => 
+    array (
+    ),
+    'badajoz' => 
+    array (
+    ),
+    'baghdad' => 
+    array (
+    ),
+    'bahn' => 
+    array (
+    ),
+    'bale' => 
+    array (
+    ),
+    'baltimore' => 
+    array (
+    ),
+    'barcelona' => 
+    array (
+    ),
+    'baseball' => 
+    array (
+    ),
+    'basel' => 
+    array (
+    ),
+    'baths' => 
+    array (
+    ),
+    'bauern' => 
+    array (
+    ),
+    'beauxarts' => 
+    array (
+    ),
+    'beeldengeluid' => 
+    array (
+    ),
+    'bellevue' => 
+    array (
+    ),
+    'bergbau' => 
+    array (
+    ),
+    'berkeley' => 
+    array (
+    ),
+    'berlin' => 
+    array (
+    ),
+    'bern' => 
+    array (
+    ),
+    'bible' => 
+    array (
+    ),
+    'bilbao' => 
+    array (
+    ),
+    'bill' => 
+    array (
+    ),
+    'birdart' => 
+    array (
+    ),
+    'birthplace' => 
+    array (
+    ),
+    'bonn' => 
+    array (
+    ),
+    'boston' => 
+    array (
+    ),
+    'botanical' => 
+    array (
+    ),
+    'botanicalgarden' => 
+    array (
+    ),
+    'botanicgarden' => 
+    array (
+    ),
+    'botany' => 
+    array (
+    ),
+    'brandywinevalley' => 
+    array (
+    ),
+    'brasil' => 
+    array (
+    ),
+    'bristol' => 
+    array (
+    ),
+    'british' => 
+    array (
+    ),
+    'britishcolumbia' => 
+    array (
+    ),
+    'broadcast' => 
+    array (
+    ),
+    'brunel' => 
+    array (
+    ),
+    'brussel' => 
+    array (
+    ),
+    'brussels' => 
+    array (
+    ),
+    'bruxelles' => 
+    array (
+    ),
+    'building' => 
+    array (
+    ),
+    'burghof' => 
+    array (
+    ),
+    'bus' => 
+    array (
+    ),
+    'bushey' => 
+    array (
+    ),
+    'cadaques' => 
+    array (
+    ),
+    'california' => 
+    array (
+    ),
+    'cambridge' => 
+    array (
+    ),
+    'can' => 
+    array (
+    ),
+    'canada' => 
+    array (
+    ),
+    'capebreton' => 
+    array (
+    ),
+    'carrier' => 
+    array (
+    ),
+    'cartoonart' => 
+    array (
+    ),
+    'casadelamoneda' => 
+    array (
+    ),
+    'castle' => 
+    array (
+    ),
+    'castres' => 
+    array (
+    ),
+    'celtic' => 
+    array (
+    ),
+    'center' => 
+    array (
+    ),
+    'chattanooga' => 
+    array (
+    ),
+    'cheltenham' => 
+    array (
+    ),
+    'chesapeakebay' => 
+    array (
+    ),
+    'chicago' => 
+    array (
+    ),
+    'children' => 
+    array (
+    ),
+    'childrens' => 
+    array (
+    ),
+    'childrensgarden' => 
+    array (
+    ),
+    'chiropractic' => 
+    array (
+    ),
+    'chocolate' => 
+    array (
+    ),
+    'christiansburg' => 
+    array (
+    ),
+    'cincinnati' => 
+    array (
+    ),
+    'cinema' => 
+    array (
+    ),
+    'circus' => 
+    array (
+    ),
+    'civilisation' => 
+    array (
+    ),
+    'civilization' => 
+    array (
+    ),
+    'civilwar' => 
+    array (
+    ),
+    'clinton' => 
+    array (
+    ),
+    'clock' => 
+    array (
+    ),
+    'coal' => 
+    array (
+    ),
+    'coastaldefence' => 
+    array (
+    ),
+    'cody' => 
+    array (
+    ),
+    'coldwar' => 
+    array (
+    ),
+    'collection' => 
+    array (
+    ),
+    'colonialwilliamsburg' => 
+    array (
+    ),
+    'coloradoplateau' => 
+    array (
+    ),
+    'columbia' => 
+    array (
+    ),
+    'columbus' => 
+    array (
+    ),
+    'communication' => 
+    array (
+    ),
+    'communications' => 
+    array (
+    ),
+    'community' => 
+    array (
+    ),
+    'computer' => 
+    array (
+    ),
+    'computerhistory' => 
+    array (
+    ),
+    'xn--comunicaes-v6a2o' => 
+    array (
+    ),
+    'contemporary' => 
+    array (
+    ),
+    'contemporaryart' => 
+    array (
+    ),
+    'convent' => 
+    array (
+    ),
+    'copenhagen' => 
+    array (
+    ),
+    'corporation' => 
+    array (
+    ),
+    'xn--correios-e-telecomunicaes-ghc29a' => 
+    array (
+    ),
+    'corvette' => 
+    array (
+    ),
+    'costume' => 
+    array (
+    ),
+    'countryestate' => 
+    array (
+    ),
+    'county' => 
+    array (
+    ),
+    'crafts' => 
+    array (
+    ),
+    'cranbrook' => 
+    array (
+    ),
+    'creation' => 
+    array (
+    ),
+    'cultural' => 
+    array (
+    ),
+    'culturalcenter' => 
+    array (
+    ),
+    'culture' => 
+    array (
+    ),
+    'cyber' => 
+    array (
+    ),
+    'cymru' => 
+    array (
+    ),
+    'dali' => 
+    array (
+    ),
+    'dallas' => 
+    array (
+    ),
+    'database' => 
+    array (
+    ),
+    'ddr' => 
+    array (
+    ),
+    'decorativearts' => 
+    array (
+    ),
+    'delaware' => 
+    array (
+    ),
+    'delmenhorst' => 
+    array (
+    ),
+    'denmark' => 
+    array (
+    ),
+    'depot' => 
+    array (
+    ),
+    'design' => 
+    array (
+    ),
+    'detroit' => 
+    array (
+    ),
+    'dinosaur' => 
+    array (
+    ),
+    'discovery' => 
+    array (
+    ),
+    'dolls' => 
+    array (
+    ),
+    'donostia' => 
+    array (
+    ),
+    'durham' => 
+    array (
+    ),
+    'eastafrica' => 
+    array (
+    ),
+    'eastcoast' => 
+    array (
+    ),
+    'education' => 
+    array (
+    ),
+    'educational' => 
+    array (
+    ),
+    'egyptian' => 
+    array (
+    ),
+    'eisenbahn' => 
+    array (
+    ),
+    'elburg' => 
+    array (
+    ),
+    'elvendrell' => 
+    array (
+    ),
+    'embroidery' => 
+    array (
+    ),
+    'encyclopedic' => 
+    array (
+    ),
+    'england' => 
+    array (
+    ),
+    'entomology' => 
+    array (
+    ),
+    'environment' => 
+    array (
+    ),
+    'environmentalconservation' => 
+    array (
+    ),
+    'epilepsy' => 
+    array (
+    ),
+    'essex' => 
+    array (
+    ),
+    'estate' => 
+    array (
+    ),
+    'ethnology' => 
+    array (
+    ),
+    'exeter' => 
+    array (
+    ),
+    'exhibition' => 
+    array (
+    ),
+    'family' => 
+    array (
+    ),
+    'farm' => 
+    array (
+    ),
+    'farmequipment' => 
+    array (
+    ),
+    'farmers' => 
+    array (
+    ),
+    'farmstead' => 
+    array (
+    ),
+    'field' => 
+    array (
+    ),
+    'figueres' => 
+    array (
+    ),
+    'filatelia' => 
+    array (
+    ),
+    'film' => 
+    array (
+    ),
+    'fineart' => 
+    array (
+    ),
+    'finearts' => 
+    array (
+    ),
+    'finland' => 
+    array (
+    ),
+    'flanders' => 
+    array (
+    ),
+    'florida' => 
+    array (
+    ),
+    'force' => 
+    array (
+    ),
+    'fortmissoula' => 
+    array (
+    ),
+    'fortworth' => 
+    array (
+    ),
+    'foundation' => 
+    array (
+    ),
+    'francaise' => 
+    array (
+    ),
+    'frankfurt' => 
+    array (
+    ),
+    'franziskaner' => 
+    array (
+    ),
+    'freemasonry' => 
+    array (
+    ),
+    'freiburg' => 
+    array (
+    ),
+    'fribourg' => 
+    array (
+    ),
+    'frog' => 
+    array (
+    ),
+    'fundacio' => 
+    array (
+    ),
+    'furniture' => 
+    array (
+    ),
+    'gallery' => 
+    array (
+    ),
+    'garden' => 
+    array (
+    ),
+    'gateway' => 
+    array (
+    ),
+    'geelvinck' => 
+    array (
+    ),
+    'gemological' => 
+    array (
+    ),
+    'geology' => 
+    array (
+    ),
+    'georgia' => 
+    array (
+    ),
+    'giessen' => 
+    array (
+    ),
+    'glas' => 
+    array (
+    ),
+    'glass' => 
+    array (
+    ),
+    'gorge' => 
+    array (
+    ),
+    'grandrapids' => 
+    array (
+    ),
+    'graz' => 
+    array (
+    ),
+    'guernsey' => 
+    array (
+    ),
+    'halloffame' => 
+    array (
+    ),
+    'hamburg' => 
+    array (
+    ),
+    'handson' => 
+    array (
+    ),
+    'harvestcelebration' => 
+    array (
+    ),
+    'hawaii' => 
+    array (
+    ),
+    'health' => 
+    array (
+    ),
+    'heimatunduhren' => 
+    array (
+    ),
+    'hellas' => 
+    array (
+    ),
+    'helsinki' => 
+    array (
+    ),
+    'hembygdsforbund' => 
+    array (
+    ),
+    'heritage' => 
+    array (
+    ),
+    'histoire' => 
+    array (
+    ),
+    'historical' => 
+    array (
+    ),
+    'historicalsociety' => 
+    array (
+    ),
+    'historichouses' => 
+    array (
+    ),
+    'historisch' => 
+    array (
+    ),
+    'historisches' => 
+    array (
+    ),
+    'history' => 
+    array (
+    ),
+    'historyofscience' => 
+    array (
+    ),
+    'horology' => 
+    array (
+    ),
+    'house' => 
+    array (
+    ),
+    'humanities' => 
+    array (
+    ),
+    'illustration' => 
+    array (
+    ),
+    'imageandsound' => 
+    array (
+    ),
+    'indian' => 
+    array (
+    ),
+    'indiana' => 
+    array (
+    ),
+    'indianapolis' => 
+    array (
+    ),
+    'indianmarket' => 
+    array (
+    ),
+    'intelligence' => 
+    array (
+    ),
+    'interactive' => 
+    array (
+    ),
+    'iraq' => 
+    array (
+    ),
+    'iron' => 
+    array (
+    ),
+    'isleofman' => 
+    array (
+    ),
+    'jamison' => 
+    array (
+    ),
+    'jefferson' => 
+    array (
+    ),
+    'jerusalem' => 
+    array (
+    ),
+    'jewelry' => 
+    array (
+    ),
+    'jewish' => 
+    array (
+    ),
+    'jewishart' => 
+    array (
+    ),
+    'jfk' => 
+    array (
+    ),
+    'journalism' => 
+    array (
+    ),
+    'judaica' => 
+    array (
+    ),
+    'judygarland' => 
+    array (
+    ),
+    'juedisches' => 
+    array (
+    ),
+    'juif' => 
+    array (
+    ),
+    'karate' => 
+    array (
+    ),
+    'karikatur' => 
+    array (
+    ),
+    'kids' => 
+    array (
+    ),
+    'koebenhavn' => 
+    array (
+    ),
+    'koeln' => 
+    array (
+    ),
+    'kunst' => 
+    array (
+    ),
+    'kunstsammlung' => 
+    array (
+    ),
+    'kunstunddesign' => 
+    array (
+    ),
+    'labor' => 
+    array (
+    ),
+    'labour' => 
+    array (
+    ),
+    'lajolla' => 
+    array (
+    ),
+    'lancashire' => 
+    array (
+    ),
+    'landes' => 
+    array (
+    ),
+    'lans' => 
+    array (
+    ),
+    'xn--lns-qla' => 
+    array (
+    ),
+    'larsson' => 
+    array (
+    ),
+    'lewismiller' => 
+    array (
+    ),
+    'lincoln' => 
+    array (
+    ),
+    'linz' => 
+    array (
+    ),
+    'living' => 
+    array (
+    ),
+    'livinghistory' => 
+    array (
+    ),
+    'localhistory' => 
+    array (
+    ),
+    'london' => 
+    array (
+    ),
+    'losangeles' => 
+    array (
+    ),
+    'louvre' => 
+    array (
+    ),
+    'loyalist' => 
+    array (
+    ),
+    'lucerne' => 
+    array (
+    ),
+    'luxembourg' => 
+    array (
+    ),
+    'luzern' => 
+    array (
+    ),
+    'mad' => 
+    array (
+    ),
+    'madrid' => 
+    array (
+    ),
+    'mallorca' => 
+    array (
+    ),
+    'manchester' => 
+    array (
+    ),
+    'mansion' => 
+    array (
+    ),
+    'mansions' => 
+    array (
+    ),
+    'manx' => 
+    array (
+    ),
+    'marburg' => 
+    array (
+    ),
+    'maritime' => 
+    array (
+    ),
+    'maritimo' => 
+    array (
+    ),
+    'maryland' => 
+    array (
+    ),
+    'marylhurst' => 
+    array (
+    ),
+    'media' => 
+    array (
+    ),
+    'medical' => 
+    array (
+    ),
+    'medizinhistorisches' => 
+    array (
+    ),
+    'meeres' => 
+    array (
+    ),
+    'memorial' => 
+    array (
+    ),
+    'mesaverde' => 
+    array (
+    ),
+    'michigan' => 
+    array (
+    ),
+    'midatlantic' => 
+    array (
+    ),
+    'military' => 
+    array (
+    ),
+    'mill' => 
+    array (
+    ),
+    'miners' => 
+    array (
+    ),
+    'mining' => 
+    array (
+    ),
+    'minnesota' => 
+    array (
+    ),
+    'missile' => 
+    array (
+    ),
+    'missoula' => 
+    array (
+    ),
+    'modern' => 
+    array (
+    ),
+    'moma' => 
+    array (
+    ),
+    'money' => 
+    array (
+    ),
+    'monmouth' => 
+    array (
+    ),
+    'monticello' => 
+    array (
+    ),
+    'montreal' => 
+    array (
+    ),
+    'moscow' => 
+    array (
+    ),
+    'motorcycle' => 
+    array (
+    ),
+    'muenchen' => 
+    array (
+    ),
+    'muenster' => 
+    array (
+    ),
+    'mulhouse' => 
+    array (
+    ),
+    'muncie' => 
+    array (
+    ),
+    'museet' => 
+    array (
+    ),
+    'museumcenter' => 
+    array (
+    ),
+    'museumvereniging' => 
+    array (
+    ),
+    'music' => 
+    array (
+    ),
+    'national' => 
+    array (
+    ),
+    'nationalfirearms' => 
+    array (
+    ),
+    'nationalheritage' => 
+    array (
+    ),
+    'nativeamerican' => 
+    array (
+    ),
+    'naturalhistory' => 
+    array (
+    ),
+    'naturalhistorymuseum' => 
+    array (
+    ),
+    'naturalsciences' => 
+    array (
+    ),
+    'nature' => 
+    array (
+    ),
+    'naturhistorisches' => 
+    array (
+    ),
+    'natuurwetenschappen' => 
+    array (
+    ),
+    'naumburg' => 
+    array (
+    ),
+    'naval' => 
+    array (
+    ),
+    'nebraska' => 
+    array (
+    ),
+    'neues' => 
+    array (
+    ),
+    'newhampshire' => 
+    array (
+    ),
+    'newjersey' => 
+    array (
+    ),
+    'newmexico' => 
+    array (
+    ),
+    'newport' => 
+    array (
+    ),
+    'newspaper' => 
+    array (
+    ),
+    'newyork' => 
+    array (
+    ),
+    'niepce' => 
+    array (
+    ),
+    'norfolk' => 
+    array (
+    ),
+    'north' => 
+    array (
+    ),
+    'nrw' => 
+    array (
+    ),
+    'nuernberg' => 
+    array (
+    ),
+    'nuremberg' => 
+    array (
+    ),
+    'nyc' => 
+    array (
+    ),
+    'nyny' => 
+    array (
+    ),
+    'oceanographic' => 
+    array (
+    ),
+    'oceanographique' => 
+    array (
+    ),
+    'omaha' => 
+    array (
+    ),
+    'online' => 
+    array (
+    ),
+    'ontario' => 
+    array (
+    ),
+    'openair' => 
+    array (
+    ),
+    'oregon' => 
+    array (
+    ),
+    'oregontrail' => 
+    array (
+    ),
+    'otago' => 
+    array (
+    ),
+    'oxford' => 
+    array (
+    ),
+    'pacific' => 
+    array (
+    ),
+    'paderborn' => 
+    array (
+    ),
+    'palace' => 
+    array (
+    ),
+    'paleo' => 
+    array (
+    ),
+    'palmsprings' => 
+    array (
+    ),
+    'panama' => 
+    array (
+    ),
+    'paris' => 
+    array (
+    ),
+    'pasadena' => 
+    array (
+    ),
+    'pharmacy' => 
+    array (
+    ),
+    'philadelphia' => 
+    array (
+    ),
+    'philadelphiaarea' => 
+    array (
+    ),
+    'philately' => 
+    array (
+    ),
+    'phoenix' => 
+    array (
+    ),
+    'photography' => 
+    array (
+    ),
+    'pilots' => 
+    array (
+    ),
+    'pittsburgh' => 
+    array (
+    ),
+    'planetarium' => 
+    array (
+    ),
+    'plantation' => 
+    array (
+    ),
+    'plants' => 
+    array (
+    ),
+    'plaza' => 
+    array (
+    ),
+    'portal' => 
+    array (
+    ),
+    'portland' => 
+    array (
+    ),
+    'portlligat' => 
+    array (
+    ),
+    'posts-and-telecommunications' => 
+    array (
+    ),
+    'preservation' => 
+    array (
+    ),
+    'presidio' => 
+    array (
+    ),
+    'press' => 
+    array (
+    ),
+    'project' => 
+    array (
+    ),
+    'public' => 
+    array (
+    ),
+    'pubol' => 
+    array (
+    ),
+    'quebec' => 
+    array (
+    ),
+    'railroad' => 
+    array (
+    ),
+    'railway' => 
+    array (
+    ),
+    'research' => 
+    array (
+    ),
+    'resistance' => 
+    array (
+    ),
+    'riodejaneiro' => 
+    array (
+    ),
+    'rochester' => 
+    array (
+    ),
+    'rockart' => 
+    array (
+    ),
+    'roma' => 
+    array (
+    ),
+    'russia' => 
+    array (
+    ),
+    'saintlouis' => 
+    array (
+    ),
+    'salem' => 
+    array (
+    ),
+    'salvadordali' => 
+    array (
+    ),
+    'salzburg' => 
+    array (
+    ),
+    'sandiego' => 
+    array (
+    ),
+    'sanfrancisco' => 
+    array (
+    ),
+    'santabarbara' => 
+    array (
+    ),
+    'santacruz' => 
+    array (
+    ),
+    'santafe' => 
+    array (
+    ),
+    'saskatchewan' => 
+    array (
+    ),
+    'satx' => 
+    array (
+    ),
+    'savannahga' => 
+    array (
+    ),
+    'schlesisches' => 
+    array (
+    ),
+    'schoenbrunn' => 
+    array (
+    ),
+    'schokoladen' => 
+    array (
+    ),
+    'school' => 
+    array (
+    ),
+    'schweiz' => 
+    array (
+    ),
+    'science' => 
+    array (
+    ),
+    'scienceandhistory' => 
+    array (
+    ),
+    'scienceandindustry' => 
+    array (
+    ),
+    'sciencecenter' => 
+    array (
+    ),
+    'sciencecenters' => 
+    array (
+    ),
+    'science-fiction' => 
+    array (
+    ),
+    'sciencehistory' => 
+    array (
+    ),
+    'sciences' => 
+    array (
+    ),
+    'sciencesnaturelles' => 
+    array (
+    ),
+    'scotland' => 
+    array (
+    ),
+    'seaport' => 
+    array (
+    ),
+    'settlement' => 
+    array (
+    ),
+    'settlers' => 
+    array (
+    ),
+    'shell' => 
+    array (
+    ),
+    'sherbrooke' => 
+    array (
+    ),
+    'sibenik' => 
+    array (
+    ),
+    'silk' => 
+    array (
+    ),
+    'ski' => 
+    array (
+    ),
+    'skole' => 
+    array (
+    ),
+    'society' => 
+    array (
+    ),
+    'sologne' => 
+    array (
+    ),
+    'soundandvision' => 
+    array (
+    ),
+    'southcarolina' => 
+    array (
+    ),
+    'southwest' => 
+    array (
+    ),
+    'space' => 
+    array (
+    ),
+    'spy' => 
+    array (
+    ),
+    'square' => 
+    array (
+    ),
+    'stadt' => 
+    array (
+    ),
+    'stalbans' => 
+    array (
+    ),
+    'starnberg' => 
+    array (
+    ),
+    'state' => 
+    array (
+    ),
+    'stateofdelaware' => 
+    array (
+    ),
+    'station' => 
+    array (
+    ),
+    'steam' => 
+    array (
+    ),
+    'steiermark' => 
+    array (
+    ),
+    'stjohn' => 
+    array (
+    ),
+    'stockholm' => 
+    array (
+    ),
+    'stpetersburg' => 
+    array (
+    ),
+    'stuttgart' => 
+    array (
+    ),
+    'suisse' => 
+    array (
+    ),
+    'surgeonshall' => 
+    array (
+    ),
+    'surrey' => 
+    array (
+    ),
+    'svizzera' => 
+    array (
+    ),
+    'sweden' => 
+    array (
+    ),
+    'sydney' => 
+    array (
+    ),
+    'tank' => 
+    array (
+    ),
+    'tcm' => 
+    array (
+    ),
+    'technology' => 
+    array (
+    ),
+    'telekommunikation' => 
+    array (
+    ),
+    'television' => 
+    array (
+    ),
+    'texas' => 
+    array (
+    ),
+    'textile' => 
+    array (
+    ),
+    'theater' => 
+    array (
+    ),
+    'time' => 
+    array (
+    ),
+    'timekeeping' => 
+    array (
+    ),
+    'topology' => 
+    array (
+    ),
+    'torino' => 
+    array (
+    ),
+    'touch' => 
+    array (
+    ),
+    'town' => 
+    array (
+    ),
+    'transport' => 
+    array (
+    ),
+    'tree' => 
+    array (
+    ),
+    'trolley' => 
+    array (
+    ),
+    'trust' => 
+    array (
+    ),
+    'trustee' => 
+    array (
+    ),
+    'uhren' => 
+    array (
+    ),
+    'ulm' => 
+    array (
+    ),
+    'undersea' => 
+    array (
+    ),
+    'university' => 
+    array (
+    ),
+    'usa' => 
+    array (
+    ),
+    'usantiques' => 
+    array (
+    ),
+    'usarts' => 
+    array (
+    ),
+    'uscountryestate' => 
+    array (
+    ),
+    'usculture' => 
+    array (
+    ),
+    'usdecorativearts' => 
+    array (
+    ),
+    'usgarden' => 
+    array (
+    ),
+    'ushistory' => 
+    array (
+    ),
+    'ushuaia' => 
+    array (
+    ),
+    'uslivinghistory' => 
+    array (
+    ),
+    'utah' => 
+    array (
+    ),
+    'uvic' => 
+    array (
+    ),
+    'valley' => 
+    array (
+    ),
+    'vantaa' => 
+    array (
+    ),
+    'versailles' => 
+    array (
+    ),
+    'viking' => 
+    array (
+    ),
+    'village' => 
+    array (
+    ),
+    'virginia' => 
+    array (
+    ),
+    'virtual' => 
+    array (
+    ),
+    'virtuel' => 
+    array (
+    ),
+    'vlaanderen' => 
+    array (
+    ),
+    'volkenkunde' => 
+    array (
+    ),
+    'wales' => 
+    array (
+    ),
+    'wallonie' => 
+    array (
+    ),
+    'war' => 
+    array (
+    ),
+    'washingtondc' => 
+    array (
+    ),
+    'watchandclock' => 
+    array (
+    ),
+    'watch-and-clock' => 
+    array (
+    ),
+    'western' => 
+    array (
+    ),
+    'westfalen' => 
+    array (
+    ),
+    'whaling' => 
+    array (
+    ),
+    'wildlife' => 
+    array (
+    ),
+    'williamsburg' => 
+    array (
+    ),
+    'windmill' => 
+    array (
+    ),
+    'workshop' => 
+    array (
+    ),
+    'york' => 
+    array (
+    ),
+    'yorkshire' => 
+    array (
+    ),
+    'yosemite' => 
+    array (
+    ),
+    'youth' => 
+    array (
+    ),
+    'zoological' => 
+    array (
+    ),
+    'zoology' => 
+    array (
+    ),
+    'xn--9dbhblg6di' => 
+    array (
+    ),
+    'xn--h1aegh' => 
+    array (
+    ),
+  ),
+  'mv' => 
+  array (
+    'aero' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'museum' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+  ),
+  'mw' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'museum' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'mx' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'my' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+  ),
+  'mz' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'adv' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'na' => 
+  array (
+    'info' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'school' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'dr' => 
+    array (
+    ),
+    'us' => 
+    array (
+    ),
+    'mx' => 
+    array (
+    ),
+    'ca' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'cc' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+    'ws' => 
+    array (
+    ),
+    'mobi' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'name' => 
+  array (
+  ),
+  'nc' => 
+  array (
+    'asso' => 
+    array (
+    ),
+  ),
+  'ne' => 
+  array (
+  ),
+  'net' => 
+  array (
+  ),
+  'nf' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'per' => 
+    array (
+    ),
+    'rec' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+    'arts' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'other' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+  ),
+  'ng' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'i' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'mobi' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+  ),
+  'ni' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+  ),
+  'nl' => 
+  array (
+    'bv' => 
+    array (
+    ),
+  ),
+  'no' => 
+  array (
+    'fhs' => 
+    array (
+    ),
+    'vgs' => 
+    array (
+    ),
+    'fylkesbibl' => 
+    array (
+    ),
+    'folkebibl' => 
+    array (
+    ),
+    'museum' => 
+    array (
+    ),
+    'idrett' => 
+    array (
+    ),
+    'priv' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'stat' => 
+    array (
+    ),
+    'dep' => 
+    array (
+    ),
+    'kommune' => 
+    array (
+    ),
+    'herad' => 
+    array (
+    ),
+    'aa' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'ah' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'bu' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'fm' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'hl' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'hm' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'jan-mayen' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'mr' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'nl' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'nt' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'of' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'ol' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'oslo' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'rl' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'sf' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'st' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'svalbard' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'tm' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'tr' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'va' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'vf' => 
+    array (
+      'gs' => 
+      array (
+      ),
+    ),
+    'akrehamn' => 
+    array (
+    ),
+    'xn--krehamn-dxa' => 
+    array (
+    ),
+    'algard' => 
+    array (
+    ),
+    'xn--lgrd-poac' => 
+    array (
+    ),
+    'arna' => 
+    array (
+    ),
+    'brumunddal' => 
+    array (
+    ),
+    'bryne' => 
+    array (
+    ),
+    'bronnoysund' => 
+    array (
+    ),
+    'xn--brnnysund-m8ac' => 
+    array (
+    ),
+    'drobak' => 
+    array (
+    ),
+    'xn--drbak-wua' => 
+    array (
+    ),
+    'egersund' => 
+    array (
+    ),
+    'fetsund' => 
+    array (
+    ),
+    'floro' => 
+    array (
+    ),
+    'xn--flor-jra' => 
+    array (
+    ),
+    'fredrikstad' => 
+    array (
+    ),
+    'hokksund' => 
+    array (
+    ),
+    'honefoss' => 
+    array (
+    ),
+    'xn--hnefoss-q1a' => 
+    array (
+    ),
+    'jessheim' => 
+    array (
+    ),
+    'jorpeland' => 
+    array (
+    ),
+    'xn--jrpeland-54a' => 
+    array (
+    ),
+    'kirkenes' => 
+    array (
+    ),
+    'kopervik' => 
+    array (
+    ),
+    'krokstadelva' => 
+    array (
+    ),
+    'langevag' => 
+    array (
+    ),
+    'xn--langevg-jxa' => 
+    array (
+    ),
+    'leirvik' => 
+    array (
+    ),
+    'mjondalen' => 
+    array (
+    ),
+    'xn--mjndalen-64a' => 
+    array (
+    ),
+    'mo-i-rana' => 
+    array (
+    ),
+    'mosjoen' => 
+    array (
+    ),
+    'xn--mosjen-eya' => 
+    array (
+    ),
+    'nesoddtangen' => 
+    array (
+    ),
+    'orkanger' => 
+    array (
+    ),
+    'osoyro' => 
+    array (
+    ),
+    'xn--osyro-wua' => 
+    array (
+    ),
+    'raholt' => 
+    array (
+    ),
+    'xn--rholt-mra' => 
+    array (
+    ),
+    'sandnessjoen' => 
+    array (
+    ),
+    'xn--sandnessjen-ogb' => 
+    array (
+    ),
+    'skedsmokorset' => 
+    array (
+    ),
+    'slattum' => 
+    array (
+    ),
+    'spjelkavik' => 
+    array (
+    ),
+    'stathelle' => 
+    array (
+    ),
+    'stavern' => 
+    array (
+    ),
+    'stjordalshalsen' => 
+    array (
+    ),
+    'xn--stjrdalshalsen-sqb' => 
+    array (
+    ),
+    'tananger' => 
+    array (
+    ),
+    'tranby' => 
+    array (
+    ),
+    'vossevangen' => 
+    array (
+    ),
+    'afjord' => 
+    array (
+    ),
+    'xn--fjord-lra' => 
+    array (
+    ),
+    'agdenes' => 
+    array (
+    ),
+    'al' => 
+    array (
+    ),
+    'xn--l-1fa' => 
+    array (
+    ),
+    'alesund' => 
+    array (
+    ),
+    'xn--lesund-hua' => 
+    array (
+    ),
+    'alstahaug' => 
+    array (
+    ),
+    'alta' => 
+    array (
+    ),
+    'xn--lt-liac' => 
+    array (
+    ),
+    'alaheadju' => 
+    array (
+    ),
+    'xn--laheadju-7ya' => 
+    array (
+    ),
+    'alvdal' => 
+    array (
+    ),
+    'amli' => 
+    array (
+    ),
+    'xn--mli-tla' => 
+    array (
+    ),
+    'amot' => 
+    array (
+    ),
+    'xn--mot-tla' => 
+    array (
+    ),
+    'andebu' => 
+    array (
+    ),
+    'andoy' => 
+    array (
+    ),
+    'xn--andy-ira' => 
+    array (
+    ),
+    'andasuolo' => 
+    array (
+    ),
+    'ardal' => 
+    array (
+    ),
+    'xn--rdal-poa' => 
+    array (
+    ),
+    'aremark' => 
+    array (
+    ),
+    'arendal' => 
+    array (
+    ),
+    'xn--s-1fa' => 
+    array (
+    ),
+    'aseral' => 
+    array (
+    ),
+    'xn--seral-lra' => 
+    array (
+    ),
+    'asker' => 
+    array (
+    ),
+    'askim' => 
+    array (
+    ),
+    'askvoll' => 
+    array (
+    ),
+    'askoy' => 
+    array (
+    ),
+    'xn--asky-ira' => 
+    array (
+    ),
+    'asnes' => 
+    array (
+    ),
+    'xn--snes-poa' => 
+    array (
+    ),
+    'audnedaln' => 
+    array (
+    ),
+    'aukra' => 
+    array (
+    ),
+    'aure' => 
+    array (
+    ),
+    'aurland' => 
+    array (
+    ),
+    'aurskog-holand' => 
+    array (
+    ),
+    'xn--aurskog-hland-jnb' => 
+    array (
+    ),
+    'austevoll' => 
+    array (
+    ),
+    'austrheim' => 
+    array (
+    ),
+    'averoy' => 
+    array (
+    ),
+    'xn--avery-yua' => 
+    array (
+    ),
+    'balestrand' => 
+    array (
+    ),
+    'ballangen' => 
+    array (
+    ),
+    'balat' => 
+    array (
+    ),
+    'xn--blt-elab' => 
+    array (
+    ),
+    'balsfjord' => 
+    array (
+    ),
+    'bahccavuotna' => 
+    array (
+    ),
+    'xn--bhccavuotna-k7a' => 
+    array (
+    ),
+    'bamble' => 
+    array (
+    ),
+    'bardu' => 
+    array (
+    ),
+    'beardu' => 
+    array (
+    ),
+    'beiarn' => 
+    array (
+    ),
+    'bajddar' => 
+    array (
+    ),
+    'xn--bjddar-pta' => 
+    array (
+    ),
+    'baidar' => 
+    array (
+    ),
+    'xn--bidr-5nac' => 
+    array (
+    ),
+    'berg' => 
+    array (
+    ),
+    'bergen' => 
+    array (
+    ),
+    'berlevag' => 
+    array (
+    ),
+    'xn--berlevg-jxa' => 
+    array (
+    ),
+    'bearalvahki' => 
+    array (
+    ),
+    'xn--bearalvhki-y4a' => 
+    array (
+    ),
+    'bindal' => 
+    array (
+    ),
+    'birkenes' => 
+    array (
+    ),
+    'bjarkoy' => 
+    array (
+    ),
+    'xn--bjarky-fya' => 
+    array (
+    ),
+    'bjerkreim' => 
+    array (
+    ),
+    'bjugn' => 
+    array (
+    ),
+    'bodo' => 
+    array (
+    ),
+    'xn--bod-2na' => 
+    array (
+    ),
+    'badaddja' => 
+    array (
+    ),
+    'xn--bdddj-mrabd' => 
+    array (
+    ),
+    'budejju' => 
+    array (
+    ),
+    'bokn' => 
+    array (
+    ),
+    'bremanger' => 
+    array (
+    ),
+    'bronnoy' => 
+    array (
+    ),
+    'xn--brnny-wuac' => 
+    array (
+    ),
+    'bygland' => 
+    array (
+    ),
+    'bykle' => 
+    array (
+    ),
+    'barum' => 
+    array (
+    ),
+    'xn--brum-voa' => 
+    array (
+    ),
+    'telemark' => 
+    array (
+      'bo' => 
+      array (
+      ),
+      'xn--b-5ga' => 
+      array (
+      ),
+    ),
+    'nordland' => 
+    array (
+      'bo' => 
+      array (
+      ),
+      'xn--b-5ga' => 
+      array (
+      ),
+      'heroy' => 
+      array (
+      ),
+      'xn--hery-ira' => 
+      array (
+      ),
+    ),
+    'bievat' => 
+    array (
+    ),
+    'xn--bievt-0qa' => 
+    array (
+    ),
+    'bomlo' => 
+    array (
+    ),
+    'xn--bmlo-gra' => 
+    array (
+    ),
+    'batsfjord' => 
+    array (
+    ),
+    'xn--btsfjord-9za' => 
+    array (
+    ),
+    'bahcavuotna' => 
+    array (
+    ),
+    'xn--bhcavuotna-s4a' => 
+    array (
+    ),
+    'dovre' => 
+    array (
+    ),
+    'drammen' => 
+    array (
+    ),
+    'drangedal' => 
+    array (
+    ),
+    'dyroy' => 
+    array (
+    ),
+    'xn--dyry-ira' => 
+    array (
+    ),
+    'donna' => 
+    array (
+    ),
+    'xn--dnna-gra' => 
+    array (
+    ),
+    'eid' => 
+    array (
+    ),
+    'eidfjord' => 
+    array (
+    ),
+    'eidsberg' => 
+    array (
+    ),
+    'eidskog' => 
+    array (
+    ),
+    'eidsvoll' => 
+    array (
+    ),
+    'eigersund' => 
+    array (
+    ),
+    'elverum' => 
+    array (
+    ),
+    'enebakk' => 
+    array (
+    ),
+    'engerdal' => 
+    array (
+    ),
+    'etne' => 
+    array (
+    ),
+    'etnedal' => 
+    array (
+    ),
+    'evenes' => 
+    array (
+    ),
+    'evenassi' => 
+    array (
+    ),
+    'xn--eveni-0qa01ga' => 
+    array (
+    ),
+    'evje-og-hornnes' => 
+    array (
+    ),
+    'farsund' => 
+    array (
+    ),
+    'fauske' => 
+    array (
+    ),
+    'fuossko' => 
+    array (
+    ),
+    'fuoisku' => 
+    array (
+    ),
+    'fedje' => 
+    array (
+    ),
+    'fet' => 
+    array (
+    ),
+    'finnoy' => 
+    array (
+    ),
+    'xn--finny-yua' => 
+    array (
+    ),
+    'fitjar' => 
+    array (
+    ),
+    'fjaler' => 
+    array (
+    ),
+    'fjell' => 
+    array (
+    ),
+    'flakstad' => 
+    array (
+    ),
+    'flatanger' => 
+    array (
+    ),
+    'flekkefjord' => 
+    array (
+    ),
+    'flesberg' => 
+    array (
+    ),
+    'flora' => 
+    array (
+    ),
+    'fla' => 
+    array (
+    ),
+    'xn--fl-zia' => 
+    array (
+    ),
+    'folldal' => 
+    array (
+    ),
+    'forsand' => 
+    array (
+    ),
+    'fosnes' => 
+    array (
+    ),
+    'frei' => 
+    array (
+    ),
+    'frogn' => 
+    array (
+    ),
+    'froland' => 
+    array (
+    ),
+    'frosta' => 
+    array (
+    ),
+    'frana' => 
+    array (
+    ),
+    'xn--frna-woa' => 
+    array (
+    ),
+    'froya' => 
+    array (
+    ),
+    'xn--frya-hra' => 
+    array (
+    ),
+    'fusa' => 
+    array (
+    ),
+    'fyresdal' => 
+    array (
+    ),
+    'forde' => 
+    array (
+    ),
+    'xn--frde-gra' => 
+    array (
+    ),
+    'gamvik' => 
+    array (
+    ),
+    'gangaviika' => 
+    array (
+    ),
+    'xn--ggaviika-8ya47h' => 
+    array (
+    ),
+    'gaular' => 
+    array (
+    ),
+    'gausdal' => 
+    array (
+    ),
+    'gildeskal' => 
+    array (
+    ),
+    'xn--gildeskl-g0a' => 
+    array (
+    ),
+    'giske' => 
+    array (
+    ),
+    'gjemnes' => 
+    array (
+    ),
+    'gjerdrum' => 
+    array (
+    ),
+    'gjerstad' => 
+    array (
+    ),
+    'gjesdal' => 
+    array (
+    ),
+    'gjovik' => 
+    array (
+    ),
+    'xn--gjvik-wua' => 
+    array (
+    ),
+    'gloppen' => 
+    array (
+    ),
+    'gol' => 
+    array (
+    ),
+    'gran' => 
+    array (
+    ),
+    'grane' => 
+    array (
+    ),
+    'granvin' => 
+    array (
+    ),
+    'gratangen' => 
+    array (
+    ),
+    'grimstad' => 
+    array (
+    ),
+    'grong' => 
+    array (
+    ),
+    'kraanghke' => 
+    array (
+    ),
+    'xn--kranghke-b0a' => 
+    array (
+    ),
+    'grue' => 
+    array (
+    ),
+    'gulen' => 
+    array (
+    ),
+    'hadsel' => 
+    array (
+    ),
+    'halden' => 
+    array (
+    ),
+    'halsa' => 
+    array (
+    ),
+    'hamar' => 
+    array (
+    ),
+    'hamaroy' => 
+    array (
+    ),
+    'habmer' => 
+    array (
+    ),
+    'xn--hbmer-xqa' => 
+    array (
+    ),
+    'hapmir' => 
+    array (
+    ),
+    'xn--hpmir-xqa' => 
+    array (
+    ),
+    'hammerfest' => 
+    array (
+    ),
+    'hammarfeasta' => 
+    array (
+    ),
+    'xn--hmmrfeasta-s4ac' => 
+    array (
+    ),
+    'haram' => 
+    array (
+    ),
+    'hareid' => 
+    array (
+    ),
+    'harstad' => 
+    array (
+    ),
+    'hasvik' => 
+    array (
+    ),
+    'aknoluokta' => 
+    array (
+    ),
+    'xn--koluokta-7ya57h' => 
+    array (
+    ),
+    'hattfjelldal' => 
+    array (
+    ),
+    'aarborte' => 
+    array (
+    ),
+    'haugesund' => 
+    array (
+    ),
+    'hemne' => 
+    array (
+    ),
+    'hemnes' => 
+    array (
+    ),
+    'hemsedal' => 
+    array (
+    ),
+    'more-og-romsdal' => 
+    array (
+      'heroy' => 
+      array (
+      ),
+      'sande' => 
+      array (
+      ),
+    ),
+    'xn--mre-og-romsdal-qqb' => 
+    array (
+      'xn--hery-ira' => 
+      array (
+      ),
+      'sande' => 
+      array (
+      ),
+    ),
+    'hitra' => 
+    array (
+    ),
+    'hjartdal' => 
+    array (
+    ),
+    'hjelmeland' => 
+    array (
+    ),
+    'hobol' => 
+    array (
+    ),
+    'xn--hobl-ira' => 
+    array (
+    ),
+    'hof' => 
+    array (
+    ),
+    'hol' => 
+    array (
+    ),
+    'hole' => 
+    array (
+    ),
+    'holmestrand' => 
+    array (
+    ),
+    'holtalen' => 
+    array (
+    ),
+    'xn--holtlen-hxa' => 
+    array (
+    ),
+    'hornindal' => 
+    array (
+    ),
+    'horten' => 
+    array (
+    ),
+    'hurdal' => 
+    array (
+    ),
+    'hurum' => 
+    array (
+    ),
+    'hvaler' => 
+    array (
+    ),
+    'hyllestad' => 
+    array (
+    ),
+    'hagebostad' => 
+    array (
+    ),
+    'xn--hgebostad-g3a' => 
+    array (
+    ),
+    'hoyanger' => 
+    array (
+    ),
+    'xn--hyanger-q1a' => 
+    array (
+    ),
+    'hoylandet' => 
+    array (
+    ),
+    'xn--hylandet-54a' => 
+    array (
+    ),
+    'ha' => 
+    array (
+    ),
+    'xn--h-2fa' => 
+    array (
+    ),
+    'ibestad' => 
+    array (
+    ),
+    'inderoy' => 
+    array (
+    ),
+    'xn--indery-fya' => 
+    array (
+    ),
+    'iveland' => 
+    array (
+    ),
+    'jevnaker' => 
+    array (
+    ),
+    'jondal' => 
+    array (
+    ),
+    'jolster' => 
+    array (
+    ),
+    'xn--jlster-bya' => 
+    array (
+    ),
+    'karasjok' => 
+    array (
+    ),
+    'karasjohka' => 
+    array (
+    ),
+    'xn--krjohka-hwab49j' => 
+    array (
+    ),
+    'karlsoy' => 
+    array (
+    ),
+    'galsa' => 
+    array (
+    ),
+    'xn--gls-elac' => 
+    array (
+    ),
+    'karmoy' => 
+    array (
+    ),
+    'xn--karmy-yua' => 
+    array (
+    ),
+    'kautokeino' => 
+    array (
+    ),
+    'guovdageaidnu' => 
+    array (
+    ),
+    'klepp' => 
+    array (
+    ),
+    'klabu' => 
+    array (
+    ),
+    'xn--klbu-woa' => 
+    array (
+    ),
+    'kongsberg' => 
+    array (
+    ),
+    'kongsvinger' => 
+    array (
+    ),
+    'kragero' => 
+    array (
+    ),
+    'xn--krager-gya' => 
+    array (
+    ),
+    'kristiansand' => 
+    array (
+    ),
+    'kristiansund' => 
+    array (
+    ),
+    'krodsherad' => 
+    array (
+    ),
+    'xn--krdsherad-m8a' => 
+    array (
+    ),
+    'kvalsund' => 
+    array (
+    ),
+    'rahkkeravju' => 
+    array (
+    ),
+    'xn--rhkkervju-01af' => 
+    array (
+    ),
+    'kvam' => 
+    array (
+    ),
+    'kvinesdal' => 
+    array (
+    ),
+    'kvinnherad' => 
+    array (
+    ),
+    'kviteseid' => 
+    array (
+    ),
+    'kvitsoy' => 
+    array (
+    ),
+    'xn--kvitsy-fya' => 
+    array (
+    ),
+    'kvafjord' => 
+    array (
+    ),
+    'xn--kvfjord-nxa' => 
+    array (
+    ),
+    'giehtavuoatna' => 
+    array (
+    ),
+    'kvanangen' => 
+    array (
+    ),
+    'xn--kvnangen-k0a' => 
+    array (
+    ),
+    'navuotna' => 
+    array (
+    ),
+    'xn--nvuotna-hwa' => 
+    array (
+    ),
+    'kafjord' => 
+    array (
+    ),
+    'xn--kfjord-iua' => 
+    array (
+    ),
+    'gaivuotna' => 
+    array (
+    ),
+    'xn--givuotna-8ya' => 
+    array (
+    ),
+    'larvik' => 
+    array (
+    ),
+    'lavangen' => 
+    array (
+    ),
+    'lavagis' => 
+    array (
+    ),
+    'loabat' => 
+    array (
+    ),
+    'xn--loabt-0qa' => 
+    array (
+    ),
+    'lebesby' => 
+    array (
+    ),
+    'davvesiida' => 
+    array (
+    ),
+    'leikanger' => 
+    array (
+    ),
+    'leirfjord' => 
+    array (
+    ),
+    'leka' => 
+    array (
+    ),
+    'leksvik' => 
+    array (
+    ),
+    'lenvik' => 
+    array (
+    ),
+    'leangaviika' => 
+    array (
+    ),
+    'xn--leagaviika-52b' => 
+    array (
+    ),
+    'lesja' => 
+    array (
+    ),
+    'levanger' => 
+    array (
+    ),
+    'lier' => 
+    array (
+    ),
+    'lierne' => 
+    array (
+    ),
+    'lillehammer' => 
+    array (
+    ),
+    'lillesand' => 
+    array (
+    ),
+    'lindesnes' => 
+    array (
+    ),
+    'lindas' => 
+    array (
+    ),
+    'xn--linds-pra' => 
+    array (
+    ),
+    'lom' => 
+    array (
+    ),
+    'loppa' => 
+    array (
+    ),
+    'lahppi' => 
+    array (
+    ),
+    'xn--lhppi-xqa' => 
+    array (
+    ),
+    'lund' => 
+    array (
+    ),
+    'lunner' => 
+    array (
+    ),
+    'luroy' => 
+    array (
+    ),
+    'xn--lury-ira' => 
+    array (
+    ),
+    'luster' => 
+    array (
+    ),
+    'lyngdal' => 
+    array (
+    ),
+    'lyngen' => 
+    array (
+    ),
+    'ivgu' => 
+    array (
+    ),
+    'lardal' => 
+    array (
+    ),
+    'lerdal' => 
+    array (
+    ),
+    'xn--lrdal-sra' => 
+    array (
+    ),
+    'lodingen' => 
+    array (
+    ),
+    'xn--ldingen-q1a' => 
+    array (
+    ),
+    'lorenskog' => 
+    array (
+    ),
+    'xn--lrenskog-54a' => 
+    array (
+    ),
+    'loten' => 
+    array (
+    ),
+    'xn--lten-gra' => 
+    array (
+    ),
+    'malvik' => 
+    array (
+    ),
+    'masoy' => 
+    array (
+    ),
+    'xn--msy-ula0h' => 
+    array (
+    ),
+    'muosat' => 
+    array (
+    ),
+    'xn--muost-0qa' => 
+    array (
+    ),
+    'mandal' => 
+    array (
+    ),
+    'marker' => 
+    array (
+    ),
+    'marnardal' => 
+    array (
+    ),
+    'masfjorden' => 
+    array (
+    ),
+    'meland' => 
+    array (
+    ),
+    'meldal' => 
+    array (
+    ),
+    'melhus' => 
+    array (
+    ),
+    'meloy' => 
+    array (
+    ),
+    'xn--mely-ira' => 
+    array (
+    ),
+    'meraker' => 
+    array (
+    ),
+    'xn--merker-kua' => 
+    array (
+    ),
+    'moareke' => 
+    array (
+    ),
+    'xn--moreke-jua' => 
+    array (
+    ),
+    'midsund' => 
+    array (
+    ),
+    'midtre-gauldal' => 
+    array (
+    ),
+    'modalen' => 
+    array (
+    ),
+    'modum' => 
+    array (
+    ),
+    'molde' => 
+    array (
+    ),
+    'moskenes' => 
+    array (
+    ),
+    'moss' => 
+    array (
+    ),
+    'mosvik' => 
+    array (
+    ),
+    'malselv' => 
+    array (
+    ),
+    'xn--mlselv-iua' => 
+    array (
+    ),
+    'malatvuopmi' => 
+    array (
+    ),
+    'xn--mlatvuopmi-s4a' => 
+    array (
+    ),
+    'namdalseid' => 
+    array (
+    ),
+    'aejrie' => 
+    array (
+    ),
+    'namsos' => 
+    array (
+    ),
+    'namsskogan' => 
+    array (
+    ),
+    'naamesjevuemie' => 
+    array (
+    ),
+    'xn--nmesjevuemie-tcba' => 
+    array (
+    ),
+    'laakesvuemie' => 
+    array (
+    ),
+    'nannestad' => 
+    array (
+    ),
+    'narvik' => 
+    array (
+    ),
+    'narviika' => 
+    array (
+    ),
+    'naustdal' => 
+    array (
+    ),
+    'nedre-eiker' => 
+    array (
+    ),
+    'akershus' => 
+    array (
+      'nes' => 
+      array (
+      ),
+    ),
+    'buskerud' => 
+    array (
+      'nes' => 
+      array (
+      ),
+    ),
+    'nesna' => 
+    array (
+    ),
+    'nesodden' => 
+    array (
+    ),
+    'nesseby' => 
+    array (
+    ),
+    'unjarga' => 
+    array (
+    ),
+    'xn--unjrga-rta' => 
+    array (
+    ),
+    'nesset' => 
+    array (
+    ),
+    'nissedal' => 
+    array (
+    ),
+    'nittedal' => 
+    array (
+    ),
+    'nord-aurdal' => 
+    array (
+    ),
+    'nord-fron' => 
+    array (
+    ),
+    'nord-odal' => 
+    array (
+    ),
+    'norddal' => 
+    array (
+    ),
+    'nordkapp' => 
+    array (
+    ),
+    'davvenjarga' => 
+    array (
+    ),
+    'xn--davvenjrga-y4a' => 
+    array (
+    ),
+    'nordre-land' => 
+    array (
+    ),
+    'nordreisa' => 
+    array (
+    ),
+    'raisa' => 
+    array (
+    ),
+    'xn--risa-5na' => 
+    array (
+    ),
+    'nore-og-uvdal' => 
+    array (
+    ),
+    'notodden' => 
+    array (
+    ),
+    'naroy' => 
+    array (
+    ),
+    'xn--nry-yla5g' => 
+    array (
+    ),
+    'notteroy' => 
+    array (
+    ),
+    'xn--nttery-byae' => 
+    array (
+    ),
+    'odda' => 
+    array (
+    ),
+    'oksnes' => 
+    array (
+    ),
+    'xn--ksnes-uua' => 
+    array (
+    ),
+    'oppdal' => 
+    array (
+    ),
+    'oppegard' => 
+    array (
+    ),
+    'xn--oppegrd-ixa' => 
+    array (
+    ),
+    'orkdal' => 
+    array (
+    ),
+    'orland' => 
+    array (
+    ),
+    'xn--rland-uua' => 
+    array (
+    ),
+    'orskog' => 
+    array (
+    ),
+    'xn--rskog-uua' => 
+    array (
+    ),
+    'orsta' => 
+    array (
+    ),
+    'xn--rsta-fra' => 
+    array (
+    ),
+    'hedmark' => 
+    array (
+      'os' => 
+      array (
+      ),
+      'valer' => 
+      array (
+      ),
+      'xn--vler-qoa' => 
+      array (
+      ),
+    ),
+    'hordaland' => 
+    array (
+      'os' => 
+      array (
+      ),
+    ),
+    'osen' => 
+    array (
+    ),
+    'osteroy' => 
+    array (
+    ),
+    'xn--ostery-fya' => 
+    array (
+    ),
+    'ostre-toten' => 
+    array (
+    ),
+    'xn--stre-toten-zcb' => 
+    array (
+    ),
+    'overhalla' => 
+    array (
+    ),
+    'ovre-eiker' => 
+    array (
+    ),
+    'xn--vre-eiker-k8a' => 
+    array (
+    ),
+    'oyer' => 
+    array (
+    ),
+    'xn--yer-zna' => 
+    array (
+    ),
+    'oygarden' => 
+    array (
+    ),
+    'xn--ygarden-p1a' => 
+    array (
+    ),
+    'oystre-slidre' => 
+    array (
+    ),
+    'xn--ystre-slidre-ujb' => 
+    array (
+    ),
+    'porsanger' => 
+    array (
+    ),
+    'porsangu' => 
+    array (
+    ),
+    'xn--porsgu-sta26f' => 
+    array (
+    ),
+    'porsgrunn' => 
+    array (
+    ),
+    'radoy' => 
+    array (
+    ),
+    'xn--rady-ira' => 
+    array (
+    ),
+    'rakkestad' => 
+    array (
+    ),
+    'rana' => 
+    array (
+    ),
+    'ruovat' => 
+    array (
+    ),
+    'randaberg' => 
+    array (
+    ),
+    'rauma' => 
+    array (
+    ),
+    'rendalen' => 
+    array (
+    ),
+    'rennebu' => 
+    array (
+    ),
+    'rennesoy' => 
+    array (
+    ),
+    'xn--rennesy-v1a' => 
+    array (
+    ),
+    'rindal' => 
+    array (
+    ),
+    'ringebu' => 
+    array (
+    ),
+    'ringerike' => 
+    array (
+    ),
+    'ringsaker' => 
+    array (
+    ),
+    'rissa' => 
+    array (
+    ),
+    'risor' => 
+    array (
+    ),
+    'xn--risr-ira' => 
+    array (
+    ),
+    'roan' => 
+    array (
+    ),
+    'rollag' => 
+    array (
+    ),
+    'rygge' => 
+    array (
+    ),
+    'ralingen' => 
+    array (
+    ),
+    'xn--rlingen-mxa' => 
+    array (
+    ),
+    'rodoy' => 
+    array (
+    ),
+    'xn--rdy-0nab' => 
+    array (
+    ),
+    'romskog' => 
+    array (
+    ),
+    'xn--rmskog-bya' => 
+    array (
+    ),
+    'roros' => 
+    array (
+    ),
+    'xn--rros-gra' => 
+    array (
+    ),
+    'rost' => 
+    array (
+    ),
+    'xn--rst-0na' => 
+    array (
+    ),
+    'royken' => 
+    array (
+    ),
+    'xn--ryken-vua' => 
+    array (
+    ),
+    'royrvik' => 
+    array (
+    ),
+    'xn--ryrvik-bya' => 
+    array (
+    ),
+    'rade' => 
+    array (
+    ),
+    'xn--rde-ula' => 
+    array (
+    ),
+    'salangen' => 
+    array (
+    ),
+    'siellak' => 
+    array (
+    ),
+    'saltdal' => 
+    array (
+    ),
+    'salat' => 
+    array (
+    ),
+    'xn--slt-elab' => 
+    array (
+    ),
+    'xn--slat-5na' => 
+    array (
+    ),
+    'samnanger' => 
+    array (
+    ),
+    'vestfold' => 
+    array (
+      'sande' => 
+      array (
+      ),
+    ),
+    'sandefjord' => 
+    array (
+    ),
+    'sandnes' => 
+    array (
+    ),
+    'sandoy' => 
+    array (
+    ),
+    'xn--sandy-yua' => 
+    array (
+    ),
+    'sarpsborg' => 
+    array (
+    ),
+    'sauda' => 
+    array (
+    ),
+    'sauherad' => 
+    array (
+    ),
+    'sel' => 
+    array (
+    ),
+    'selbu' => 
+    array (
+    ),
+    'selje' => 
+    array (
+    ),
+    'seljord' => 
+    array (
+    ),
+    'sigdal' => 
+    array (
+    ),
+    'siljan' => 
+    array (
+    ),
+    'sirdal' => 
+    array (
+    ),
+    'skaun' => 
+    array (
+    ),
+    'skedsmo' => 
+    array (
+    ),
+    'ski' => 
+    array (
+    ),
+    'skien' => 
+    array (
+    ),
+    'skiptvet' => 
+    array (
+    ),
+    'skjervoy' => 
+    array (
+    ),
+    'xn--skjervy-v1a' => 
+    array (
+    ),
+    'skierva' => 
+    array (
+    ),
+    'xn--skierv-uta' => 
+    array (
+    ),
+    'skjak' => 
+    array (
+    ),
+    'xn--skjk-soa' => 
+    array (
+    ),
+    'skodje' => 
+    array (
+    ),
+    'skanland' => 
+    array (
+    ),
+    'xn--sknland-fxa' => 
+    array (
+    ),
+    'skanit' => 
+    array (
+    ),
+    'xn--sknit-yqa' => 
+    array (
+    ),
+    'smola' => 
+    array (
+    ),
+    'xn--smla-hra' => 
+    array (
+    ),
+    'snillfjord' => 
+    array (
+    ),
+    'snasa' => 
+    array (
+    ),
+    'xn--snsa-roa' => 
+    array (
+    ),
+    'snoasa' => 
+    array (
+    ),
+    'snaase' => 
+    array (
+    ),
+    'xn--snase-nra' => 
+    array (
+    ),
+    'sogndal' => 
+    array (
+    ),
+    'sokndal' => 
+    array (
+    ),
+    'sola' => 
+    array (
+    ),
+    'solund' => 
+    array (
+    ),
+    'songdalen' => 
+    array (
+    ),
+    'sortland' => 
+    array (
+    ),
+    'spydeberg' => 
+    array (
+    ),
+    'stange' => 
+    array (
+    ),
+    'stavanger' => 
+    array (
+    ),
+    'steigen' => 
+    array (
+    ),
+    'steinkjer' => 
+    array (
+    ),
+    'stjordal' => 
+    array (
+    ),
+    'xn--stjrdal-s1a' => 
+    array (
+    ),
+    'stokke' => 
+    array (
+    ),
+    'stor-elvdal' => 
+    array (
+    ),
+    'stord' => 
+    array (
+    ),
+    'stordal' => 
+    array (
+    ),
+    'storfjord' => 
+    array (
+    ),
+    'omasvuotna' => 
+    array (
+    ),
+    'strand' => 
+    array (
+    ),
+    'stranda' => 
+    array (
+    ),
+    'stryn' => 
+    array (
+    ),
+    'sula' => 
+    array (
+    ),
+    'suldal' => 
+    array (
+    ),
+    'sund' => 
+    array (
+    ),
+    'sunndal' => 
+    array (
+    ),
+    'surnadal' => 
+    array (
+    ),
+    'sveio' => 
+    array (
+    ),
+    'svelvik' => 
+    array (
+    ),
+    'sykkylven' => 
+    array (
+    ),
+    'sogne' => 
+    array (
+    ),
+    'xn--sgne-gra' => 
+    array (
+    ),
+    'somna' => 
+    array (
+    ),
+    'xn--smna-gra' => 
+    array (
+    ),
+    'sondre-land' => 
+    array (
+    ),
+    'xn--sndre-land-0cb' => 
+    array (
+    ),
+    'sor-aurdal' => 
+    array (
+    ),
+    'xn--sr-aurdal-l8a' => 
+    array (
+    ),
+    'sor-fron' => 
+    array (
+    ),
+    'xn--sr-fron-q1a' => 
+    array (
+    ),
+    'sor-odal' => 
+    array (
+    ),
+    'xn--sr-odal-q1a' => 
+    array (
+    ),
+    'sor-varanger' => 
+    array (
+    ),
+    'xn--sr-varanger-ggb' => 
+    array (
+    ),
+    'matta-varjjat' => 
+    array (
+    ),
+    'xn--mtta-vrjjat-k7af' => 
+    array (
+    ),
+    'sorfold' => 
+    array (
+    ),
+    'xn--srfold-bya' => 
+    array (
+    ),
+    'sorreisa' => 
+    array (
+    ),
+    'xn--srreisa-q1a' => 
+    array (
+    ),
+    'sorum' => 
+    array (
+    ),
+    'xn--srum-gra' => 
+    array (
+    ),
+    'tana' => 
+    array (
+    ),
+    'deatnu' => 
+    array (
+    ),
+    'time' => 
+    array (
+    ),
+    'tingvoll' => 
+    array (
+    ),
+    'tinn' => 
+    array (
+    ),
+    'tjeldsund' => 
+    array (
+    ),
+    'dielddanuorri' => 
+    array (
+    ),
+    'tjome' => 
+    array (
+    ),
+    'xn--tjme-hra' => 
+    array (
+    ),
+    'tokke' => 
+    array (
+    ),
+    'tolga' => 
+    array (
+    ),
+    'torsken' => 
+    array (
+    ),
+    'tranoy' => 
+    array (
+    ),
+    'xn--trany-yua' => 
+    array (
+    ),
+    'tromso' => 
+    array (
+    ),
+    'xn--troms-zua' => 
+    array (
+    ),
+    'tromsa' => 
+    array (
+    ),
+    'romsa' => 
+    array (
+    ),
+    'trondheim' => 
+    array (
+    ),
+    'troandin' => 
+    array (
+    ),
+    'trysil' => 
+    array (
+    ),
+    'trana' => 
+    array (
+    ),
+    'xn--trna-woa' => 
+    array (
+    ),
+    'trogstad' => 
+    array (
+    ),
+    'xn--trgstad-r1a' => 
+    array (
+    ),
+    'tvedestrand' => 
+    array (
+    ),
+    'tydal' => 
+    array (
+    ),
+    'tynset' => 
+    array (
+    ),
+    'tysfjord' => 
+    array (
+    ),
+    'divtasvuodna' => 
+    array (
+    ),
+    'divttasvuotna' => 
+    array (
+    ),
+    'tysnes' => 
+    array (
+    ),
+    'tysvar' => 
+    array (
+    ),
+    'xn--tysvr-vra' => 
+    array (
+    ),
+    'tonsberg' => 
+    array (
+    ),
+    'xn--tnsberg-q1a' => 
+    array (
+    ),
+    'ullensaker' => 
+    array (
+    ),
+    'ullensvang' => 
+    array (
+    ),
+    'ulvik' => 
+    array (
+    ),
+    'utsira' => 
+    array (
+    ),
+    'vadso' => 
+    array (
+    ),
+    'xn--vads-jra' => 
+    array (
+    ),
+    'cahcesuolo' => 
+    array (
+    ),
+    'xn--hcesuolo-7ya35b' => 
+    array (
+    ),
+    'vaksdal' => 
+    array (
+    ),
+    'valle' => 
+    array (
+    ),
+    'vang' => 
+    array (
+    ),
+    'vanylven' => 
+    array (
+    ),
+    'vardo' => 
+    array (
+    ),
+    'xn--vard-jra' => 
+    array (
+    ),
+    'varggat' => 
+    array (
+    ),
+    'xn--vrggt-xqad' => 
+    array (
+    ),
+    'vefsn' => 
+    array (
+    ),
+    'vaapste' => 
+    array (
+    ),
+    'vega' => 
+    array (
+    ),
+    'vegarshei' => 
+    array (
+    ),
+    'xn--vegrshei-c0a' => 
+    array (
+    ),
+    'vennesla' => 
+    array (
+    ),
+    'verdal' => 
+    array (
+    ),
+    'verran' => 
+    array (
+    ),
+    'vestby' => 
+    array (
+    ),
+    'vestnes' => 
+    array (
+    ),
+    'vestre-slidre' => 
+    array (
+    ),
+    'vestre-toten' => 
+    array (
+    ),
+    'vestvagoy' => 
+    array (
+    ),
+    'xn--vestvgy-ixa6o' => 
+    array (
+    ),
+    'vevelstad' => 
+    array (
+    ),
+    'vik' => 
+    array (
+    ),
+    'vikna' => 
+    array (
+    ),
+    'vindafjord' => 
+    array (
+    ),
+    'volda' => 
+    array (
+    ),
+    'voss' => 
+    array (
+    ),
+    'varoy' => 
+    array (
+    ),
+    'xn--vry-yla5g' => 
+    array (
+    ),
+    'vagan' => 
+    array (
+    ),
+    'xn--vgan-qoa' => 
+    array (
+    ),
+    'voagat' => 
+    array (
+    ),
+    'vagsoy' => 
+    array (
+    ),
+    'xn--vgsy-qoa0j' => 
+    array (
+    ),
+    'vaga' => 
+    array (
+    ),
+    'xn--vg-yiab' => 
+    array (
+    ),
+    'ostfold' => 
+    array (
+      'valer' => 
+      array (
+      ),
+    ),
+    'xn--stfold-9xa' => 
+    array (
+      'xn--vler-qoa' => 
+      array (
+      ),
+    ),
+  ),
+  'np' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'nr' => 
+  array (
+    'biz' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+  ),
+  'nu' => 
+  array (
+  ),
+  'nz' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'cri' => 
+    array (
+    ),
+    'geek' => 
+    array (
+    ),
+    'gen' => 
+    array (
+    ),
+    'govt' => 
+    array (
+    ),
+    'health' => 
+    array (
+    ),
+    'iwi' => 
+    array (
+    ),
+    'kiwi' => 
+    array (
+    ),
+    'maori' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'xn--mori-qsa' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'parliament' => 
+    array (
+    ),
+    'school' => 
+    array (
+    ),
+  ),
+  'om' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'museum' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+  ),
+  'org' => 
+  array (
+  ),
+  'pa' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sld' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'ing' => 
+    array (
+    ),
+    'abo' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+  ),
+  'pe' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'pf' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'pg' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'ph' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'ngo' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'i' => 
+    array (
+    ),
+  ),
+  'pk' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'fam' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'gok' => 
+    array (
+    ),
+    'gon' => 
+    array (
+    ),
+    'gop' => 
+    array (
+    ),
+    'gos' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+  ),
+  'pl' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'aid' => 
+    array (
+    ),
+    'agro' => 
+    array (
+    ),
+    'atm' => 
+    array (
+    ),
+    'auto' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gmina' => 
+    array (
+    ),
+    'gsm' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'mail' => 
+    array (
+    ),
+    'miasta' => 
+    array (
+    ),
+    'media' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'nieruchomosci' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'pc' => 
+    array (
+    ),
+    'powiat' => 
+    array (
+    ),
+    'priv' => 
+    array (
+    ),
+    'realestate' => 
+    array (
+    ),
+    'rel' => 
+    array (
+    ),
+    'sex' => 
+    array (
+    ),
+    'shop' => 
+    array (
+    ),
+    'sklep' => 
+    array (
+    ),
+    'sos' => 
+    array (
+    ),
+    'szkola' => 
+    array (
+    ),
+    'targi' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'tourism' => 
+    array (
+    ),
+    'travel' => 
+    array (
+    ),
+    'turystyka' => 
+    array (
+    ),
+    'gov' => 
+    array (
+      'ap' => 
+      array (
+      ),
+      'ic' => 
+      array (
+      ),
+      'is' => 
+      array (
+      ),
+      'us' => 
+      array (
+      ),
+      'kmpsp' => 
+      array (
+      ),
+      'kppsp' => 
+      array (
+      ),
+      'kwpsp' => 
+      array (
+      ),
+      'psp' => 
+      array (
+      ),
+      'wskr' => 
+      array (
+      ),
+      'kwp' => 
+      array (
+      ),
+      'mw' => 
+      array (
+      ),
+      'ug' => 
+      array (
+      ),
+      'um' => 
+      array (
+      ),
+      'umig' => 
+      array (
+      ),
+      'ugim' => 
+      array (
+      ),
+      'upow' => 
+      array (
+      ),
+      'uw' => 
+      array (
+      ),
+      'starostwo' => 
+      array (
+      ),
+      'pa' => 
+      array (
+      ),
+      'po' => 
+      array (
+      ),
+      'psse' => 
+      array (
+      ),
+      'pup' => 
+      array (
+      ),
+      'rzgw' => 
+      array (
+      ),
+      'sa' => 
+      array (
+      ),
+      'so' => 
+      array (
+      ),
+      'sr' => 
+      array (
+      ),
+      'wsa' => 
+      array (
+      ),
+      'sko' => 
+      array (
+      ),
+      'uzs' => 
+      array (
+      ),
+      'wiih' => 
+      array (
+      ),
+      'winb' => 
+      array (
+      ),
+      'pinb' => 
+      array (
+      ),
+      'wios' => 
+      array (
+      ),
+      'witd' => 
+      array (
+      ),
+      'wzmiuw' => 
+      array (
+      ),
+      'piw' => 
+      array (
+      ),
+      'wiw' => 
+      array (
+      ),
+      'griw' => 
+      array (
+      ),
+      'wif' => 
+      array (
+      ),
+      'oum' => 
+      array (
+      ),
+      'sdn' => 
+      array (
+      ),
+      'zp' => 
+      array (
+      ),
+      'uppo' => 
+      array (
+      ),
+      'mup' => 
+      array (
+      ),
+      'wuoz' => 
+      array (
+      ),
+      'konsulat' => 
+      array (
+      ),
+      'oirm' => 
+      array (
+      ),
+    ),
+    'augustow' => 
+    array (
+    ),
+    'babia-gora' => 
+    array (
+    ),
+    'bedzin' => 
+    array (
+    ),
+    'beskidy' => 
+    array (
+    ),
+    'bialowieza' => 
+    array (
+    ),
+    'bialystok' => 
+    array (
+    ),
+    'bielawa' => 
+    array (
+    ),
+    'bieszczady' => 
+    array (
+    ),
+    'boleslawiec' => 
+    array (
+    ),
+    'bydgoszcz' => 
+    array (
+    ),
+    'bytom' => 
+    array (
+    ),
+    'cieszyn' => 
+    array (
+    ),
+    'czeladz' => 
+    array (
+    ),
+    'czest' => 
+    array (
+    ),
+    'dlugoleka' => 
+    array (
+    ),
+    'elblag' => 
+    array (
+    ),
+    'elk' => 
+    array (
+    ),
+    'glogow' => 
+    array (
+    ),
+    'gniezno' => 
+    array (
+    ),
+    'gorlice' => 
+    array (
+    ),
+    'grajewo' => 
+    array (
+    ),
+    'ilawa' => 
+    array (
+    ),
+    'jaworzno' => 
+    array (
+    ),
+    'jelenia-gora' => 
+    array (
+    ),
+    'jgora' => 
+    array (
+    ),
+    'kalisz' => 
+    array (
+    ),
+    'kazimierz-dolny' => 
+    array (
+    ),
+    'karpacz' => 
+    array (
+    ),
+    'kartuzy' => 
+    array (
+    ),
+    'kaszuby' => 
+    array (
+    ),
+    'katowice' => 
+    array (
+    ),
+    'kepno' => 
+    array (
+    ),
+    'ketrzyn' => 
+    array (
+    ),
+    'klodzko' => 
+    array (
+    ),
+    'kobierzyce' => 
+    array (
+    ),
+    'kolobrzeg' => 
+    array (
+    ),
+    'konin' => 
+    array (
+    ),
+    'konskowola' => 
+    array (
+    ),
+    'kutno' => 
+    array (
+    ),
+    'lapy' => 
+    array (
+    ),
+    'lebork' => 
+    array (
+    ),
+    'legnica' => 
+    array (
+    ),
+    'lezajsk' => 
+    array (
+    ),
+    'limanowa' => 
+    array (
+    ),
+    'lomza' => 
+    array (
+    ),
+    'lowicz' => 
+    array (
+    ),
+    'lubin' => 
+    array (
+    ),
+    'lukow' => 
+    array (
+    ),
+    'malbork' => 
+    array (
+    ),
+    'malopolska' => 
+    array (
+    ),
+    'mazowsze' => 
+    array (
+    ),
+    'mazury' => 
+    array (
+    ),
+    'mielec' => 
+    array (
+    ),
+    'mielno' => 
+    array (
+    ),
+    'mragowo' => 
+    array (
+    ),
+    'naklo' => 
+    array (
+    ),
+    'nowaruda' => 
+    array (
+    ),
+    'nysa' => 
+    array (
+    ),
+    'olawa' => 
+    array (
+    ),
+    'olecko' => 
+    array (
+    ),
+    'olkusz' => 
+    array (
+    ),
+    'olsztyn' => 
+    array (
+    ),
+    'opoczno' => 
+    array (
+    ),
+    'opole' => 
+    array (
+    ),
+    'ostroda' => 
+    array (
+    ),
+    'ostroleka' => 
+    array (
+    ),
+    'ostrowiec' => 
+    array (
+    ),
+    'ostrowwlkp' => 
+    array (
+    ),
+    'pila' => 
+    array (
+    ),
+    'pisz' => 
+    array (
+    ),
+    'podhale' => 
+    array (
+    ),
+    'podlasie' => 
+    array (
+    ),
+    'polkowice' => 
+    array (
+    ),
+    'pomorze' => 
+    array (
+    ),
+    'pomorskie' => 
+    array (
+    ),
+    'prochowice' => 
+    array (
+    ),
+    'pruszkow' => 
+    array (
+    ),
+    'przeworsk' => 
+    array (
+    ),
+    'pulawy' => 
+    array (
+    ),
+    'radom' => 
+    array (
+    ),
+    'rawa-maz' => 
+    array (
+    ),
+    'rybnik' => 
+    array (
+    ),
+    'rzeszow' => 
+    array (
+    ),
+    'sanok' => 
+    array (
+    ),
+    'sejny' => 
+    array (
+    ),
+    'slask' => 
+    array (
+    ),
+    'slupsk' => 
+    array (
+    ),
+    'sosnowiec' => 
+    array (
+    ),
+    'stalowa-wola' => 
+    array (
+    ),
+    'skoczow' => 
+    array (
+    ),
+    'starachowice' => 
+    array (
+    ),
+    'stargard' => 
+    array (
+    ),
+    'suwalki' => 
+    array (
+    ),
+    'swidnica' => 
+    array (
+    ),
+    'swiebodzin' => 
+    array (
+    ),
+    'swinoujscie' => 
+    array (
+    ),
+    'szczecin' => 
+    array (
+    ),
+    'szczytno' => 
+    array (
+    ),
+    'tarnobrzeg' => 
+    array (
+    ),
+    'tgory' => 
+    array (
+    ),
+    'turek' => 
+    array (
+    ),
+    'tychy' => 
+    array (
+    ),
+    'ustka' => 
+    array (
+    ),
+    'walbrzych' => 
+    array (
+    ),
+    'warmia' => 
+    array (
+    ),
+    'warszawa' => 
+    array (
+    ),
+    'waw' => 
+    array (
+    ),
+    'wegrow' => 
+    array (
+    ),
+    'wielun' => 
+    array (
+    ),
+    'wlocl' => 
+    array (
+    ),
+    'wloclawek' => 
+    array (
+    ),
+    'wodzislaw' => 
+    array (
+    ),
+    'wolomin' => 
+    array (
+    ),
+    'wroclaw' => 
+    array (
+    ),
+    'zachpomor' => 
+    array (
+    ),
+    'zagan' => 
+    array (
+    ),
+    'zarow' => 
+    array (
+    ),
+    'zgora' => 
+    array (
+    ),
+    'zgorzelec' => 
+    array (
+    ),
+  ),
+  'pm' => 
+  array (
+  ),
+  'pn' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'post' => 
+  array (
+  ),
+  'pr' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'isla' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'est' => 
+    array (
+    ),
+    'prof' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+  ),
+  'pro' => 
+  array (
+    'aaa' => 
+    array (
+    ),
+    'aca' => 
+    array (
+    ),
+    'acct' => 
+    array (
+    ),
+    'avocat' => 
+    array (
+    ),
+    'bar' => 
+    array (
+    ),
+    'cpa' => 
+    array (
+    ),
+    'eng' => 
+    array (
+    ),
+    'jur' => 
+    array (
+    ),
+    'law' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'recht' => 
+    array (
+    ),
+  ),
+  'ps' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'sec' => 
+    array (
+    ),
+    'plo' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+  ),
+  'pt' => 
+  array (
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'publ' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'nome' => 
+    array (
+    ),
+  ),
+  'pw' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'ne' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'ed' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'belau' => 
+    array (
+    ),
+  ),
+  'py' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'qa' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+  ),
+  're' => 
+  array (
+    'asso' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+  ),
+  'ro' => 
+  array (
+    'arts' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'nt' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'rec' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'www' => 
+    array (
+    ),
+  ),
+  'rs' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'ru' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'pp' => 
+    array (
+    ),
+    'adygeya' => 
+    array (
+    ),
+    'altai' => 
+    array (
+    ),
+    'amur' => 
+    array (
+    ),
+    'arkhangelsk' => 
+    array (
+    ),
+    'astrakhan' => 
+    array (
+    ),
+    'bashkiria' => 
+    array (
+    ),
+    'belgorod' => 
+    array (
+    ),
+    'bir' => 
+    array (
+    ),
+    'bryansk' => 
+    array (
+    ),
+    'buryatia' => 
+    array (
+    ),
+    'cbg' => 
+    array (
+    ),
+    'chel' => 
+    array (
+    ),
+    'chelyabinsk' => 
+    array (
+    ),
+    'chita' => 
+    array (
+    ),
+    'chukotka' => 
+    array (
+    ),
+    'chuvashia' => 
+    array (
+    ),
+    'dagestan' => 
+    array (
+    ),
+    'dudinka' => 
+    array (
+    ),
+    'e-burg' => 
+    array (
+    ),
+    'grozny' => 
+    array (
+    ),
+    'irkutsk' => 
+    array (
+    ),
+    'ivanovo' => 
+    array (
+    ),
+    'izhevsk' => 
+    array (
+    ),
+    'jar' => 
+    array (
+    ),
+    'joshkar-ola' => 
+    array (
+    ),
+    'kalmykia' => 
+    array (
+    ),
+    'kaluga' => 
+    array (
+    ),
+    'kamchatka' => 
+    array (
+    ),
+    'karelia' => 
+    array (
+    ),
+    'kazan' => 
+    array (
+    ),
+    'kchr' => 
+    array (
+    ),
+    'kemerovo' => 
+    array (
+    ),
+    'khabarovsk' => 
+    array (
+    ),
+    'khakassia' => 
+    array (
+    ),
+    'khv' => 
+    array (
+    ),
+    'kirov' => 
+    array (
+    ),
+    'koenig' => 
+    array (
+    ),
+    'komi' => 
+    array (
+    ),
+    'kostroma' => 
+    array (
+    ),
+    'krasnoyarsk' => 
+    array (
+    ),
+    'kuban' => 
+    array (
+    ),
+    'kurgan' => 
+    array (
+    ),
+    'kursk' => 
+    array (
+    ),
+    'lipetsk' => 
+    array (
+    ),
+    'magadan' => 
+    array (
+    ),
+    'mari' => 
+    array (
+    ),
+    'mari-el' => 
+    array (
+    ),
+    'marine' => 
+    array (
+    ),
+    'mordovia' => 
+    array (
+    ),
+    'msk' => 
+    array (
+    ),
+    'murmansk' => 
+    array (
+    ),
+    'nalchik' => 
+    array (
+    ),
+    'nnov' => 
+    array (
+    ),
+    'nov' => 
+    array (
+    ),
+    'novosibirsk' => 
+    array (
+    ),
+    'nsk' => 
+    array (
+    ),
+    'omsk' => 
+    array (
+    ),
+    'orenburg' => 
+    array (
+    ),
+    'oryol' => 
+    array (
+    ),
+    'palana' => 
+    array (
+    ),
+    'penza' => 
+    array (
+    ),
+    'perm' => 
+    array (
+    ),
+    'ptz' => 
+    array (
+    ),
+    'rnd' => 
+    array (
+    ),
+    'ryazan' => 
+    array (
+    ),
+    'sakhalin' => 
+    array (
+    ),
+    'samara' => 
+    array (
+    ),
+    'saratov' => 
+    array (
+    ),
+    'simbirsk' => 
+    array (
+    ),
+    'smolensk' => 
+    array (
+    ),
+    'spb' => 
+    array (
+    ),
+    'stavropol' => 
+    array (
+    ),
+    'stv' => 
+    array (
+    ),
+    'surgut' => 
+    array (
+    ),
+    'tambov' => 
+    array (
+    ),
+    'tatarstan' => 
+    array (
+    ),
+    'tom' => 
+    array (
+    ),
+    'tomsk' => 
+    array (
+    ),
+    'tsaritsyn' => 
+    array (
+    ),
+    'tsk' => 
+    array (
+    ),
+    'tula' => 
+    array (
+    ),
+    'tuva' => 
+    array (
+    ),
+    'tver' => 
+    array (
+    ),
+    'tyumen' => 
+    array (
+    ),
+    'udm' => 
+    array (
+    ),
+    'udmurtia' => 
+    array (
+    ),
+    'ulan-ude' => 
+    array (
+    ),
+    'vladikavkaz' => 
+    array (
+    ),
+    'vladimir' => 
+    array (
+    ),
+    'vladivostok' => 
+    array (
+    ),
+    'volgograd' => 
+    array (
+    ),
+    'vologda' => 
+    array (
+    ),
+    'voronezh' => 
+    array (
+    ),
+    'vrn' => 
+    array (
+    ),
+    'vyatka' => 
+    array (
+    ),
+    'yakutia' => 
+    array (
+    ),
+    'yamal' => 
+    array (
+    ),
+    'yaroslavl' => 
+    array (
+    ),
+    'yekaterinburg' => 
+    array (
+    ),
+    'yuzhno-sakhalinsk' => 
+    array (
+    ),
+    'amursk' => 
+    array (
+    ),
+    'baikal' => 
+    array (
+    ),
+    'cmw' => 
+    array (
+    ),
+    'fareast' => 
+    array (
+    ),
+    'jamal' => 
+    array (
+    ),
+    'kms' => 
+    array (
+    ),
+    'k-uralsk' => 
+    array (
+    ),
+    'kustanai' => 
+    array (
+    ),
+    'kuzbass' => 
+    array (
+    ),
+    'mytis' => 
+    array (
+    ),
+    'nakhodka' => 
+    array (
+    ),
+    'nkz' => 
+    array (
+    ),
+    'norilsk' => 
+    array (
+    ),
+    'oskol' => 
+    array (
+    ),
+    'pyatigorsk' => 
+    array (
+    ),
+    'rubtsovsk' => 
+    array (
+    ),
+    'snz' => 
+    array (
+    ),
+    'syzran' => 
+    array (
+    ),
+    'vdonsk' => 
+    array (
+    ),
+    'zgrad' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'test' => 
+    array (
+    ),
+  ),
+  'rw' => 
+  array (
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+  ),
+  'sa' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'pub' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+  ),
+  'sb' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'sc' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'sd' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+  ),
+  'se' => 
+  array (
+    'a' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'b' => 
+    array (
+    ),
+    'bd' => 
+    array (
+    ),
+    'brand' => 
+    array (
+    ),
+    'c' => 
+    array (
+    ),
+    'd' => 
+    array (
+    ),
+    'e' => 
+    array (
+    ),
+    'f' => 
+    array (
+    ),
+    'fh' => 
+    array (
+    ),
+    'fhsk' => 
+    array (
+    ),
+    'fhv' => 
+    array (
+    ),
+    'g' => 
+    array (
+    ),
+    'h' => 
+    array (
+    ),
+    'i' => 
+    array (
+    ),
+    'k' => 
+    array (
+    ),
+    'komforb' => 
+    array (
+    ),
+    'kommunalforbund' => 
+    array (
+    ),
+    'komvux' => 
+    array (
+    ),
+    'l' => 
+    array (
+    ),
+    'lanbib' => 
+    array (
+    ),
+    'm' => 
+    array (
+    ),
+    'n' => 
+    array (
+    ),
+    'naturbruksgymn' => 
+    array (
+    ),
+    'o' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'p' => 
+    array (
+    ),
+    'parti' => 
+    array (
+    ),
+    'pp' => 
+    array (
+    ),
+    'press' => 
+    array (
+    ),
+    'r' => 
+    array (
+    ),
+    's' => 
+    array (
+    ),
+    't' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'u' => 
+    array (
+    ),
+    'w' => 
+    array (
+    ),
+    'x' => 
+    array (
+    ),
+    'y' => 
+    array (
+    ),
+    'z' => 
+    array (
+    ),
+  ),
+  'sg' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'per' => 
+    array (
+    ),
+  ),
+  'sh' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'si' => 
+  array (
+  ),
+  'sj' => 
+  array (
+  ),
+  'sk' => 
+  array (
+  ),
+  'sl' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'sm' => 
+  array (
+  ),
+  'sn' => 
+  array (
+    'art' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gouv' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'perso' => 
+    array (
+    ),
+    'univ' => 
+    array (
+    ),
+  ),
+  'so' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'sr' => 
+  array (
+  ),
+  'st' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'consulado' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'embaixada' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'principe' => 
+    array (
+    ),
+    'saotome' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+  ),
+  'su' => 
+  array (
+    'adygeya' => 
+    array (
+    ),
+    'arkhangelsk' => 
+    array (
+    ),
+    'balashov' => 
+    array (
+    ),
+    'bashkiria' => 
+    array (
+    ),
+    'bryansk' => 
+    array (
+    ),
+    'dagestan' => 
+    array (
+    ),
+    'grozny' => 
+    array (
+    ),
+    'ivanovo' => 
+    array (
+    ),
+    'kalmykia' => 
+    array (
+    ),
+    'kaluga' => 
+    array (
+    ),
+    'karelia' => 
+    array (
+    ),
+    'khakassia' => 
+    array (
+    ),
+    'krasnodar' => 
+    array (
+    ),
+    'kurgan' => 
+    array (
+    ),
+    'lenug' => 
+    array (
+    ),
+    'mordovia' => 
+    array (
+    ),
+    'msk' => 
+    array (
+    ),
+    'murmansk' => 
+    array (
+    ),
+    'nalchik' => 
+    array (
+    ),
+    'nov' => 
+    array (
+    ),
+    'obninsk' => 
+    array (
+    ),
+    'penza' => 
+    array (
+    ),
+    'pokrovsk' => 
+    array (
+    ),
+    'sochi' => 
+    array (
+    ),
+    'spb' => 
+    array (
+    ),
+    'togliatti' => 
+    array (
+    ),
+    'troitsk' => 
+    array (
+    ),
+    'tula' => 
+    array (
+    ),
+    'tuva' => 
+    array (
+    ),
+    'vladikavkaz' => 
+    array (
+    ),
+    'vladimir' => 
+    array (
+    ),
+    'vologda' => 
+    array (
+    ),
+  ),
+  'sv' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'red' => 
+    array (
+    ),
+  ),
+  'sx' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'sy' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'sz' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'tc' => 
+  array (
+  ),
+  'td' => 
+  array (
+  ),
+  'tel' => 
+  array (
+  ),
+  'tf' => 
+  array (
+  ),
+  'tg' => 
+  array (
+  ),
+  'th' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'mi' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+  ),
+  'tj' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'nic' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'test' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'tk' => 
+  array (
+  ),
+  'tl' => 
+  array (
+    'gov' => 
+    array (
+    ),
+  ),
+  'tm' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'tn' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'ens' => 
+    array (
+    ),
+    'fin' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'ind' => 
+    array (
+    ),
+    'intl' => 
+    array (
+    ),
+    'nat' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'perso' => 
+    array (
+    ),
+    'tourism' => 
+    array (
+    ),
+    'edunet' => 
+    array (
+    ),
+    'rnrt' => 
+    array (
+    ),
+    'rns' => 
+    array (
+    ),
+    'rnu' => 
+    array (
+    ),
+    'mincom' => 
+    array (
+    ),
+    'agrinet' => 
+    array (
+    ),
+    'defense' => 
+    array (
+    ),
+    'turen' => 
+    array (
+    ),
+  ),
+  'to' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+  ),
+  'tr' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+    'gen' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+    'av' => 
+    array (
+    ),
+    'dr' => 
+    array (
+    ),
+    'bbs' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'tel' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'bel' => 
+    array (
+    ),
+    'pol' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'k12' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'kep' => 
+    array (
+    ),
+    'nc' => 
+    array (
+      'gov' => 
+      array (
+      ),
+    ),
+  ),
+  'travel' => 
+  array (
+  ),
+  'tt' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'coop' => 
+    array (
+    ),
+    'jobs' => 
+    array (
+    ),
+    'mobi' => 
+    array (
+    ),
+    'travel' => 
+    array (
+    ),
+    'museum' => 
+    array (
+    ),
+    'aero' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'tv' => 
+  array (
+  ),
+  'tw' => 
+  array (
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'idv' => 
+    array (
+    ),
+    'game' => 
+    array (
+    ),
+    'ebiz' => 
+    array (
+    ),
+    'club' => 
+    array (
+    ),
+    'xn--zf0ao64a' => 
+    array (
+    ),
+    'xn--uc0atv' => 
+    array (
+    ),
+    'xn--czrw28b' => 
+    array (
+    ),
+  ),
+  'tz' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'hotel' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'me' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'mobi' => 
+    array (
+    ),
+    'ne' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'sc' => 
+    array (
+    ),
+    'tv' => 
+    array (
+    ),
+  ),
+  'ua' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'cherkassy' => 
+    array (
+    ),
+    'cherkasy' => 
+    array (
+    ),
+    'chernigov' => 
+    array (
+    ),
+    'chernihiv' => 
+    array (
+    ),
+    'chernivtsi' => 
+    array (
+    ),
+    'chernovtsy' => 
+    array (
+    ),
+    'ck' => 
+    array (
+    ),
+    'cn' => 
+    array (
+    ),
+    'cr' => 
+    array (
+    ),
+    'crimea' => 
+    array (
+    ),
+    'cv' => 
+    array (
+    ),
+    'dn' => 
+    array (
+    ),
+    'dnepropetrovsk' => 
+    array (
+    ),
+    'dnipropetrovsk' => 
+    array (
+    ),
+    'dominic' => 
+    array (
+    ),
+    'donetsk' => 
+    array (
+    ),
+    'dp' => 
+    array (
+    ),
+    'if' => 
+    array (
+    ),
+    'ivano-frankivsk' => 
+    array (
+    ),
+    'kh' => 
+    array (
+    ),
+    'kharkiv' => 
+    array (
+    ),
+    'kharkov' => 
+    array (
+    ),
+    'kherson' => 
+    array (
+    ),
+    'khmelnitskiy' => 
+    array (
+    ),
+    'khmelnytskyi' => 
+    array (
+    ),
+    'kiev' => 
+    array (
+    ),
+    'kirovograd' => 
+    array (
+    ),
+    'km' => 
+    array (
+    ),
+    'kr' => 
+    array (
+    ),
+    'krym' => 
+    array (
+    ),
+    'ks' => 
+    array (
+    ),
+    'kv' => 
+    array (
+    ),
+    'kyiv' => 
+    array (
+    ),
+    'lg' => 
+    array (
+    ),
+    'lt' => 
+    array (
+    ),
+    'lugansk' => 
+    array (
+    ),
+    'lutsk' => 
+    array (
+    ),
+    'lv' => 
+    array (
+    ),
+    'lviv' => 
+    array (
+    ),
+    'mk' => 
+    array (
+    ),
+    'mykolaiv' => 
+    array (
+    ),
+    'nikolaev' => 
+    array (
+    ),
+    'od' => 
+    array (
+    ),
+    'odesa' => 
+    array (
+    ),
+    'odessa' => 
+    array (
+    ),
+    'pl' => 
+    array (
+    ),
+    'poltava' => 
+    array (
+    ),
+    'rivne' => 
+    array (
+    ),
+    'rovno' => 
+    array (
+    ),
+    'rv' => 
+    array (
+    ),
+    'sb' => 
+    array (
+    ),
+    'sebastopol' => 
+    array (
+    ),
+    'sevastopol' => 
+    array (
+    ),
+    'sm' => 
+    array (
+    ),
+    'sumy' => 
+    array (
+    ),
+    'te' => 
+    array (
+    ),
+    'ternopil' => 
+    array (
+    ),
+    'uz' => 
+    array (
+    ),
+    'uzhgorod' => 
+    array (
+    ),
+    'vinnica' => 
+    array (
+    ),
+    'vinnytsia' => 
+    array (
+    ),
+    'vn' => 
+    array (
+    ),
+    'volyn' => 
+    array (
+    ),
+    'yalta' => 
+    array (
+    ),
+    'zaporizhzhe' => 
+    array (
+    ),
+    'zaporizhzhia' => 
+    array (
+    ),
+    'zhitomir' => 
+    array (
+    ),
+    'zhytomyr' => 
+    array (
+    ),
+    'zp' => 
+    array (
+    ),
+    'zt' => 
+    array (
+    ),
+  ),
+  'ug' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'or' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'sc' => 
+    array (
+    ),
+    'go' => 
+    array (
+    ),
+    'ne' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'uk' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'ltd' => 
+    array (
+    ),
+    'me' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'nhs' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'plc' => 
+    array (
+    ),
+    'police' => 
+    array (
+    ),
+    'sch' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+  ),
+  'us' => 
+  array (
+    'dni' => 
+    array (
+    ),
+    'fed' => 
+    array (
+    ),
+    'isa' => 
+    array (
+    ),
+    'kids' => 
+    array (
+    ),
+    'nsn' => 
+    array (
+    ),
+    'ak' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'al' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ar' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'as' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'az' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ca' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'co' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ct' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'dc' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'de' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+    ),
+    'fl' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ga' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'gu' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'hi' => 
+    array (
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ia' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'id' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'il' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'in' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ks' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ky' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'la' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ma' => 
+    array (
+      'k12' => 
+      array (
+        'pvt' => 
+        array (
+        ),
+        'chtr' => 
+        array (
+        ),
+        'paroch' => 
+        array (
+        ),
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'md' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'me' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'mi' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'mn' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'mo' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ms' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'mt' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nc' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nd' => 
+    array (
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ne' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nh' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nj' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nm' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'nv' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ny' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'oh' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ok' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'or' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'pa' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'pr' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ri' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'sc' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'sd' => 
+    array (
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'tn' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'tx' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'ut' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'vi' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'vt' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'va' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'wa' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'wi' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+    'wv' => 
+    array (
+      'cc' => 
+      array (
+      ),
+    ),
+    'wy' => 
+    array (
+      'k12' => 
+      array (
+      ),
+      'cc' => 
+      array (
+      ),
+      'lib' => 
+      array (
+      ),
+    ),
+  ),
+  'uy' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gub' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'uz' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'va' => 
+  array (
+  ),
+  'vc' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  've' => 
+  array (
+    'arts' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'e12' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'gob' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'rec' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+    'tec' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'vg' => 
+  array (
+  ),
+  'vi' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'k12' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'vn' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'int' => 
+    array (
+    ),
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'name' => 
+    array (
+    ),
+    'pro' => 
+    array (
+    ),
+    'health' => 
+    array (
+    ),
+  ),
+  'vu' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+  ),
+  'wf' => 
+  array (
+  ),
+  'ws' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'yt' => 
+  array (
+  ),
+  'xn--mgbaam7a8h' => 
+  array (
+  ),
+  'xn--y9a3aq' => 
+  array (
+  ),
+  'xn--54b7fta0cc' => 
+  array (
+  ),
+  'xn--90ais' => 
+  array (
+  ),
+  'xn--fiqs8s' => 
+  array (
+  ),
+  'xn--fiqz9s' => 
+  array (
+  ),
+  'xn--lgbbat1ad8j' => 
+  array (
+  ),
+  'xn--wgbh1c' => 
+  array (
+  ),
+  'xn--e1a4c' => 
+  array (
+  ),
+  'xn--node' => 
+  array (
+  ),
+  'xn--qxam' => 
+  array (
+  ),
+  'xn--j6w193g' => 
+  array (
+  ),
+  'xn--h2brj9c' => 
+  array (
+  ),
+  'xn--mgbbh1a71e' => 
+  array (
+  ),
+  'xn--fpcrj9c3d' => 
+  array (
+  ),
+  'xn--gecrj9c' => 
+  array (
+  ),
+  'xn--s9brj9c' => 
+  array (
+  ),
+  'xn--45brj9c' => 
+  array (
+  ),
+  'xn--xkc2dl3a5ee0h' => 
+  array (
+  ),
+  'xn--mgba3a4f16a' => 
+  array (
+  ),
+  'xn--mgba3a4fra' => 
+  array (
+  ),
+  'xn--mgbtx2b' => 
+  array (
+  ),
+  'xn--mgbayh7gpa' => 
+  array (
+  ),
+  'xn--3e0b707e' => 
+  array (
+  ),
+  'xn--80ao21a' => 
+  array (
+  ),
+  'xn--fzc2c9e2c' => 
+  array (
+  ),
+  'xn--xkc2al3hye2a' => 
+  array (
+  ),
+  'xn--mgbc0a9azcg' => 
+  array (
+  ),
+  'xn--d1alf' => 
+  array (
+  ),
+  'xn--l1acc' => 
+  array (
+  ),
+  'xn--mix891f' => 
+  array (
+  ),
+  'xn--mix082f' => 
+  array (
+  ),
+  'xn--mgbx4cd0ab' => 
+  array (
+  ),
+  'xn--mgb9awbf' => 
+  array (
+  ),
+  'xn--mgbai9azgqp6j' => 
+  array (
+  ),
+  'xn--mgbai9a5eva00b' => 
+  array (
+  ),
+  'xn--ygbi2ammx' => 
+  array (
+  ),
+  'xn--90a3ac' => 
+  array (
+    'xn--o1ac' => 
+    array (
+    ),
+    'xn--c1avg' => 
+    array (
+    ),
+    'xn--90azh' => 
+    array (
+    ),
+    'xn--d1at' => 
+    array (
+    ),
+    'xn--o1ach' => 
+    array (
+    ),
+    'xn--80au' => 
+    array (
+    ),
+  ),
+  'xn--p1ai' => 
+  array (
+  ),
+  'xn--wgbl6a' => 
+  array (
+  ),
+  'xn--mgberp4a5d4ar' => 
+  array (
+  ),
+  'xn--mgberp4a5d4a87g' => 
+  array (
+  ),
+  'xn--mgbqly7c0a67fbc' => 
+  array (
+  ),
+  'xn--mgbqly7cvafr' => 
+  array (
+  ),
+  'xn--mgbpl2fh' => 
+  array (
+  ),
+  'xn--yfro4i67o' => 
+  array (
+  ),
+  'xn--clchc0ea0b2g2a9gcd' => 
+  array (
+  ),
+  'xn--ogbpf8fl' => 
+  array (
+  ),
+  'xn--mgbtf8fl' => 
+  array (
+  ),
+  'xn--o3cw4h' => 
+  array (
+  ),
+  'xn--pgbs0dh' => 
+  array (
+  ),
+  'xn--kpry57d' => 
+  array (
+  ),
+  'xn--kprw13d' => 
+  array (
+  ),
+  'xn--nnx388a' => 
+  array (
+  ),
+  'xn--j1amh' => 
+  array (
+  ),
+  'xn--mgb2ddes' => 
+  array (
+  ),
+  'xxx' => 
+  array (
+  ),
+  'ye' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'za' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'agric' => 
+    array (
+    ),
+    'alt' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'grondar' => 
+    array (
+    ),
+    'law' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'ngo' => 
+    array (
+    ),
+    'nis' => 
+    array (
+    ),
+    'nom' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'school' => 
+    array (
+    ),
+    'tm' => 
+    array (
+    ),
+    'web' => 
+    array (
+    ),
+  ),
+  'zm' => 
+  array (
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
+    array (
+    ),
+  ),
+  'zw' => 
+  array (
+    '*' => 
+    array (
+    ),
+  ),
+  'aaa' => 
+  array (
+  ),
+  'aarp' => 
+  array (
+  ),
+  'abarth' => 
+  array (
+  ),
+  'abb' => 
+  array (
+  ),
+  'abbott' => 
+  array (
+  ),
+  'abbvie' => 
+  array (
+  ),
+  'abc' => 
+  array (
+  ),
+  'able' => 
+  array (
+  ),
+  'abogado' => 
+  array (
+  ),
+  'abudhabi' => 
+  array (
+  ),
+  'academy' => 
+  array (
+  ),
+  'accenture' => 
+  array (
+  ),
+  'accountant' => 
+  array (
+  ),
+  'accountants' => 
+  array (
+  ),
+  'aco' => 
+  array (
+  ),
+  'active' => 
+  array (
+  ),
+  'actor' => 
+  array (
+  ),
+  'adac' => 
+  array (
+  ),
+  'ads' => 
+  array (
+  ),
+  'adult' => 
+  array (
+  ),
+  'aeg' => 
+  array (
+  ),
+  'aetna' => 
+  array (
+  ),
+  'afamilycompany' => 
+  array (
+  ),
+  'afl' => 
+  array (
+  ),
+  'africa' => 
+  array (
+  ),
+  'agakhan' => 
+  array (
+  ),
+  'agency' => 
+  array (
+  ),
+  'aig' => 
+  array (
+  ),
+  'aigo' => 
+  array (
+  ),
+  'airbus' => 
+  array (
+  ),
+  'airforce' => 
+  array (
+  ),
+  'airtel' => 
+  array (
+  ),
+  'akdn' => 
+  array (
+  ),
+  'alfaromeo' => 
+  array (
+  ),
+  'alibaba' => 
+  array (
+  ),
+  'alipay' => 
+  array (
+  ),
+  'allfinanz' => 
+  array (
+  ),
+  'allstate' => 
+  array (
+  ),
+  'ally' => 
+  array (
+  ),
+  'alsace' => 
+  array (
+  ),
+  'alstom' => 
+  array (
+  ),
+  'americanexpress' => 
+  array (
+  ),
+  'americanfamily' => 
+  array (
+  ),
+  'amex' => 
+  array (
+  ),
+  'amfam' => 
+  array (
+  ),
+  'amica' => 
+  array (
+  ),
+  'amsterdam' => 
+  array (
+  ),
+  'analytics' => 
+  array (
+  ),
+  'android' => 
+  array (
+  ),
+  'anquan' => 
+  array (
+  ),
+  'anz' => 
+  array (
+  ),
+  'aol' => 
+  array (
+  ),
+  'apartments' => 
+  array (
+  ),
+  'app' => 
+  array (
+  ),
+  'apple' => 
+  array (
+  ),
+  'aquarelle' => 
+  array (
+  ),
+  'arab' => 
+  array (
+  ),
+  'aramco' => 
+  array (
+  ),
+  'archi' => 
+  array (
+  ),
+  'army' => 
+  array (
+  ),
+  'art' => 
+  array (
+  ),
+  'arte' => 
+  array (
+  ),
+  'asda' => 
+  array (
+  ),
+  'associates' => 
+  array (
+  ),
+  'athleta' => 
+  array (
+  ),
+  'attorney' => 
+  array (
+  ),
+  'auction' => 
+  array (
+  ),
+  'audi' => 
+  array (
+  ),
+  'audible' => 
+  array (
+  ),
+  'audio' => 
+  array (
+  ),
+  'auspost' => 
+  array (
+  ),
+  'author' => 
+  array (
+  ),
+  'auto' => 
+  array (
+  ),
+  'autos' => 
+  array (
+  ),
+  'avianca' => 
+  array (
+  ),
+  'aws' => 
+  array (
+  ),
+  'axa' => 
+  array (
+  ),
+  'azure' => 
+  array (
+  ),
+  'baby' => 
+  array (
+  ),
+  'baidu' => 
+  array (
+  ),
+  'banamex' => 
+  array (
+  ),
+  'bananarepublic' => 
+  array (
+  ),
+  'band' => 
+  array (
+  ),
+  'bank' => 
+  array (
+  ),
+  'bar' => 
+  array (
+  ),
+  'barcelona' => 
+  array (
+  ),
+  'barclaycard' => 
+  array (
+  ),
+  'barclays' => 
+  array (
+  ),
+  'barefoot' => 
+  array (
+  ),
+  'bargains' => 
+  array (
+  ),
+  'baseball' => 
+  array (
+  ),
+  'basketball' => 
+  array (
+  ),
+  'bauhaus' => 
+  array (
+  ),
+  'bayern' => 
+  array (
+  ),
+  'bbc' => 
+  array (
+  ),
+  'bbt' => 
+  array (
+  ),
+  'bbva' => 
+  array (
+  ),
+  'bcg' => 
+  array (
+  ),
+  'bcn' => 
+  array (
+  ),
+  'beats' => 
+  array (
+  ),
+  'beauty' => 
+  array (
+  ),
+  'beer' => 
+  array (
+  ),
+  'bentley' => 
+  array (
+  ),
+  'berlin' => 
+  array (
+  ),
+  'best' => 
+  array (
+  ),
+  'bestbuy' => 
+  array (
+  ),
+  'bet' => 
+  array (
+  ),
+  'bharti' => 
+  array (
+  ),
+  'bible' => 
+  array (
+  ),
+  'bid' => 
+  array (
+  ),
+  'bike' => 
+  array (
+  ),
+  'bing' => 
+  array (
+  ),
+  'bingo' => 
+  array (
+  ),
+  'bio' => 
+  array (
+  ),
+  'black' => 
+  array (
+  ),
+  'blackfriday' => 
+  array (
+  ),
+  'blanco' => 
+  array (
+  ),
+  'blockbuster' => 
+  array (
+  ),
+  'blog' => 
+  array (
+  ),
+  'bloomberg' => 
+  array (
+  ),
+  'blue' => 
+  array (
+  ),
+  'bms' => 
+  array (
+  ),
+  'bmw' => 
+  array (
+  ),
+  'bnl' => 
+  array (
+  ),
+  'bnpparibas' => 
+  array (
+  ),
+  'boats' => 
+  array (
+  ),
+  'boehringer' => 
+  array (
+  ),
+  'bofa' => 
+  array (
+  ),
+  'bom' => 
+  array (
+  ),
+  'bond' => 
+  array (
+  ),
+  'boo' => 
+  array (
+  ),
+  'book' => 
+  array (
+  ),
+  'booking' => 
+  array (
+  ),
+  'boots' => 
+  array (
+  ),
+  'bosch' => 
+  array (
+  ),
+  'bostik' => 
+  array (
+  ),
+  'boston' => 
+  array (
+  ),
+  'bot' => 
+  array (
+  ),
+  'boutique' => 
+  array (
+  ),
+  'box' => 
+  array (
+  ),
+  'bradesco' => 
+  array (
+  ),
+  'bridgestone' => 
+  array (
+  ),
+  'broadway' => 
+  array (
+  ),
+  'broker' => 
+  array (
+  ),
+  'brother' => 
+  array (
+  ),
+  'brussels' => 
+  array (
+  ),
+  'budapest' => 
+  array (
+  ),
+  'bugatti' => 
+  array (
+  ),
+  'build' => 
+  array (
+  ),
+  'builders' => 
+  array (
+  ),
+  'business' => 
+  array (
+  ),
+  'buy' => 
+  array (
+  ),
+  'buzz' => 
+  array (
+  ),
+  'bzh' => 
+  array (
+  ),
+  'cab' => 
+  array (
+  ),
+  'cafe' => 
+  array (
+  ),
+  'cal' => 
+  array (
+  ),
+  'call' => 
+  array (
+  ),
+  'calvinklein' => 
+  array (
+  ),
+  'cam' => 
+  array (
+  ),
+  'camera' => 
+  array (
+  ),
+  'camp' => 
+  array (
+  ),
+  'cancerresearch' => 
+  array (
+  ),
+  'canon' => 
+  array (
+  ),
+  'capetown' => 
+  array (
+  ),
+  'capital' => 
+  array (
+  ),
+  'capitalone' => 
+  array (
+  ),
+  'car' => 
+  array (
+  ),
+  'caravan' => 
+  array (
+  ),
+  'cards' => 
+  array (
+  ),
+  'care' => 
+  array (
+  ),
+  'career' => 
+  array (
+  ),
+  'careers' => 
+  array (
+  ),
+  'cars' => 
+  array (
+  ),
+  'cartier' => 
+  array (
+  ),
+  'casa' => 
+  array (
+  ),
+  'case' => 
+  array (
+  ),
+  'caseih' => 
+  array (
+  ),
+  'cash' => 
+  array (
+  ),
+  'casino' => 
+  array (
+  ),
+  'catering' => 
+  array (
+  ),
+  'catholic' => 
+  array (
+  ),
+  'cba' => 
+  array (
+  ),
+  'cbn' => 
+  array (
+  ),
+  'cbre' => 
+  array (
+  ),
+  'cbs' => 
+  array (
+  ),
+  'ceb' => 
+  array (
+  ),
+  'center' => 
+  array (
+  ),
+  'ceo' => 
+  array (
+  ),
+  'cern' => 
+  array (
+  ),
+  'cfa' => 
+  array (
+  ),
+  'cfd' => 
+  array (
+  ),
+  'chanel' => 
+  array (
+  ),
+  'channel' => 
+  array (
+  ),
+  'chase' => 
+  array (
+  ),
+  'chat' => 
+  array (
+  ),
+  'cheap' => 
+  array (
+  ),
+  'chintai' => 
+  array (
+  ),
+  'chloe' => 
+  array (
+  ),
+  'christmas' => 
+  array (
+  ),
+  'chrome' => 
+  array (
+  ),
+  'chrysler' => 
+  array (
+  ),
+  'church' => 
+  array (
+  ),
+  'cipriani' => 
+  array (
+  ),
+  'circle' => 
+  array (
+  ),
+  'cisco' => 
+  array (
+  ),
+  'citadel' => 
+  array (
+  ),
+  'citi' => 
+  array (
+  ),
+  'citic' => 
+  array (
+  ),
+  'city' => 
+  array (
+  ),
+  'cityeats' => 
+  array (
+  ),
+  'claims' => 
+  array (
+  ),
+  'cleaning' => 
+  array (
+  ),
+  'click' => 
+  array (
+  ),
+  'clinic' => 
+  array (
+  ),
+  'clinique' => 
+  array (
+  ),
+  'clothing' => 
+  array (
+  ),
+  'cloud' => 
+  array (
+  ),
+  'club' => 
+  array (
+  ),
+  'clubmed' => 
+  array (
+  ),
+  'coach' => 
+  array (
+  ),
+  'codes' => 
+  array (
+  ),
+  'coffee' => 
+  array (
+  ),
+  'college' => 
+  array (
+  ),
+  'cologne' => 
+  array (
+  ),
+  'comcast' => 
+  array (
+  ),
+  'commbank' => 
+  array (
+  ),
+  'community' => 
+  array (
+  ),
+  'company' => 
+  array (
+  ),
+  'compare' => 
+  array (
+  ),
+  'computer' => 
+  array (
+  ),
+  'comsec' => 
+  array (
+  ),
+  'condos' => 
+  array (
+  ),
+  'construction' => 
+  array (
+  ),
+  'consulting' => 
+  array (
+  ),
+  'contact' => 
+  array (
+  ),
+  'contractors' => 
+  array (
+  ),
+  'cooking' => 
+  array (
+  ),
+  'cookingchannel' => 
+  array (
+  ),
+  'cool' => 
+  array (
+  ),
+  'corsica' => 
+  array (
+  ),
+  'country' => 
+  array (
+  ),
+  'coupon' => 
+  array (
+  ),
+  'coupons' => 
+  array (
+  ),
+  'courses' => 
+  array (
+  ),
+  'credit' => 
+  array (
+  ),
+  'creditcard' => 
+  array (
+  ),
+  'creditunion' => 
+  array (
+  ),
+  'cricket' => 
+  array (
+  ),
+  'crown' => 
+  array (
+  ),
+  'crs' => 
+  array (
+  ),
+  'cruise' => 
+  array (
+  ),
+  'cruises' => 
+  array (
+  ),
+  'csc' => 
+  array (
+  ),
+  'cuisinella' => 
+  array (
+  ),
+  'cymru' => 
+  array (
+  ),
+  'cyou' => 
+  array (
+  ),
+  'dabur' => 
+  array (
+  ),
+  'dad' => 
+  array (
+  ),
+  'dance' => 
+  array (
+  ),
+  'data' => 
+  array (
+  ),
+  'date' => 
+  array (
+  ),
+  'dating' => 
+  array (
+  ),
+  'datsun' => 
+  array (
+  ),
+  'day' => 
+  array (
+  ),
+  'dclk' => 
+  array (
+  ),
+  'dds' => 
+  array (
+  ),
+  'deal' => 
+  array (
+  ),
+  'dealer' => 
+  array (
+  ),
+  'deals' => 
+  array (
+  ),
+  'degree' => 
+  array (
+  ),
+  'delivery' => 
+  array (
+  ),
+  'dell' => 
+  array (
+  ),
+  'deloitte' => 
+  array (
+  ),
+  'delta' => 
+  array (
+  ),
+  'democrat' => 
+  array (
+  ),
+  'dental' => 
+  array (
+  ),
+  'dentist' => 
+  array (
+  ),
+  'desi' => 
+  array (
+  ),
+  'design' => 
+  array (
+  ),
+  'dev' => 
+  array (
+  ),
+  'dhl' => 
+  array (
+  ),
+  'diamonds' => 
+  array (
+  ),
+  'diet' => 
+  array (
+  ),
+  'digital' => 
+  array (
+  ),
+  'direct' => 
+  array (
+  ),
+  'directory' => 
+  array (
+  ),
+  'discount' => 
+  array (
+  ),
+  'discover' => 
+  array (
+  ),
+  'dish' => 
+  array (
+  ),
+  'diy' => 
+  array (
+  ),
+  'dnp' => 
+  array (
+  ),
+  'docs' => 
+  array (
+  ),
+  'doctor' => 
+  array (
+  ),
+  'dodge' => 
+  array (
+  ),
+  'dog' => 
+  array (
+  ),
+  'doha' => 
+  array (
+  ),
+  'domains' => 
+  array (
+  ),
+  'dot' => 
+  array (
+  ),
+  'download' => 
+  array (
+  ),
+  'drive' => 
+  array (
+  ),
+  'dtv' => 
+  array (
+  ),
+  'dubai' => 
+  array (
+  ),
+  'duck' => 
+  array (
+  ),
+  'dunlop' => 
+  array (
+  ),
+  'duns' => 
+  array (
+  ),
+  'dupont' => 
+  array (
+  ),
+  'durban' => 
+  array (
+  ),
+  'dvag' => 
+  array (
+  ),
+  'dvr' => 
+  array (
+  ),
+  'dwg' => 
+  array (
+  ),
+  'earth' => 
+  array (
+  ),
+  'eat' => 
+  array (
+  ),
+  'eco' => 
+  array (
+  ),
+  'edeka' => 
+  array (
+  ),
+  'education' => 
+  array (
+  ),
+  'email' => 
+  array (
+  ),
+  'emerck' => 
+  array (
+  ),
+  'emerson' => 
+  array (
+  ),
+  'energy' => 
+  array (
+  ),
+  'engineer' => 
+  array (
+  ),
+  'engineering' => 
+  array (
+  ),
+  'enterprises' => 
+  array (
+  ),
+  'epost' => 
+  array (
+  ),
+  'epson' => 
+  array (
+  ),
+  'equipment' => 
+  array (
+  ),
+  'ericsson' => 
+  array (
+  ),
+  'erni' => 
+  array (
+  ),
+  'esq' => 
+  array (
+  ),
+  'estate' => 
+  array (
+  ),
+  'esurance' => 
+  array (
+  ),
+  'etisalat' => 
+  array (
+  ),
+  'eurovision' => 
+  array (
+  ),
+  'eus' => 
+  array (
+  ),
+  'events' => 
+  array (
+  ),
+  'everbank' => 
+  array (
+  ),
+  'exchange' => 
+  array (
+  ),
+  'expert' => 
+  array (
+  ),
+  'exposed' => 
+  array (
+  ),
+  'express' => 
+  array (
+  ),
+  'extraspace' => 
+  array (
+  ),
+  'fage' => 
+  array (
+  ),
+  'fail' => 
+  array (
+  ),
+  'fairwinds' => 
+  array (
+  ),
+  'faith' => 
+  array (
+  ),
+  'family' => 
+  array (
+  ),
+  'fan' => 
+  array (
+  ),
+  'fans' => 
+  array (
+  ),
+  'farm' => 
+  array (
+  ),
+  'farmers' => 
+  array (
+  ),
+  'fashion' => 
+  array (
+  ),
+  'fast' => 
+  array (
+  ),
+  'fedex' => 
+  array (
+  ),
+  'feedback' => 
+  array (
+  ),
+  'ferrari' => 
+  array (
+  ),
+  'ferrero' => 
+  array (
+  ),
+  'fiat' => 
+  array (
+  ),
+  'fidelity' => 
+  array (
+  ),
+  'fido' => 
+  array (
+  ),
+  'film' => 
+  array (
+  ),
+  'final' => 
+  array (
+  ),
+  'finance' => 
+  array (
+  ),
+  'financial' => 
+  array (
+  ),
+  'fire' => 
+  array (
+  ),
+  'firestone' => 
+  array (
+  ),
+  'firmdale' => 
+  array (
+  ),
+  'fish' => 
+  array (
+  ),
+  'fishing' => 
+  array (
+  ),
+  'fit' => 
+  array (
+  ),
+  'fitness' => 
+  array (
+  ),
+  'flickr' => 
+  array (
+  ),
+  'flights' => 
+  array (
+  ),
+  'flir' => 
+  array (
+  ),
+  'florist' => 
+  array (
+  ),
+  'flowers' => 
+  array (
+  ),
+  'fly' => 
+  array (
+  ),
+  'foo' => 
+  array (
+  ),
+  'food' => 
+  array (
+  ),
+  'foodnetwork' => 
+  array (
+  ),
+  'football' => 
+  array (
+  ),
+  'ford' => 
+  array (
+  ),
+  'forex' => 
+  array (
+  ),
+  'forsale' => 
+  array (
+  ),
+  'forum' => 
+  array (
+  ),
+  'foundation' => 
+  array (
+  ),
+  'fox' => 
+  array (
+  ),
+  'free' => 
+  array (
+  ),
+  'fresenius' => 
+  array (
+  ),
+  'frl' => 
+  array (
+  ),
+  'frogans' => 
+  array (
+  ),
+  'frontdoor' => 
+  array (
+  ),
+  'frontier' => 
+  array (
+  ),
+  'ftr' => 
+  array (
+  ),
+  'fujitsu' => 
+  array (
+  ),
+  'fujixerox' => 
+  array (
+  ),
+  'fun' => 
+  array (
+  ),
+  'fund' => 
+  array (
+  ),
+  'furniture' => 
+  array (
+  ),
+  'futbol' => 
+  array (
+  ),
+  'fyi' => 
+  array (
+  ),
+  'gal' => 
+  array (
+  ),
+  'gallery' => 
+  array (
+  ),
+  'gallo' => 
+  array (
+  ),
+  'gallup' => 
+  array (
+  ),
+  'game' => 
+  array (
+  ),
+  'games' => 
+  array (
+  ),
+  'gap' => 
+  array (
+  ),
+  'garden' => 
+  array (
+  ),
+  'gbiz' => 
+  array (
+  ),
+  'gdn' => 
+  array (
+  ),
+  'gea' => 
+  array (
+  ),
+  'gent' => 
+  array (
+  ),
+  'genting' => 
+  array (
+  ),
+  'george' => 
+  array (
+  ),
+  'ggee' => 
+  array (
+  ),
+  'gift' => 
+  array (
+  ),
+  'gifts' => 
+  array (
+  ),
+  'gives' => 
+  array (
+  ),
+  'giving' => 
+  array (
+  ),
+  'glade' => 
+  array (
+  ),
+  'glass' => 
+  array (
+  ),
+  'gle' => 
+  array (
+  ),
+  'global' => 
+  array (
+  ),
+  'globo' => 
+  array (
+  ),
+  'gmail' => 
+  array (
+  ),
+  'gmbh' => 
+  array (
+  ),
+  'gmo' => 
+  array (
+  ),
+  'gmx' => 
+  array (
+  ),
+  'godaddy' => 
+  array (
+  ),
+  'gold' => 
+  array (
+  ),
+  'goldpoint' => 
+  array (
+  ),
+  'golf' => 
+  array (
+  ),
+  'goo' => 
+  array (
+  ),
+  'goodhands' => 
+  array (
+  ),
+  'goodyear' => 
+  array (
+  ),
+  'goog' => 
+  array (
+  ),
+  'google' => 
+  array (
+  ),
+  'gop' => 
+  array (
+  ),
+  'got' => 
+  array (
+  ),
+  'grainger' => 
+  array (
+  ),
+  'graphics' => 
+  array (
+  ),
+  'gratis' => 
+  array (
+  ),
+  'green' => 
+  array (
+  ),
+  'gripe' => 
+  array (
+  ),
+  'grocery' => 
+  array (
+  ),
+  'group' => 
+  array (
+  ),
+  'guardian' => 
+  array (
+  ),
+  'gucci' => 
+  array (
+  ),
+  'guge' => 
+  array (
+  ),
+  'guide' => 
+  array (
+  ),
+  'guitars' => 
+  array (
+  ),
+  'guru' => 
+  array (
+  ),
+  'hair' => 
+  array (
+  ),
+  'hamburg' => 
+  array (
+  ),
+  'hangout' => 
+  array (
+  ),
+  'haus' => 
+  array (
+  ),
+  'hbo' => 
+  array (
+  ),
+  'hdfc' => 
+  array (
+  ),
+  'hdfcbank' => 
+  array (
+  ),
+  'health' => 
+  array (
+  ),
+  'healthcare' => 
+  array (
+  ),
+  'help' => 
+  array (
+  ),
+  'helsinki' => 
+  array (
+  ),
+  'here' => 
+  array (
+  ),
+  'hermes' => 
+  array (
+  ),
+  'hgtv' => 
+  array (
+  ),
+  'hiphop' => 
+  array (
+  ),
+  'hisamitsu' => 
+  array (
+  ),
+  'hitachi' => 
+  array (
+  ),
+  'hiv' => 
+  array (
+  ),
+  'hkt' => 
+  array (
+  ),
+  'hockey' => 
+  array (
+  ),
+  'holdings' => 
+  array (
+  ),
+  'holiday' => 
+  array (
+  ),
+  'homedepot' => 
+  array (
+  ),
+  'homegoods' => 
+  array (
+  ),
+  'homes' => 
+  array (
+  ),
+  'homesense' => 
+  array (
+  ),
+  'honda' => 
+  array (
+  ),
+  'honeywell' => 
+  array (
+  ),
+  'horse' => 
+  array (
+  ),
+  'host' => 
+  array (
+  ),
+  'hosting' => 
+  array (
+  ),
+  'hot' => 
+  array (
+  ),
+  'hoteles' => 
+  array (
+  ),
+  'hotels' => 
+  array (
+  ),
+  'hotmail' => 
+  array (
+  ),
+  'house' => 
+  array (
+  ),
+  'how' => 
+  array (
+  ),
+  'hsbc' => 
+  array (
+  ),
+  'htc' => 
+  array (
+  ),
+  'hughes' => 
+  array (
+  ),
+  'hyatt' => 
+  array (
+  ),
+  'hyundai' => 
+  array (
+  ),
+  'ibm' => 
+  array (
+  ),
+  'icbc' => 
+  array (
+  ),
+  'ice' => 
+  array (
+  ),
+  'icu' => 
+  array (
+  ),
+  'ieee' => 
+  array (
+  ),
+  'ifm' => 
+  array (
+  ),
+  'iinet' => 
+  array (
+  ),
+  'ikano' => 
+  array (
+  ),
+  'imamat' => 
+  array (
+  ),
+  'imdb' => 
+  array (
+  ),
+  'immo' => 
+  array (
+  ),
+  'immobilien' => 
+  array (
+  ),
+  'industries' => 
+  array (
+  ),
+  'infiniti' => 
+  array (
+  ),
+  'ing' => 
+  array (
+  ),
+  'ink' => 
+  array (
+  ),
+  'institute' => 
+  array (
+  ),
+  'insurance' => 
+  array (
+  ),
+  'insure' => 
+  array (
+  ),
+  'intel' => 
+  array (
+  ),
+  'international' => 
+  array (
+  ),
+  'intuit' => 
+  array (
+  ),
+  'investments' => 
+  array (
+  ),
+  'ipiranga' => 
+  array (
+  ),
+  'irish' => 
+  array (
+  ),
+  'iselect' => 
+  array (
+  ),
+  'ismaili' => 
+  array (
+  ),
+  'ist' => 
+  array (
+  ),
+  'istanbul' => 
+  array (
+  ),
+  'itau' => 
+  array (
+  ),
+  'itv' => 
+  array (
+  ),
+  'iveco' => 
+  array (
+  ),
+  'iwc' => 
+  array (
+  ),
+  'jaguar' => 
+  array (
+  ),
+  'java' => 
+  array (
+  ),
+  'jcb' => 
+  array (
+  ),
+  'jcp' => 
+  array (
+  ),
+  'jeep' => 
+  array (
+  ),
+  'jetzt' => 
+  array (
+  ),
+  'jewelry' => 
+  array (
+  ),
+  'jio' => 
+  array (
+  ),
+  'jlc' => 
+  array (
+  ),
+  'jll' => 
+  array (
+  ),
+  'jmp' => 
+  array (
+  ),
+  'jnj' => 
+  array (
+  ),
+  'joburg' => 
+  array (
+  ),
+  'jot' => 
+  array (
+  ),
+  'joy' => 
+  array (
+  ),
+  'jpmorgan' => 
+  array (
+  ),
+  'jprs' => 
+  array (
+  ),
+  'juegos' => 
+  array (
+  ),
+  'juniper' => 
+  array (
+  ),
+  'kaufen' => 
+  array (
+  ),
+  'kddi' => 
+  array (
+  ),
+  'kerryhotels' => 
+  array (
+  ),
+  'kerrylogistics' => 
+  array (
+  ),
+  'kerryproperties' => 
+  array (
+  ),
+  'kfh' => 
+  array (
+  ),
+  'kia' => 
+  array (
+  ),
+  'kim' => 
+  array (
+  ),
+  'kinder' => 
+  array (
+  ),
+  'kindle' => 
+  array (
+  ),
+  'kitchen' => 
+  array (
+  ),
+  'kiwi' => 
+  array (
+  ),
+  'koeln' => 
+  array (
+  ),
+  'komatsu' => 
+  array (
+  ),
+  'kosher' => 
+  array (
+  ),
+  'kpmg' => 
+  array (
+  ),
+  'kpn' => 
+  array (
+  ),
+  'krd' => 
+  array (
+  ),
+  'kred' => 
+  array (
+  ),
+  'kuokgroup' => 
+  array (
+  ),
+  'kyoto' => 
+  array (
+  ),
+  'lacaixa' => 
+  array (
+  ),
+  'ladbrokes' => 
+  array (
+  ),
+  'lamborghini' => 
+  array (
+  ),
+  'lamer' => 
+  array (
+  ),
+  'lancaster' => 
+  array (
+  ),
+  'lancia' => 
+  array (
+  ),
+  'lancome' => 
+  array (
+  ),
+  'land' => 
+  array (
+  ),
+  'landrover' => 
+  array (
+  ),
+  'lanxess' => 
+  array (
+  ),
+  'lasalle' => 
+  array (
+  ),
+  'lat' => 
+  array (
+  ),
+  'latino' => 
+  array (
+  ),
+  'latrobe' => 
+  array (
+  ),
+  'law' => 
+  array (
+  ),
+  'lawyer' => 
+  array (
+  ),
+  'lds' => 
+  array (
+  ),
+  'lease' => 
+  array (
+  ),
+  'leclerc' => 
+  array (
+  ),
+  'lefrak' => 
+  array (
+  ),
+  'legal' => 
+  array (
+  ),
+  'lego' => 
+  array (
+  ),
+  'lexus' => 
+  array (
+  ),
+  'lgbt' => 
+  array (
+  ),
+  'liaison' => 
+  array (
+  ),
+  'lidl' => 
+  array (
+  ),
+  'life' => 
+  array (
+  ),
+  'lifeinsurance' => 
+  array (
+  ),
+  'lifestyle' => 
+  array (
+  ),
+  'lighting' => 
+  array (
+  ),
+  'like' => 
+  array (
+  ),
+  'lilly' => 
+  array (
+  ),
+  'limited' => 
+  array (
+  ),
+  'limo' => 
+  array (
+  ),
+  'lincoln' => 
+  array (
+  ),
+  'linde' => 
+  array (
+  ),
+  'link' => 
+  array (
+  ),
+  'lipsy' => 
+  array (
+  ),
+  'live' => 
+  array (
+  ),
+  'living' => 
+  array (
+  ),
+  'lixil' => 
+  array (
+  ),
+  'loan' => 
+  array (
+  ),
+  'loans' => 
+  array (
+  ),
+  'locker' => 
+  array (
+  ),
+  'locus' => 
+  array (
+  ),
+  'loft' => 
+  array (
+  ),
+  'lol' => 
+  array (
+  ),
+  'london' => 
+  array (
+  ),
+  'lotte' => 
+  array (
+  ),
+  'lotto' => 
+  array (
+  ),
+  'love' => 
+  array (
+  ),
+  'lpl' => 
+  array (
+  ),
+  'lplfinancial' => 
+  array (
+  ),
+  'ltd' => 
+  array (
+  ),
+  'ltda' => 
+  array (
+  ),
+  'lundbeck' => 
+  array (
+  ),
+  'lupin' => 
+  array (
+  ),
+  'luxe' => 
+  array (
+  ),
+  'luxury' => 
+  array (
+  ),
+  'macys' => 
+  array (
+  ),
+  'madrid' => 
+  array (
+  ),
+  'maif' => 
+  array (
+  ),
+  'maison' => 
+  array (
+  ),
+  'makeup' => 
+  array (
+  ),
+  'man' => 
+  array (
+  ),
+  'management' => 
+  array (
+  ),
+  'mango' => 
+  array (
+  ),
+  'map' => 
+  array (
+  ),
+  'market' => 
+  array (
+  ),
+  'marketing' => 
+  array (
+  ),
+  'markets' => 
+  array (
+  ),
+  'marriott' => 
+  array (
+  ),
+  'marshalls' => 
+  array (
+  ),
+  'maserati' => 
+  array (
+  ),
+  'mattel' => 
+  array (
+  ),
+  'mba' => 
+  array (
+  ),
+  'mcd' => 
+  array (
+  ),
+  'mcdonalds' => 
+  array (
+  ),
+  'mckinsey' => 
+  array (
+  ),
+  'med' => 
+  array (
+  ),
+  'media' => 
+  array (
+  ),
+  'meet' => 
+  array (
+  ),
+  'melbourne' => 
+  array (
+  ),
+  'meme' => 
+  array (
+  ),
+  'memorial' => 
+  array (
+  ),
+  'men' => 
+  array (
+  ),
+  'menu' => 
+  array (
+  ),
+  'meo' => 
+  array (
+  ),
+  'merckmsd' => 
+  array (
+  ),
+  'metlife' => 
+  array (
+  ),
+  'miami' => 
+  array (
+  ),
+  'microsoft' => 
+  array (
+  ),
+  'mini' => 
+  array (
+  ),
+  'mint' => 
+  array (
+  ),
+  'mit' => 
+  array (
+  ),
+  'mitsubishi' => 
+  array (
+  ),
+  'mlb' => 
+  array (
+  ),
+  'mls' => 
+  array (
+  ),
+  'mma' => 
+  array (
+  ),
+  'mobile' => 
+  array (
+  ),
+  'mobily' => 
+  array (
+  ),
+  'moda' => 
+  array (
+  ),
+  'moe' => 
+  array (
+  ),
+  'moi' => 
+  array (
+  ),
+  'mom' => 
+  array (
+  ),
+  'monash' => 
+  array (
+  ),
+  'money' => 
+  array (
+  ),
+  'monster' => 
+  array (
+  ),
+  'montblanc' => 
+  array (
+  ),
+  'mopar' => 
+  array (
+  ),
+  'mormon' => 
+  array (
+  ),
+  'mortgage' => 
+  array (
+  ),
+  'moscow' => 
+  array (
+  ),
+  'moto' => 
+  array (
+  ),
+  'motorcycles' => 
+  array (
+  ),
+  'mov' => 
+  array (
+  ),
+  'movie' => 
+  array (
+  ),
+  'movistar' => 
+  array (
+  ),
+  'msd' => 
+  array (
+  ),
+  'mtn' => 
+  array (
+  ),
+  'mtpc' => 
+  array (
+  ),
+  'mtr' => 
+  array (
+  ),
+  'mutual' => 
+  array (
+  ),
+  'mutuelle' => 
+  array (
+  ),
+  'nab' => 
+  array (
+  ),
+  'nadex' => 
+  array (
+  ),
+  'nagoya' => 
+  array (
+  ),
+  'nationwide' => 
+  array (
+  ),
+  'natura' => 
+  array (
+  ),
+  'navy' => 
+  array (
+  ),
+  'nba' => 
+  array (
+  ),
+  'nec' => 
+  array (
+  ),
+  'netbank' => 
+  array (
+  ),
+  'netflix' => 
+  array (
+  ),
+  'network' => 
+  array (
+  ),
+  'neustar' => 
+  array (
+  ),
+  'new' => 
+  array (
+  ),
+  'newholland' => 
+  array (
+  ),
+  'news' => 
+  array (
+  ),
+  'next' => 
+  array (
+  ),
+  'nextdirect' => 
+  array (
+  ),
+  'nexus' => 
+  array (
+  ),
+  'nfl' => 
+  array (
+  ),
+  'ngo' => 
+  array (
+  ),
+  'nhk' => 
+  array (
+  ),
+  'nico' => 
+  array (
+  ),
+  'nike' => 
+  array (
+  ),
+  'nikon' => 
+  array (
+  ),
+  'ninja' => 
+  array (
+  ),
+  'nissan' => 
+  array (
+  ),
+  'nissay' => 
+  array (
+  ),
+  'nokia' => 
+  array (
+  ),
+  'northwesternmutual' => 
+  array (
+  ),
+  'norton' => 
+  array (
+  ),
+  'now' => 
+  array (
+  ),
+  'nowruz' => 
+  array (
+  ),
+  'nowtv' => 
+  array (
+  ),
+  'nra' => 
+  array (
+  ),
+  'nrw' => 
+  array (
+  ),
+  'ntt' => 
+  array (
+  ),
+  'nyc' => 
+  array (
+  ),
+  'obi' => 
+  array (
+  ),
+  'observer' => 
+  array (
+  ),
+  'off' => 
+  array (
+  ),
+  'office' => 
+  array (
+  ),
+  'okinawa' => 
+  array (
+  ),
+  'olayan' => 
+  array (
+  ),
+  'olayangroup' => 
+  array (
+  ),
+  'oldnavy' => 
+  array (
+  ),
+  'ollo' => 
+  array (
+  ),
+  'omega' => 
+  array (
+  ),
+  'one' => 
+  array (
+  ),
+  'ong' => 
+  array (
+  ),
+  'onl' => 
+  array (
+  ),
+  'online' => 
+  array (
+  ),
+  'onyourside' => 
+  array (
+  ),
+  'ooo' => 
+  array (
+  ),
+  'open' => 
+  array (
+  ),
+  'oracle' => 
+  array (
+  ),
+  'orange' => 
+  array (
+  ),
+  'organic' => 
+  array (
+  ),
+  'orientexpress' => 
+  array (
+  ),
+  'origins' => 
+  array (
+  ),
+  'osaka' => 
+  array (
+  ),
+  'otsuka' => 
+  array (
+  ),
+  'ott' => 
+  array (
+  ),
+  'ovh' => 
+  array (
+  ),
+  'page' => 
+  array (
+  ),
+  'pamperedchef' => 
+  array (
+  ),
+  'panasonic' => 
+  array (
+  ),
+  'panerai' => 
+  array (
+  ),
+  'paris' => 
+  array (
+  ),
+  'pars' => 
+  array (
+  ),
+  'partners' => 
+  array (
+  ),
+  'parts' => 
+  array (
+  ),
+  'party' => 
+  array (
+  ),
+  'passagens' => 
+  array (
+  ),
+  'pay' => 
+  array (
+  ),
+  'pccw' => 
+  array (
+  ),
+  'pet' => 
+  array (
+  ),
+  'pfizer' => 
+  array (
+  ),
+  'pharmacy' => 
+  array (
+  ),
+  'phd' => 
+  array (
+  ),
+  'philips' => 
+  array (
+  ),
+  'phone' => 
+  array (
+  ),
+  'photo' => 
+  array (
+  ),
+  'photography' => 
+  array (
+  ),
+  'photos' => 
+  array (
+  ),
+  'physio' => 
+  array (
+  ),
+  'piaget' => 
+  array (
+  ),
+  'pics' => 
+  array (
+  ),
+  'pictet' => 
+  array (
+  ),
+  'pictures' => 
+  array (
+  ),
+  'pid' => 
+  array (
+  ),
+  'pin' => 
+  array (
+  ),
+  'ping' => 
+  array (
+  ),
+  'pink' => 
+  array (
+  ),
+  'pioneer' => 
+  array (
+  ),
+  'pizza' => 
+  array (
+  ),
+  'place' => 
+  array (
+  ),
+  'play' => 
+  array (
+  ),
+  'playstation' => 
+  array (
+  ),
+  'plumbing' => 
+  array (
+  ),
+  'plus' => 
+  array (
+  ),
+  'pnc' => 
+  array (
+  ),
+  'pohl' => 
+  array (
+  ),
+  'poker' => 
+  array (
+  ),
+  'politie' => 
+  array (
+  ),
+  'porn' => 
+  array (
+  ),
+  'pramerica' => 
+  array (
+  ),
+  'praxi' => 
+  array (
+  ),
+  'press' => 
+  array (
+  ),
+  'prime' => 
+  array (
+  ),
+  'prod' => 
+  array (
+  ),
+  'productions' => 
+  array (
+  ),
+  'prof' => 
+  array (
+  ),
+  'progressive' => 
+  array (
+  ),
+  'promo' => 
+  array (
+  ),
+  'properties' => 
+  array (
+  ),
+  'property' => 
+  array (
+  ),
+  'protection' => 
+  array (
+  ),
+  'pru' => 
+  array (
+  ),
+  'prudential' => 
+  array (
+  ),
+  'pub' => 
+  array (
+  ),
+  'pwc' => 
+  array (
+  ),
+  'qpon' => 
+  array (
+  ),
+  'quebec' => 
+  array (
+  ),
+  'quest' => 
+  array (
+  ),
+  'qvc' => 
+  array (
+  ),
+  'racing' => 
+  array (
+  ),
+  'radio' => 
+  array (
+  ),
+  'raid' => 
+  array (
+  ),
+  'read' => 
+  array (
+  ),
+  'realestate' => 
+  array (
+  ),
+  'realtor' => 
+  array (
+  ),
+  'realty' => 
+  array (
+  ),
+  'recipes' => 
+  array (
+  ),
+  'red' => 
+  array (
+  ),
+  'redstone' => 
+  array (
+  ),
+  'redumbrella' => 
+  array (
+  ),
+  'rehab' => 
+  array (
+  ),
+  'reise' => 
+  array (
+  ),
+  'reisen' => 
+  array (
+  ),
+  'reit' => 
+  array (
+  ),
+  'reliance' => 
+  array (
+  ),
+  'ren' => 
+  array (
+  ),
+  'rent' => 
+  array (
+  ),
+  'rentals' => 
+  array (
+  ),
+  'repair' => 
+  array (
+  ),
+  'report' => 
+  array (
+  ),
+  'republican' => 
+  array (
+  ),
+  'rest' => 
+  array (
+  ),
+  'restaurant' => 
+  array (
+  ),
+  'review' => 
+  array (
+  ),
+  'reviews' => 
+  array (
+  ),
+  'rexroth' => 
+  array (
+  ),
+  'rich' => 
+  array (
+  ),
+  'richardli' => 
+  array (
+  ),
+  'ricoh' => 
+  array (
+  ),
+  'rightathome' => 
+  array (
+  ),
+  'ril' => 
+  array (
+  ),
+  'rio' => 
+  array (
+  ),
+  'rip' => 
+  array (
+  ),
+  'rmit' => 
+  array (
+  ),
+  'rocher' => 
+  array (
+  ),
+  'rocks' => 
+  array (
+  ),
+  'rodeo' => 
+  array (
+  ),
+  'rogers' => 
+  array (
+  ),
+  'room' => 
+  array (
+  ),
+  'rsvp' => 
+  array (
+  ),
+  'ruhr' => 
+  array (
+  ),
+  'run' => 
+  array (
+  ),
+  'rwe' => 
+  array (
+  ),
+  'ryukyu' => 
+  array (
+  ),
+  'saarland' => 
+  array (
+  ),
+  'safe' => 
+  array (
+  ),
+  'safety' => 
+  array (
+  ),
+  'sakura' => 
+  array (
+  ),
+  'sale' => 
+  array (
+  ),
+  'salon' => 
+  array (
+  ),
+  'samsclub' => 
+  array (
+  ),
+  'samsung' => 
+  array (
+  ),
+  'sandvik' => 
+  array (
+  ),
+  'sandvikcoromant' => 
+  array (
+  ),
+  'sanofi' => 
+  array (
+  ),
+  'sap' => 
+  array (
+  ),
+  'sapo' => 
+  array (
+  ),
+  'sarl' => 
+  array (
+  ),
+  'sas' => 
+  array (
+  ),
+  'save' => 
+  array (
+  ),
+  'saxo' => 
+  array (
+  ),
+  'sbi' => 
+  array (
+  ),
+  'sbs' => 
+  array (
+  ),
+  'sca' => 
+  array (
+  ),
+  'scb' => 
+  array (
+  ),
+  'schaeffler' => 
+  array (
+  ),
+  'schmidt' => 
+  array (
+  ),
+  'scholarships' => 
+  array (
+  ),
+  'school' => 
+  array (
+  ),
+  'schule' => 
+  array (
+  ),
+  'schwarz' => 
+  array (
+  ),
+  'science' => 
+  array (
+  ),
+  'scjohnson' => 
+  array (
+  ),
+  'scor' => 
+  array (
+  ),
+  'scot' => 
+  array (
+  ),
+  'search' => 
+  array (
+  ),
+  'seat' => 
+  array (
+  ),
+  'secure' => 
+  array (
+  ),
+  'security' => 
+  array (
+  ),
+  'seek' => 
+  array (
+  ),
+  'select' => 
+  array (
+  ),
+  'sener' => 
+  array (
+  ),
+  'services' => 
+  array (
+  ),
+  'ses' => 
+  array (
+  ),
+  'seven' => 
+  array (
+  ),
+  'sew' => 
+  array (
+  ),
+  'sex' => 
+  array (
+  ),
+  'sexy' => 
+  array (
+  ),
+  'sfr' => 
+  array (
+  ),
+  'shangrila' => 
+  array (
+  ),
+  'sharp' => 
+  array (
+  ),
+  'shaw' => 
+  array (
+  ),
+  'shell' => 
+  array (
+  ),
+  'shia' => 
+  array (
+  ),
+  'shiksha' => 
+  array (
+  ),
+  'shoes' => 
+  array (
+  ),
+  'shop' => 
+  array (
+  ),
+  'shopping' => 
+  array (
+  ),
+  'shouji' => 
+  array (
+  ),
+  'show' => 
+  array (
+  ),
+  'showtime' => 
+  array (
+  ),
+  'shriram' => 
+  array (
+  ),
+  'silk' => 
+  array (
+  ),
+  'sina' => 
+  array (
+  ),
+  'singles' => 
+  array (
+  ),
+  'site' => 
+  array (
+  ),
+  'ski' => 
+  array (
+  ),
+  'skin' => 
+  array (
+  ),
+  'sky' => 
+  array (
+  ),
+  'skype' => 
+  array (
+  ),
+  'sling' => 
+  array (
+  ),
+  'smart' => 
+  array (
+  ),
+  'smile' => 
+  array (
+  ),
+  'sncf' => 
+  array (
+  ),
+  'soccer' => 
+  array (
+  ),
+  'social' => 
+  array (
+  ),
+  'softbank' => 
+  array (
+  ),
+  'software' => 
+  array (
+  ),
+  'sohu' => 
+  array (
+  ),
+  'solar' => 
+  array (
+  ),
+  'solutions' => 
+  array (
+  ),
+  'song' => 
+  array (
+  ),
+  'sony' => 
+  array (
+  ),
+  'soy' => 
+  array (
+  ),
+  'space' => 
+  array (
+  ),
+  'spiegel' => 
+  array (
+  ),
+  'spot' => 
+  array (
+  ),
+  'spreadbetting' => 
+  array (
+  ),
+  'srl' => 
+  array (
+  ),
+  'srt' => 
+  array (
+  ),
+  'stada' => 
+  array (
+  ),
+  'staples' => 
+  array (
+  ),
+  'star' => 
+  array (
+  ),
+  'starhub' => 
+  array (
+  ),
+  'statebank' => 
+  array (
+  ),
+  'statefarm' => 
+  array (
+  ),
+  'statoil' => 
+  array (
+  ),
+  'stc' => 
+  array (
+  ),
+  'stcgroup' => 
+  array (
+  ),
+  'stockholm' => 
+  array (
+  ),
+  'storage' => 
+  array (
+  ),
+  'store' => 
+  array (
+  ),
+  'stream' => 
+  array (
+  ),
+  'studio' => 
+  array (
+  ),
+  'study' => 
+  array (
+  ),
+  'style' => 
+  array (
+  ),
+  'sucks' => 
+  array (
+  ),
+  'supplies' => 
+  array (
+  ),
+  'supply' => 
+  array (
+  ),
+  'support' => 
+  array (
+  ),
+  'surf' => 
+  array (
+  ),
+  'surgery' => 
+  array (
+  ),
+  'suzuki' => 
+  array (
+  ),
+  'swatch' => 
+  array (
+  ),
+  'swiftcover' => 
+  array (
+  ),
+  'swiss' => 
+  array (
+  ),
+  'sydney' => 
+  array (
+  ),
+  'symantec' => 
+  array (
+  ),
+  'systems' => 
+  array (
+  ),
+  'tab' => 
+  array (
+  ),
+  'taipei' => 
+  array (
+  ),
+  'talk' => 
+  array (
+  ),
+  'taobao' => 
+  array (
+  ),
+  'target' => 
+  array (
+  ),
+  'tatamotors' => 
+  array (
+  ),
+  'tatar' => 
+  array (
+  ),
+  'tattoo' => 
+  array (
+  ),
+  'tax' => 
+  array (
+  ),
+  'taxi' => 
+  array (
+  ),
+  'tci' => 
+  array (
+  ),
+  'tdk' => 
+  array (
+  ),
+  'team' => 
+  array (
+  ),
+  'tech' => 
+  array (
+  ),
+  'technology' => 
+  array (
+  ),
+  'telecity' => 
+  array (
+  ),
+  'telefonica' => 
+  array (
+  ),
+  'temasek' => 
+  array (
+  ),
+  'tennis' => 
+  array (
+  ),
+  'teva' => 
+  array (
+  ),
+  'thd' => 
+  array (
+  ),
+  'theater' => 
+  array (
+  ),
+  'theatre' => 
+  array (
+  ),
+  'theguardian' => 
+  array (
+  ),
+  'tiaa' => 
+  array (
+  ),
+  'tickets' => 
+  array (
+  ),
+  'tienda' => 
+  array (
+  ),
+  'tiffany' => 
+  array (
+  ),
+  'tips' => 
+  array (
+  ),
+  'tires' => 
+  array (
+  ),
+  'tirol' => 
+  array (
+  ),
+  'tjmaxx' => 
+  array (
+  ),
+  'tjx' => 
+  array (
+  ),
+  'tkmaxx' => 
+  array (
+  ),
+  'tmall' => 
+  array (
+  ),
+  'today' => 
+  array (
+  ),
+  'tokyo' => 
+  array (
+  ),
+  'tools' => 
+  array (
+  ),
+  'top' => 
+  array (
+  ),
+  'toray' => 
+  array (
+  ),
+  'toshiba' => 
+  array (
+  ),
+  'total' => 
+  array (
+  ),
+  'tours' => 
+  array (
+  ),
+  'town' => 
+  array (
+  ),
+  'toyota' => 
+  array (
+  ),
+  'toys' => 
+  array (
+  ),
+  'trade' => 
+  array (
+  ),
+  'trading' => 
+  array (
+  ),
+  'training' => 
+  array (
+  ),
+  'travelchannel' => 
+  array (
+  ),
+  'travelers' => 
+  array (
+  ),
+  'travelersinsurance' => 
+  array (
+  ),
+  'trust' => 
+  array (
+  ),
+  'trv' => 
+  array (
+  ),
+  'tube' => 
+  array (
+  ),
+  'tui' => 
+  array (
+  ),
+  'tunes' => 
+  array (
+  ),
+  'tushu' => 
+  array (
+  ),
+  'tvs' => 
+  array (
+  ),
+  'ubank' => 
+  array (
+  ),
+  'ubs' => 
+  array (
+  ),
+  'uconnect' => 
+  array (
+  ),
+  'unicom' => 
+  array (
+  ),
+  'university' => 
+  array (
+  ),
+  'uno' => 
+  array (
+  ),
+  'uol' => 
+  array (
+  ),
+  'ups' => 
+  array (
+  ),
+  'vacations' => 
+  array (
+  ),
+  'vana' => 
+  array (
+  ),
+  'vanguard' => 
+  array (
+  ),
+  'vegas' => 
+  array (
+  ),
+  'ventures' => 
+  array (
+  ),
+  'verisign' => 
+  array (
+  ),
+  'versicherung' => 
+  array (
+  ),
+  'vet' => 
+  array (
+  ),
+  'viajes' => 
+  array (
+  ),
+  'video' => 
+  array (
+  ),
+  'vig' => 
+  array (
+  ),
+  'viking' => 
+  array (
+  ),
+  'villas' => 
+  array (
+  ),
+  'vin' => 
+  array (
+  ),
+  'vip' => 
+  array (
+  ),
+  'virgin' => 
+  array (
+  ),
+  'visa' => 
+  array (
+  ),
+  'vision' => 
+  array (
+  ),
+  'vista' => 
+  array (
+  ),
+  'vistaprint' => 
+  array (
+  ),
+  'viva' => 
+  array (
+  ),
+  'vivo' => 
+  array (
+  ),
+  'vlaanderen' => 
+  array (
+  ),
+  'vodka' => 
+  array (
+  ),
+  'volkswagen' => 
+  array (
+  ),
+  'volvo' => 
+  array (
+  ),
+  'vote' => 
+  array (
+  ),
+  'voting' => 
+  array (
+  ),
+  'voto' => 
+  array (
+  ),
+  'voyage' => 
+  array (
+  ),
+  'vuelos' => 
+  array (
+  ),
+  'wales' => 
+  array (
+  ),
+  'walmart' => 
+  array (
+  ),
+  'walter' => 
+  array (
+  ),
+  'wang' => 
+  array (
+  ),
+  'wanggou' => 
+  array (
+  ),
+  'warman' => 
+  array (
+  ),
+  'watch' => 
+  array (
+  ),
+  'watches' => 
+  array (
+  ),
+  'weather' => 
+  array (
+  ),
+  'weatherchannel' => 
+  array (
+  ),
+  'webcam' => 
+  array (
+  ),
+  'weber' => 
+  array (
+  ),
+  'website' => 
+  array (
+  ),
+  'wed' => 
+  array (
+  ),
+  'wedding' => 
+  array (
+  ),
+  'weibo' => 
+  array (
+  ),
+  'weir' => 
+  array (
+  ),
+  'whoswho' => 
+  array (
+  ),
+  'wien' => 
+  array (
+  ),
+  'wiki' => 
+  array (
+  ),
+  'williamhill' => 
+  array (
+  ),
+  'win' => 
+  array (
+  ),
+  'windows' => 
+  array (
+  ),
+  'wine' => 
+  array (
+  ),
+  'winners' => 
+  array (
+  ),
+  'wme' => 
+  array (
+  ),
+  'wolterskluwer' => 
+  array (
+  ),
+  'woodside' => 
+  array (
+  ),
+  'work' => 
+  array (
+  ),
+  'works' => 
+  array (
+  ),
+  'world' => 
+  array (
+  ),
+  'wow' => 
+  array (
+  ),
+  'wtc' => 
+  array (
+  ),
+  'wtf' => 
+  array (
+  ),
+  'xbox' => 
+  array (
+  ),
+  'xerox' => 
+  array (
+  ),
+  'xfinity' => 
+  array (
+  ),
+  'xihuan' => 
+  array (
+  ),
+  'xin' => 
+  array (
+  ),
+  'xn--11b4c3d' => 
+  array (
+  ),
+  'xn--1ck2e1b' => 
+  array (
+  ),
+  'xn--1qqw23a' => 
+  array (
+  ),
+  'xn--30rr7y' => 
+  array (
+  ),
+  'xn--3bst00m' => 
+  array (
+  ),
+  'xn--3ds443g' => 
+  array (
+  ),
+  'xn--3oq18vl8pn36a' => 
+  array (
+  ),
+  'xn--3pxu8k' => 
+  array (
+  ),
+  'xn--42c2d9a' => 
+  array (
+  ),
+  'xn--45q11c' => 
+  array (
+  ),
+  'xn--4gbrim' => 
+  array (
+  ),
+  'xn--4gq48lf9j' => 
+  array (
+  ),
+  'xn--55qw42g' => 
+  array (
+  ),
+  'xn--55qx5d' => 
+  array (
+  ),
+  'xn--5su34j936bgsg' => 
+  array (
+  ),
+  'xn--5tzm5g' => 
+  array (
+  ),
+  'xn--6frz82g' => 
+  array (
+  ),
+  'xn--6qq986b3xl' => 
+  array (
+  ),
+  'xn--80adxhks' => 
+  array (
+  ),
+  'xn--80aqecdr1a' => 
+  array (
+  ),
+  'xn--80asehdb' => 
+  array (
+  ),
+  'xn--80aswg' => 
+  array (
+  ),
+  'xn--8y0a063a' => 
+  array (
+  ),
+  'xn--9dbq2a' => 
+  array (
+  ),
+  'xn--9et52u' => 
+  array (
+  ),
+  'xn--9krt00a' => 
+  array (
+  ),
+  'xn--b4w605ferd' => 
+  array (
+  ),
+  'xn--bck1b9a5dre4c' => 
+  array (
+  ),
+  'xn--c1avg' => 
+  array (
+  ),
+  'xn--c2br7g' => 
+  array (
+  ),
+  'xn--cck2b3b' => 
+  array (
+  ),
+  'xn--cg4bki' => 
+  array (
+  ),
+  'xn--czr694b' => 
+  array (
+  ),
+  'xn--czrs0t' => 
+  array (
+  ),
+  'xn--czru2d' => 
+  array (
+  ),
+  'xn--d1acj3b' => 
+  array (
+  ),
+  'xn--eckvdtc9d' => 
+  array (
+  ),
+  'xn--efvy88h' => 
+  array (
+  ),
+  'xn--estv75g' => 
+  array (
+  ),
+  'xn--fct429k' => 
+  array (
+  ),
+  'xn--fhbei' => 
+  array (
+  ),
+  'xn--fiq228c5hs' => 
+  array (
+  ),
+  'xn--fiq64b' => 
+  array (
+  ),
+  'xn--fjq720a' => 
+  array (
+  ),
+  'xn--flw351e' => 
+  array (
+  ),
+  'xn--fzys8d69uvgm' => 
+  array (
+  ),
+  'xn--g2xx48c' => 
+  array (
+  ),
+  'xn--gckr3f0f' => 
+  array (
+  ),
+  'xn--gk3at1e' => 
+  array (
+  ),
+  'xn--hxt814e' => 
+  array (
+  ),
+  'xn--i1b6b1a6a2e' => 
+  array (
+  ),
+  'xn--imr513n' => 
+  array (
+  ),
+  'xn--io0a7i' => 
+  array (
+  ),
+  'xn--j1aef' => 
+  array (
+  ),
+  'xn--jlq61u9w7b' => 
+  array (
+  ),
+  'xn--jvr189m' => 
+  array (
+  ),
+  'xn--kcrx77d1x4a' => 
+  array (
+  ),
+  'xn--kpu716f' => 
+  array (
+  ),
+  'xn--kput3i' => 
+  array (
+  ),
+  'xn--mgba3a3ejt' => 
+  array (
+  ),
+  'xn--mgba7c0bbn0a' => 
+  array (
+  ),
+  'xn--mgbaakc7dvf' => 
+  array (
+  ),
+  'xn--mgbab2bd' => 
+  array (
+  ),
+  'xn--mgbb9fbpob' => 
+  array (
+  ),
+  'xn--mgbca7dzdo' => 
+  array (
+  ),
+  'xn--mgbi4ecexp' => 
+  array (
+  ),
+  'xn--mgbt3dhd' => 
+  array (
+  ),
+  'xn--mk1bu44c' => 
+  array (
+  ),
+  'xn--mxtq1m' => 
+  array (
+  ),
+  'xn--ngbc5azd' => 
+  array (
+  ),
+  'xn--ngbe9e0a' => 
+  array (
+  ),
+  'xn--ngbrx' => 
+  array (
+  ),
+  'xn--nqv7f' => 
+  array (
+  ),
+  'xn--nqv7fs00ema' => 
+  array (
+  ),
+  'xn--nyqy26a' => 
+  array (
+  ),
+  'xn--p1acf' => 
+  array (
+  ),
+  'xn--pbt977c' => 
+  array (
+  ),
+  'xn--pssy2u' => 
+  array (
+  ),
+  'xn--q9jyb4c' => 
+  array (
+  ),
+  'xn--qcka1pmc' => 
+  array (
+  ),
+  'xn--rhqv96g' => 
+  array (
+  ),
+  'xn--rovu88b' => 
+  array (
+  ),
+  'xn--ses554g' => 
+  array (
+  ),
+  'xn--t60b56a' => 
+  array (
+  ),
+  'xn--tckwe' => 
+  array (
+  ),
+  'xn--tiq49xqyj' => 
+  array (
+  ),
+  'xn--unup4y' => 
+  array (
+  ),
+  'xn--vermgensberater-ctb' => 
+  array (
+  ),
+  'xn--vermgensberatung-pwb' => 
+  array (
+  ),
+  'xn--vhquv' => 
+  array (
+  ),
+  'xn--vuq861b' => 
+  array (
+  ),
+  'xn--w4r85el8fhu5dnra' => 
+  array (
+  ),
+  'xn--w4rs40l' => 
+  array (
+  ),
+  'xn--xhq521b' => 
+  array (
+  ),
+  'xn--zfr164b' => 
+  array (
+  ),
+  'xperia' => 
+  array (
+  ),
+  'xyz' => 
+  array (
+  ),
+  'yachts' => 
+  array (
+  ),
+  'yahoo' => 
+  array (
+  ),
+  'yamaxun' => 
+  array (
+  ),
+  'yandex' => 
+  array (
+  ),
+  'yodobashi' => 
+  array (
+  ),
+  'yoga' => 
+  array (
+  ),
+  'yokohama' => 
+  array (
+  ),
+  'you' => 
+  array (
+  ),
+  'youtube' => 
+  array (
+  ),
+  'yun' => 
+  array (
+  ),
+  'zappos' => 
+  array (
+  ),
+  'zara' => 
+  array (
+  ),
+  'zero' => 
+  array (
+  ),
+  'zip' => 
+  array (
+  ),
+  'zippo' => 
+  array (
+  ),
+  'zone' => 
+  array (
+  ),
+  'zuerich' => 
+  array (
+  ),
+);

--- a/data/private-public-suffix-list.php
+++ b/data/private-public-suffix-list.php
@@ -1,0 +1,2778 @@
+<?php
+return array (
+  'pl' => 
+  array (
+    'beep' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'art' => 
+    array (
+    ),
+    'gliwice' => 
+    array (
+    ),
+    'krakow' => 
+    array (
+    ),
+    'poznan' => 
+    array (
+    ),
+    'wroc' => 
+    array (
+    ),
+    'zakopane' => 
+    array (
+    ),
+    'gda' => 
+    array (
+    ),
+    'gdansk' => 
+    array (
+    ),
+    'gdynia' => 
+    array (
+    ),
+    'med' => 
+    array (
+    ),
+    'sopot' => 
+    array (
+    ),
+  ),
+  'estate' => 
+  array (
+    'compute' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+  ),
+  'network' => 
+  array (
+    'alces' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+  ),
+  'net' => 
+  array (
+    'cloudfront' => 
+    array (
+    ),
+    'myfritz' => 
+    array (
+    ),
+    'gb' => 
+    array (
+    ),
+    'hu' => 
+    array (
+    ),
+    'jp' => 
+    array (
+    ),
+    'se' => 
+    array (
+    ),
+    'uk' => 
+    array (
+    ),
+    'in' => 
+    array (
+    ),
+    'cdn77-ssl' => 
+    array (
+    ),
+    'cdn77' => 
+    array (
+      'r' => 
+      array (
+      ),
+    ),
+    'cryptonomic' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+    'at-band-camp' => 
+    array (
+    ),
+    'blogdns' => 
+    array (
+    ),
+    'broke-it' => 
+    array (
+    ),
+    'buyshouses' => 
+    array (
+    ),
+    'dnsalias' => 
+    array (
+    ),
+    'dnsdojo' => 
+    array (
+    ),
+    'does-it' => 
+    array (
+    ),
+    'dontexist' => 
+    array (
+    ),
+    'dynalias' => 
+    array (
+    ),
+    'dynathome' => 
+    array (
+    ),
+    'endofinternet' => 
+    array (
+    ),
+    'from-az' => 
+    array (
+    ),
+    'from-co' => 
+    array (
+    ),
+    'from-la' => 
+    array (
+    ),
+    'from-ny' => 
+    array (
+    ),
+    'gets-it' => 
+    array (
+    ),
+    'ham-radio-op' => 
+    array (
+    ),
+    'homeftp' => 
+    array (
+    ),
+    'homeip' => 
+    array (
+    ),
+    'homelinux' => 
+    array (
+    ),
+    'homeunix' => 
+    array (
+    ),
+    'in-the-band' => 
+    array (
+    ),
+    'is-a-chef' => 
+    array (
+    ),
+    'is-a-geek' => 
+    array (
+    ),
+    'isa-geek' => 
+    array (
+    ),
+    'kicks-ass' => 
+    array (
+    ),
+    'office-on-the' => 
+    array (
+    ),
+    'podzone' => 
+    array (
+    ),
+    'scrapper-site' => 
+    array (
+    ),
+    'selfip' => 
+    array (
+    ),
+    'sells-it' => 
+    array (
+    ),
+    'servebbs' => 
+    array (
+    ),
+    'serveftp' => 
+    array (
+    ),
+    'thruhere' => 
+    array (
+    ),
+    'webhop' => 
+    array (
+    ),
+    'dynv6' => 
+    array (
+    ),
+    'fastly' => 
+    array (
+      'ssl' => 
+      array (
+        'a' => 
+        array (
+        ),
+        'b' => 
+        array (
+        ),
+        'global' => 
+        array (
+        ),
+      ),
+      'prod' => 
+      array (
+        'a' => 
+        array (
+        ),
+        'global' => 
+        array (
+        ),
+      ),
+    ),
+    'cloudfunctions' => 
+    array (
+    ),
+    'azurewebsites' => 
+    array (
+    ),
+    'azure-mobile' => 
+    array (
+    ),
+    'cloudapp' => 
+    array (
+    ),
+    'eating-organic' => 
+    array (
+    ),
+    'mydissent' => 
+    array (
+    ),
+    'myeffect' => 
+    array (
+    ),
+    'mymediapc' => 
+    array (
+    ),
+    'mypsx' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'nhlfan' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+    'pgafan' => 
+    array (
+    ),
+    'privatizehealthinsurance' => 
+    array (
+    ),
+    'bounceme' => 
+    array (
+    ),
+    'ddns' => 
+    array (
+    ),
+    'redirectme' => 
+    array (
+    ),
+    'serveblog' => 
+    array (
+    ),
+    'serveminecraft' => 
+    array (
+    ),
+    'sytes' => 
+    array (
+    ),
+    'rackmaze' => 
+    array (
+    ),
+    'dsmynas' => 
+    array (
+    ),
+    'familyds' => 
+    array (
+    ),
+    'za' => 
+    array (
+    ),
+  ),
+  'com' => 
+  array (
+    'amazonaws' => 
+    array (
+      'compute' => 
+      array (
+        'ap-northeast-1' => 
+        array (
+        ),
+        'ap-northeast-2' => 
+        array (
+        ),
+        'ap-southeast-1' => 
+        array (
+        ),
+        'ap-southeast-2' => 
+        array (
+        ),
+        'eu-central-1' => 
+        array (
+        ),
+        'eu-west-1' => 
+        array (
+        ),
+        'sa-east-1' => 
+        array (
+        ),
+        'us-gov-west-1' => 
+        array (
+        ),
+        'us-west-1' => 
+        array (
+        ),
+        'us-west-2' => 
+        array (
+        ),
+      ),
+      'compute-1' => 
+      array (
+        'z-1' => 
+        array (
+        ),
+        'z-2' => 
+        array (
+        ),
+      ),
+      'us-east-1' => 
+      array (
+      ),
+      'elb' => 
+      array (
+      ),
+      's3' => 
+      array (
+      ),
+      's3-ap-northeast-1' => 
+      array (
+      ),
+      's3-ap-northeast-2' => 
+      array (
+      ),
+      's3-ap-southeast-1' => 
+      array (
+      ),
+      's3-ap-southeast-2' => 
+      array (
+      ),
+      's3-eu-central-1' => 
+      array (
+      ),
+      's3-eu-west-1' => 
+      array (
+      ),
+      's3-external-1' => 
+      array (
+      ),
+      's3-external-2' => 
+      array (
+      ),
+      's3-fips-us-gov-west-1' => 
+      array (
+      ),
+      's3-sa-east-1' => 
+      array (
+      ),
+      's3-us-gov-west-1' => 
+      array (
+      ),
+      's3-us-west-1' => 
+      array (
+      ),
+      's3-us-west-2' => 
+      array (
+      ),
+      'ap-northeast-2' => 
+      array (
+        's3' => 
+        array (
+        ),
+      ),
+      'eu-central-1' => 
+      array (
+        's3' => 
+        array (
+        ),
+      ),
+    ),
+    'elasticbeanstalk' => 
+    array (
+    ),
+    'on-aptible' => 
+    array (
+    ),
+    'myasustor' => 
+    array (
+    ),
+    'betainabox' => 
+    array (
+    ),
+    'ar' => 
+    array (
+    ),
+    'br' => 
+    array (
+    ),
+    'cn' => 
+    array (
+    ),
+    'de' => 
+    array (
+    ),
+    'eu' => 
+    array (
+    ),
+    'gb' => 
+    array (
+    ),
+    'hu' => 
+    array (
+    ),
+    'jpn' => 
+    array (
+    ),
+    'kr' => 
+    array (
+    ),
+    'mex' => 
+    array (
+    ),
+    'no' => 
+    array (
+    ),
+    'qc' => 
+    array (
+    ),
+    'ru' => 
+    array (
+    ),
+    'sa' => 
+    array (
+    ),
+    'se' => 
+    array (
+    ),
+    'uk' => 
+    array (
+    ),
+    'us' => 
+    array (
+    ),
+    'uy' => 
+    array (
+    ),
+    'za' => 
+    array (
+    ),
+    'africa' => 
+    array (
+    ),
+    'gr' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'xenapponazure' => 
+    array (
+    ),
+    'cloudcontrolled' => 
+    array (
+    ),
+    'cloudcontrolapp' => 
+    array (
+    ),
+    'dreamhosters' => 
+    array (
+    ),
+    'mydrobo' => 
+    array (
+    ),
+    'dyndns-at-home' => 
+    array (
+    ),
+    'dyndns-at-work' => 
+    array (
+    ),
+    'dyndns-blog' => 
+    array (
+    ),
+    'dyndns-free' => 
+    array (
+    ),
+    'dyndns-home' => 
+    array (
+    ),
+    'dyndns-ip' => 
+    array (
+    ),
+    'dyndns-mail' => 
+    array (
+    ),
+    'dyndns-office' => 
+    array (
+    ),
+    'dyndns-pics' => 
+    array (
+    ),
+    'dyndns-remote' => 
+    array (
+    ),
+    'dyndns-server' => 
+    array (
+    ),
+    'dyndns-web' => 
+    array (
+    ),
+    'dyndns-wiki' => 
+    array (
+    ),
+    'dyndns-work' => 
+    array (
+    ),
+    'blogdns' => 
+    array (
+    ),
+    'cechire' => 
+    array (
+    ),
+    'dnsalias' => 
+    array (
+    ),
+    'dnsdojo' => 
+    array (
+    ),
+    'doesntexist' => 
+    array (
+    ),
+    'dontexist' => 
+    array (
+    ),
+    'doomdns' => 
+    array (
+    ),
+    'dyn-o-saur' => 
+    array (
+    ),
+    'dynalias' => 
+    array (
+    ),
+    'est-a-la-maison' => 
+    array (
+    ),
+    'est-a-la-masion' => 
+    array (
+    ),
+    'est-le-patron' => 
+    array (
+    ),
+    'est-mon-blogueur' => 
+    array (
+    ),
+    'from-ak' => 
+    array (
+    ),
+    'from-al' => 
+    array (
+    ),
+    'from-ar' => 
+    array (
+    ),
+    'from-ca' => 
+    array (
+    ),
+    'from-ct' => 
+    array (
+    ),
+    'from-dc' => 
+    array (
+    ),
+    'from-de' => 
+    array (
+    ),
+    'from-fl' => 
+    array (
+    ),
+    'from-ga' => 
+    array (
+    ),
+    'from-hi' => 
+    array (
+    ),
+    'from-ia' => 
+    array (
+    ),
+    'from-id' => 
+    array (
+    ),
+    'from-il' => 
+    array (
+    ),
+    'from-in' => 
+    array (
+    ),
+    'from-ks' => 
+    array (
+    ),
+    'from-ky' => 
+    array (
+    ),
+    'from-ma' => 
+    array (
+    ),
+    'from-md' => 
+    array (
+    ),
+    'from-mi' => 
+    array (
+    ),
+    'from-mn' => 
+    array (
+    ),
+    'from-mo' => 
+    array (
+    ),
+    'from-ms' => 
+    array (
+    ),
+    'from-mt' => 
+    array (
+    ),
+    'from-nc' => 
+    array (
+    ),
+    'from-nd' => 
+    array (
+    ),
+    'from-ne' => 
+    array (
+    ),
+    'from-nh' => 
+    array (
+    ),
+    'from-nj' => 
+    array (
+    ),
+    'from-nm' => 
+    array (
+    ),
+    'from-nv' => 
+    array (
+    ),
+    'from-oh' => 
+    array (
+    ),
+    'from-ok' => 
+    array (
+    ),
+    'from-or' => 
+    array (
+    ),
+    'from-pa' => 
+    array (
+    ),
+    'from-pr' => 
+    array (
+    ),
+    'from-ri' => 
+    array (
+    ),
+    'from-sc' => 
+    array (
+    ),
+    'from-sd' => 
+    array (
+    ),
+    'from-tn' => 
+    array (
+    ),
+    'from-tx' => 
+    array (
+    ),
+    'from-ut' => 
+    array (
+    ),
+    'from-va' => 
+    array (
+    ),
+    'from-vt' => 
+    array (
+    ),
+    'from-wa' => 
+    array (
+    ),
+    'from-wi' => 
+    array (
+    ),
+    'from-wv' => 
+    array (
+    ),
+    'from-wy' => 
+    array (
+    ),
+    'getmyip' => 
+    array (
+    ),
+    'gotdns' => 
+    array (
+    ),
+    'hobby-site' => 
+    array (
+    ),
+    'homelinux' => 
+    array (
+    ),
+    'homeunix' => 
+    array (
+    ),
+    'iamallama' => 
+    array (
+    ),
+    'is-a-anarchist' => 
+    array (
+    ),
+    'is-a-blogger' => 
+    array (
+    ),
+    'is-a-bookkeeper' => 
+    array (
+    ),
+    'is-a-bulls-fan' => 
+    array (
+    ),
+    'is-a-caterer' => 
+    array (
+    ),
+    'is-a-chef' => 
+    array (
+    ),
+    'is-a-conservative' => 
+    array (
+    ),
+    'is-a-cpa' => 
+    array (
+    ),
+    'is-a-cubicle-slave' => 
+    array (
+    ),
+    'is-a-democrat' => 
+    array (
+    ),
+    'is-a-designer' => 
+    array (
+    ),
+    'is-a-doctor' => 
+    array (
+    ),
+    'is-a-financialadvisor' => 
+    array (
+    ),
+    'is-a-geek' => 
+    array (
+    ),
+    'is-a-green' => 
+    array (
+    ),
+    'is-a-guru' => 
+    array (
+    ),
+    'is-a-hard-worker' => 
+    array (
+    ),
+    'is-a-hunter' => 
+    array (
+    ),
+    'is-a-landscaper' => 
+    array (
+    ),
+    'is-a-lawyer' => 
+    array (
+    ),
+    'is-a-liberal' => 
+    array (
+    ),
+    'is-a-libertarian' => 
+    array (
+    ),
+    'is-a-llama' => 
+    array (
+    ),
+    'is-a-musician' => 
+    array (
+    ),
+    'is-a-nascarfan' => 
+    array (
+    ),
+    'is-a-nurse' => 
+    array (
+    ),
+    'is-a-painter' => 
+    array (
+    ),
+    'is-a-personaltrainer' => 
+    array (
+    ),
+    'is-a-photographer' => 
+    array (
+    ),
+    'is-a-player' => 
+    array (
+    ),
+    'is-a-republican' => 
+    array (
+    ),
+    'is-a-rockstar' => 
+    array (
+    ),
+    'is-a-socialist' => 
+    array (
+    ),
+    'is-a-student' => 
+    array (
+    ),
+    'is-a-teacher' => 
+    array (
+    ),
+    'is-a-techie' => 
+    array (
+    ),
+    'is-a-therapist' => 
+    array (
+    ),
+    'is-an-accountant' => 
+    array (
+    ),
+    'is-an-actor' => 
+    array (
+    ),
+    'is-an-actress' => 
+    array (
+    ),
+    'is-an-anarchist' => 
+    array (
+    ),
+    'is-an-artist' => 
+    array (
+    ),
+    'is-an-engineer' => 
+    array (
+    ),
+    'is-an-entertainer' => 
+    array (
+    ),
+    'is-certified' => 
+    array (
+    ),
+    'is-gone' => 
+    array (
+    ),
+    'is-into-anime' => 
+    array (
+    ),
+    'is-into-cars' => 
+    array (
+    ),
+    'is-into-cartoons' => 
+    array (
+    ),
+    'is-into-games' => 
+    array (
+    ),
+    'is-leet' => 
+    array (
+    ),
+    'is-not-certified' => 
+    array (
+    ),
+    'is-slick' => 
+    array (
+    ),
+    'is-uberleet' => 
+    array (
+    ),
+    'is-with-theband' => 
+    array (
+    ),
+    'isa-geek' => 
+    array (
+    ),
+    'isa-hockeynut' => 
+    array (
+    ),
+    'issmarterthanyou' => 
+    array (
+    ),
+    'likes-pie' => 
+    array (
+    ),
+    'likescandy' => 
+    array (
+    ),
+    'neat-url' => 
+    array (
+    ),
+    'saves-the-whales' => 
+    array (
+    ),
+    'selfip' => 
+    array (
+    ),
+    'sells-for-less' => 
+    array (
+    ),
+    'sells-for-u' => 
+    array (
+    ),
+    'servebbs' => 
+    array (
+    ),
+    'simple-url' => 
+    array (
+    ),
+    'space-to-rent' => 
+    array (
+    ),
+    'teaches-yoga' => 
+    array (
+    ),
+    'writesthisblog' => 
+    array (
+    ),
+    'evennode' => 
+    array (
+      'eu-1' => 
+      array (
+      ),
+      'eu-2' => 
+      array (
+      ),
+      'us-1' => 
+      array (
+      ),
+      'us-2' => 
+      array (
+      ),
+    ),
+    'fbsbx' => 
+    array (
+      'apps' => 
+      array (
+      ),
+    ),
+    'firebaseapp' => 
+    array (
+    ),
+    'flynnhub' => 
+    array (
+    ),
+    'freebox-os' => 
+    array (
+    ),
+    'freeboxos' => 
+    array (
+    ),
+    'githubusercontent' => 
+    array (
+    ),
+    'githubcloud' => 
+    array (
+      'api' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+      'ext' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+      'gist' => 
+      array (
+      ),
+    ),
+    'githubcloudusercontent' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+    'ro' => 
+    array (
+    ),
+    '0emm' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+    'appspot' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+    'codespot' => 
+    array (
+    ),
+    'googleapis' => 
+    array (
+    ),
+    'googlecode' => 
+    array (
+    ),
+    'pagespeedmobilizer' => 
+    array (
+    ),
+    'withgoogle' => 
+    array (
+    ),
+    'withyoutube' => 
+    array (
+    ),
+    'herokuapp' => 
+    array (
+    ),
+    'herokussl' => 
+    array (
+    ),
+    'joyent' => 
+    array (
+      'cns' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+    ),
+    'meteorapp' => 
+    array (
+      'eu' => 
+      array (
+      ),
+    ),
+    '4u' => 
+    array (
+    ),
+    'nfshost' => 
+    array (
+    ),
+    'blogsyte' => 
+    array (
+    ),
+    'ciscofreak' => 
+    array (
+    ),
+    'damnserver' => 
+    array (
+    ),
+    'ditchyourip' => 
+    array (
+    ),
+    'dnsiskinky' => 
+    array (
+    ),
+    'dynns' => 
+    array (
+    ),
+    'geekgalaxy' => 
+    array (
+    ),
+    'health-carereform' => 
+    array (
+    ),
+    'homesecuritymac' => 
+    array (
+    ),
+    'homesecuritypc' => 
+    array (
+    ),
+    'myactivedirectory' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'net-freaks' => 
+    array (
+    ),
+    'onthewifi' => 
+    array (
+    ),
+    'point2this' => 
+    array (
+    ),
+    'quicksytes' => 
+    array (
+    ),
+    'securitytactics' => 
+    array (
+    ),
+    'serveexchange' => 
+    array (
+    ),
+    'servehumour' => 
+    array (
+    ),
+    'servep2p' => 
+    array (
+    ),
+    'servesarcasm' => 
+    array (
+    ),
+    'stufftoread' => 
+    array (
+    ),
+    'unusualperson' => 
+    array (
+    ),
+    'workisboring' => 
+    array (
+    ),
+    '3utilities' => 
+    array (
+    ),
+    'ddnsking' => 
+    array (
+    ),
+    'myvnc' => 
+    array (
+    ),
+    'servebeer' => 
+    array (
+    ),
+    'servecounterstrike' => 
+    array (
+    ),
+    'serveftp' => 
+    array (
+    ),
+    'servegame' => 
+    array (
+    ),
+    'servehalflife' => 
+    array (
+    ),
+    'servehttp' => 
+    array (
+    ),
+    'serveirc' => 
+    array (
+    ),
+    'servemp3' => 
+    array (
+    ),
+    'servepics' => 
+    array (
+    ),
+    'servequake' => 
+    array (
+    ),
+    'operaunite' => 
+    array (
+    ),
+    'outsystemscloud' => 
+    array (
+    ),
+    'ownprovider' => 
+    array (
+    ),
+    'pgfog' => 
+    array (
+    ),
+    'pagefrontapp' => 
+    array (
+    ),
+    'gotpantheon' => 
+    array (
+    ),
+    'prgmr' => 
+    array (
+      'xen' => 
+      array (
+      ),
+    ),
+    'qa2' => 
+    array (
+    ),
+    'dev-myqnapcloud' => 
+    array (
+    ),
+    'alpha-myqnapcloud' => 
+    array (
+    ),
+    'myqnapcloud' => 
+    array (
+    ),
+    'rackmaze' => 
+    array (
+    ),
+    'rhcloud' => 
+    array (
+    ),
+    'logoip' => 
+    array (
+    ),
+    'myshopblocks' => 
+    array (
+    ),
+    'sinaapp' => 
+    array (
+    ),
+    'vipsinaapp' => 
+    array (
+    ),
+    '1kapp' => 
+    array (
+    ),
+    'bounty-full' => 
+    array (
+      'alpha' => 
+      array (
+      ),
+      'beta' => 
+      array (
+      ),
+    ),
+    'dsmynas' => 
+    array (
+    ),
+    'familyds' => 
+    array (
+    ),
+    'bloxcms' => 
+    array (
+    ),
+    'townnews-staging' => 
+    array (
+    ),
+    'hk' => 
+    array (
+    ),
+    'yolasite' => 
+    array (
+    ),
+  ),
+  'cn' => 
+  array (
+    'com' => 
+    array (
+      'amazonaws' => 
+      array (
+        'compute' => 
+        array (
+          'cn-north-1' => 
+          array (
+          ),
+        ),
+        'cn-north-1' => 
+        array (
+          's3' => 
+          array (
+          ),
+        ),
+      ),
+    ),
+  ),
+  'org' => 
+  array (
+    'pimienta' => 
+    array (
+    ),
+    'poivron' => 
+    array (
+    ),
+    'potager' => 
+    array (
+    ),
+    'sweetpepper' => 
+    array (
+    ),
+    'ae' => 
+    array (
+    ),
+    'us' => 
+    array (
+    ),
+    'certmgr' => 
+    array (
+    ),
+    'cdn77' => 
+    array (
+      'c' => 
+      array (
+      ),
+      'rsc' => 
+      array (
+      ),
+    ),
+    'cdn77-secure' => 
+    array (
+      'origin' => 
+      array (
+        'ssl' => 
+        array (
+        ),
+      ),
+    ),
+    'duckdns' => 
+    array (
+    ),
+    'tunk' => 
+    array (
+    ),
+    'dyndns' => 
+    array (
+      'go' => 
+      array (
+      ),
+      'home' => 
+      array (
+      ),
+    ),
+    'blogdns' => 
+    array (
+    ),
+    'blogsite' => 
+    array (
+    ),
+    'boldlygoingnowhere' => 
+    array (
+    ),
+    'dnsalias' => 
+    array (
+    ),
+    'dnsdojo' => 
+    array (
+    ),
+    'doesntexist' => 
+    array (
+    ),
+    'dontexist' => 
+    array (
+    ),
+    'doomdns' => 
+    array (
+    ),
+    'dvrdns' => 
+    array (
+    ),
+    'dynalias' => 
+    array (
+    ),
+    'endofinternet' => 
+    array (
+    ),
+    'endoftheinternet' => 
+    array (
+    ),
+    'from-me' => 
+    array (
+    ),
+    'game-host' => 
+    array (
+    ),
+    'gotdns' => 
+    array (
+    ),
+    'hobby-site' => 
+    array (
+    ),
+    'homedns' => 
+    array (
+    ),
+    'homeftp' => 
+    array (
+    ),
+    'homelinux' => 
+    array (
+    ),
+    'homeunix' => 
+    array (
+    ),
+    'is-a-bruinsfan' => 
+    array (
+    ),
+    'is-a-candidate' => 
+    array (
+    ),
+    'is-a-celticsfan' => 
+    array (
+    ),
+    'is-a-chef' => 
+    array (
+    ),
+    'is-a-geek' => 
+    array (
+    ),
+    'is-a-knight' => 
+    array (
+    ),
+    'is-a-linux-user' => 
+    array (
+    ),
+    'is-a-patsfan' => 
+    array (
+    ),
+    'is-a-soxfan' => 
+    array (
+    ),
+    'is-found' => 
+    array (
+    ),
+    'is-lost' => 
+    array (
+    ),
+    'is-saved' => 
+    array (
+    ),
+    'is-very-bad' => 
+    array (
+    ),
+    'is-very-evil' => 
+    array (
+    ),
+    'is-very-good' => 
+    array (
+    ),
+    'is-very-nice' => 
+    array (
+    ),
+    'is-very-sweet' => 
+    array (
+    ),
+    'isa-geek' => 
+    array (
+    ),
+    'kicks-ass' => 
+    array (
+    ),
+    'misconfused' => 
+    array (
+    ),
+    'podzone' => 
+    array (
+    ),
+    'readmyblog' => 
+    array (
+    ),
+    'selfip' => 
+    array (
+    ),
+    'sellsyourhome' => 
+    array (
+    ),
+    'servebbs' => 
+    array (
+    ),
+    'serveftp' => 
+    array (
+    ),
+    'servegame' => 
+    array (
+    ),
+    'stuff-4-sale' => 
+    array (
+    ),
+    'webhop' => 
+    array (
+    ),
+    'eu' => 
+    array (
+      'al' => 
+      array (
+      ),
+      'asso' => 
+      array (
+      ),
+      'at' => 
+      array (
+      ),
+      'au' => 
+      array (
+      ),
+      'be' => 
+      array (
+      ),
+      'bg' => 
+      array (
+      ),
+      'ca' => 
+      array (
+      ),
+      'cd' => 
+      array (
+      ),
+      'ch' => 
+      array (
+      ),
+      'cn' => 
+      array (
+      ),
+      'cy' => 
+      array (
+      ),
+      'cz' => 
+      array (
+      ),
+      'de' => 
+      array (
+      ),
+      'dk' => 
+      array (
+      ),
+      'edu' => 
+      array (
+      ),
+      'ee' => 
+      array (
+      ),
+      'es' => 
+      array (
+      ),
+      'fi' => 
+      array (
+      ),
+      'fr' => 
+      array (
+      ),
+      'gr' => 
+      array (
+      ),
+      'hr' => 
+      array (
+      ),
+      'hu' => 
+      array (
+      ),
+      'ie' => 
+      array (
+      ),
+      'il' => 
+      array (
+      ),
+      'in' => 
+      array (
+      ),
+      'int' => 
+      array (
+      ),
+      'is' => 
+      array (
+      ),
+      'it' => 
+      array (
+      ),
+      'jp' => 
+      array (
+      ),
+      'kr' => 
+      array (
+      ),
+      'lt' => 
+      array (
+      ),
+      'lu' => 
+      array (
+      ),
+      'lv' => 
+      array (
+      ),
+      'mc' => 
+      array (
+      ),
+      'me' => 
+      array (
+      ),
+      'mk' => 
+      array (
+      ),
+      'mt' => 
+      array (
+      ),
+      'my' => 
+      array (
+      ),
+      'net' => 
+      array (
+      ),
+      'ng' => 
+      array (
+      ),
+      'nl' => 
+      array (
+      ),
+      'no' => 
+      array (
+      ),
+      'nz' => 
+      array (
+      ),
+      'paris' => 
+      array (
+      ),
+      'pl' => 
+      array (
+      ),
+      'pt' => 
+      array (
+      ),
+      'q-a' => 
+      array (
+      ),
+      'ro' => 
+      array (
+      ),
+      'ru' => 
+      array (
+      ),
+      'se' => 
+      array (
+      ),
+      'si' => 
+      array (
+      ),
+      'sk' => 
+      array (
+      ),
+      'tr' => 
+      array (
+      ),
+      'uk' => 
+      array (
+      ),
+      'us' => 
+      array (
+      ),
+    ),
+    'hepforge' => 
+    array (
+    ),
+    'js' => 
+    array (
+    ),
+    'bmoattachments' => 
+    array (
+    ),
+    'cable-modem' => 
+    array (
+    ),
+    'collegefan' => 
+    array (
+    ),
+    'couchpotatofries' => 
+    array (
+    ),
+    'mlbfan' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'nflfan' => 
+    array (
+    ),
+    'read-books' => 
+    array (
+    ),
+    'ufcfan' => 
+    array (
+    ),
+    'hopto' => 
+    array (
+    ),
+    'myftp' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+    'zapto' => 
+    array (
+    ),
+    'dsmynas' => 
+    array (
+    ),
+    'familyds' => 
+    array (
+    ),
+    'tuxfamily' => 
+    array (
+    ),
+    'hk' => 
+    array (
+    ),
+    'wmflabs' => 
+    array (
+    ),
+    'za' => 
+    array (
+    ),
+  ),
+  'io' => 
+  array (
+    'backplaneapp' => 
+    array (
+    ),
+    'boxfuse' => 
+    array (
+    ),
+    'browsersafetymark' => 
+    array (
+    ),
+    'dedyn' => 
+    array (
+    ),
+    'drud' => 
+    array (
+    ),
+    'github' => 
+    array (
+    ),
+    'gitlab' => 
+    array (
+    ),
+    'hasura-app' => 
+    array (
+    ),
+    'ngrok' => 
+    array (
+    ),
+    'nid' => 
+    array (
+    ),
+    'pantheonsite' => 
+    array (
+    ),
+    'protonet' => 
+    array (
+    ),
+    'hzc' => 
+    array (
+    ),
+    'sandcats' => 
+    array (
+    ),
+    'spacekit' => 
+    array (
+    ),
+  ),
+  'la' => 
+  array (
+    'bnr' => 
+    array (
+    ),
+    'c' => 
+    array (
+    ),
+  ),
+  'eu' => 
+  array (
+    'mycd' => 
+    array (
+    ),
+  ),
+  'de' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'dnshome' => 
+    array (
+    ),
+    'fuettertdasnetz' => 
+    array (
+    ),
+    'isteingeek' => 
+    array (
+    ),
+    'istmein' => 
+    array (
+    ),
+    'lebtimnetz' => 
+    array (
+    ),
+    'leitungsen' => 
+    array (
+    ),
+    'traeumtgerade' => 
+    array (
+    ),
+    'goip' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+    'logoip' => 
+    array (
+    ),
+  ),
+  'se' => 
+  array (
+    'com' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'bz' => 
+  array (
+    'za' => 
+    array (
+    ),
+  ),
+  'nl' => 
+  array (
+    'virtueeldomein' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ca' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+  ),
+  'cz' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'realm' => 
+    array (
+    ),
+    'e4' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'no' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'sh' => 
+  array (
+    'platform' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+    'hashbang' => 
+    array (
+    ),
+  ),
+  'is' => 
+  array (
+    'cupcake' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'link' => 
+  array (
+    'cyon' => 
+    array (
+    ),
+    'mypep' => 
+    array (
+    ),
+  ),
+  'site' => 
+  array (
+    'cyon' => 
+    array (
+    ),
+  ),
+  'me' => 
+  array (
+    'daplie' => 
+    array (
+    ),
+    'brasilia' => 
+    array (
+    ),
+    'ddns' => 
+    array (
+    ),
+    'dnsfor' => 
+    array (
+    ),
+    'hopto' => 
+    array (
+    ),
+    'loginto' => 
+    array (
+    ),
+    'noip' => 
+    array (
+    ),
+    'webhop' => 
+    array (
+    ),
+    'diskstation' => 
+    array (
+    ),
+    'dscloud' => 
+    array (
+    ),
+    'i234' => 
+    array (
+    ),
+    'myds' => 
+    array (
+    ),
+    'synology' => 
+    array (
+    ),
+  ),
+  'dk' => 
+  array (
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'reg' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'us' => 
+  array (
+    'drud' => 
+    array (
+    ),
+    'is-by' => 
+    array (
+    ),
+    'land-4-sale' => 
+    array (
+    ),
+    'stuff-4-sale' => 
+    array (
+    ),
+    'golffan' => 
+    array (
+    ),
+    'noip' => 
+    array (
+    ),
+    'pointto' => 
+    array (
+    ),
+    'de' => 
+    array (
+      'lib' => 
+      array (
+      ),
+    ),
+  ),
+  'fi' => 
+  array (
+    'dy' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+    'iki' => 
+    array (
+    ),
+  ),
+  'biz' => 
+  array (
+    'dyndns' => 
+    array (
+    ),
+    'for-better' => 
+    array (
+    ),
+    'for-more' => 
+    array (
+    ),
+    'for-some' => 
+    array (
+    ),
+    'for-the' => 
+    array (
+    ),
+    'selfip' => 
+    array (
+    ),
+    'webhop' => 
+    array (
+    ),
+    'mmafan' => 
+    array (
+    ),
+    'myftp' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+    'dscloud' => 
+    array (
+    ),
+  ),
+  'info' => 
+  array (
+    'dyndns' => 
+    array (
+    ),
+    'barrel-of-knowledge' => 
+    array (
+    ),
+    'barrell-of-knowledge' => 
+    array (
+    ),
+    'for-our' => 
+    array (
+    ),
+    'groks-the' => 
+    array (
+    ),
+    'groks-this' => 
+    array (
+    ),
+    'here-for-more' => 
+    array (
+    ),
+    'knowsitall' => 
+    array (
+    ),
+    'selfip' => 
+    array (
+    ),
+    'webhop' => 
+    array (
+    ),
+    'nsupdate' => 
+    array (
+    ),
+    'dvrcam' => 
+    array (
+    ),
+    'ilovecollege' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+  ),
+  'tv' => 
+  array (
+    'dyndns' => 
+    array (
+    ),
+    'better-than' => 
+    array (
+    ),
+    'on-the-web' => 
+    array (
+    ),
+    'worse-than' => 
+    array (
+    ),
+  ),
+  'cx' => 
+  array (
+    'ath' => 
+    array (
+    ),
+  ),
+  'ws' => 
+  array (
+    'dyndns' => 
+    array (
+    ),
+    'mypets' => 
+    array (
+    ),
+  ),
+  'name' => 
+  array (
+    'her' => 
+    array (
+      'forgot' => 
+      array (
+      ),
+    ),
+    'his' => 
+    array (
+      'forgot' => 
+      array (
+      ),
+    ),
+  ),
+  'cc' => 
+  array (
+    'ftpaccess' => 
+    array (
+    ),
+    'game-server' => 
+    array (
+    ),
+    'myphotos' => 
+    array (
+    ),
+    'scrapping' => 
+    array (
+    ),
+    'fantasyleague' => 
+    array (
+    ),
+  ),
+  'nu' => 
+  array (
+    'merseine' => 
+    array (
+    ),
+    'mine' => 
+    array (
+    ),
+    'shacknet' => 
+    array (
+    ),
+  ),
+  'xyz' => 
+  array (
+    'fhapp' => 
+    array (
+    ),
+  ),
+  'fr' => 
+  array (
+    'fbx-os' => 
+    array (
+    ),
+    'fbxos' => 
+    array (
+    ),
+    'freebox-os' => 
+    array (
+    ),
+    'freeboxos' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+    'chirurgiens-dentistes-en-france' => 
+    array (
+    ),
+  ),
+  'uk' => 
+  array (
+    'gov' => 
+    array (
+      'service' => 
+      array (
+      ),
+    ),
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+      'no-ip' => 
+      array (
+      ),
+    ),
+  ),
+  'im' => 
+  array (
+    'ro' => 
+    array (
+    ),
+  ),
+  'ro' => 
+  array (
+    'shop' => 
+    array (
+    ),
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ae' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'al' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'am' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ba' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'be' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'bg' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'bj' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'cf' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ch' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+    'gotdns' => 
+    array (
+    ),
+  ),
+  'cl' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'at' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+    'biz' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'priv' => 
+    array (
+    ),
+  ),
+  'id' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'il' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'ke' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'nz' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'za' => 
+  array (
+    'co' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'ar' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'au' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'br' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'by' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'co' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'cy' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'ee' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'eg' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'es' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'mt' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'ng' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'tr' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'uy' => 
+  array (
+    'com' => 
+    array (
+      'blogspot' => 
+      array (
+      ),
+    ),
+  ),
+  'cv' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'gr' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'hk' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+    'ltd' => 
+    array (
+    ),
+    'inc' => 
+    array (
+    ),
+  ),
+  'hr' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'hu' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ie' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'in' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'it' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'jp' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'kr' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'li' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'lt' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'lu' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'md' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'mk' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'mr' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'mx' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'my' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'pe' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'pt' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'qa' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  're' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'rs' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ru' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'sg' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'si' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'sk' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'sn' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'td' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'tw' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'ug' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'vn' => 
+  array (
+    'blogspot' => 
+    array (
+    ),
+  ),
+  'zone' => 
+  array (
+    'triton' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+  ),
+  'krd' => 
+  array (
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+  ),
+  'cloud' => 
+  array (
+    'magentosite' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
+  ),
+  'ovh' => 
+  array (
+    'nerdpol' => 
+    array (
+    ),
+  ),
+  'mn' => 
+  array (
+    'nyc' => 
+    array (
+    ),
+  ),
+  'lc' => 
+  array (
+    'oy' => 
+    array (
+    ),
+  ),
+  'ua' => 
+  array (
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'pp' => 
+    array (
+    ),
+  ),
+  'land' => 
+  array (
+    'static' => 
+    array (
+      'dev' => 
+      array (
+      ),
+      'sites' => 
+      array (
+      ),
+    ),
+  ),
+  'space' => 
+  array (
+    'stackspace' => 
+    array (
+    ),
+  ),
+  'mobi' => 
+  array (
+    'dscloud' => 
+    array (
+    ),
+  ),
+  'management' => 
+  array (
+    'router' => 
+    array (
+    ),
+  ),
+);

--- a/data/public-suffix-list.php
+++ b/data/public-suffix-list.php
@@ -662,10 +662,7 @@ return array (
   ),
   'ba' => 
   array (
-    'org' => 
-    array (
-    ),
-    'net' => 
+    'com' => 
     array (
     ),
     'edu' => 
@@ -677,19 +674,10 @@ return array (
     'mil' => 
     array (
     ),
-    'unsa' => 
+    'net' => 
     array (
     ),
-    'unbi' => 
-    array (
-    ),
-    'co' => 
-    array (
-    ),
-    'com' => 
-    array (
-    ),
-    'rs' => 
+    'org' => 
     array (
     ),
     'blogspot' => 
@@ -921,6 +909,15 @@ return array (
     array (
     ),
     'webhop' => 
+    array (
+    ),
+    'mmafan' => 
+    array (
+    ),
+    'myftp' => 
+    array (
+    ),
+    'no-ip' => 
     array (
     ),
     'dscloud' => 
@@ -1355,6 +1352,9 @@ return array (
     'blogspot' => 
     array (
     ),
+    'no-ip' => 
+    array (
+    ),
   ),
   'cat' => 
   array (
@@ -1371,6 +1371,9 @@ return array (
     array (
     ),
     'scrapping' => 
+    array (
+    ),
+    'fantasyleague' => 
     array (
     ),
   ),
@@ -1392,6 +1395,9 @@ return array (
   'ch' => 
   array (
     'blogspot' => 
+    array (
+    ),
+    'gotdns' => 
     array (
     ),
   ),
@@ -1495,6 +1501,12 @@ return array (
     array (
       'amazonaws' => 
       array (
+        'compute' => 
+        array (
+          'cn-north-1' => 
+          array (
+          ),
+        ),
         'cn-north-1' => 
         array (
           's3' => 
@@ -1629,15 +1641,6 @@ return array (
     'tw' => 
     array (
     ),
-    'amazonaws' => 
-    array (
-      'compute' => 
-      array (
-        'cn-north-1' => 
-        array (
-        ),
-      ),
-    ),
   ),
   'co' => 
   array (
@@ -1693,16 +1696,19 @@ return array (
         'ap-northeast-1' => 
         array (
         ),
+        'ap-northeast-2' => 
+        array (
+        ),
         'ap-southeast-1' => 
         array (
         ),
         'ap-southeast-2' => 
         array (
         ),
-        'eu-west-1' => 
+        'eu-central-1' => 
         array (
         ),
-        'eu-central-1' => 
+        'eu-west-1' => 
         array (
         ),
         'sa-east-1' => 
@@ -1739,10 +1745,19 @@ return array (
       's3-ap-northeast-1' => 
       array (
       ),
+      's3-ap-northeast-2' => 
+      array (
+      ),
       's3-ap-southeast-1' => 
       array (
       ),
       's3-ap-southeast-2' => 
+      array (
+      ),
+      's3-eu-central-1' => 
+      array (
+      ),
+      's3-eu-west-1' => 
       array (
       ),
       's3-external-1' => 
@@ -1752,12 +1767,6 @@ return array (
       array (
       ),
       's3-fips-us-gov-west-1' => 
-      array (
-      ),
-      's3-eu-central-1' => 
-      array (
-      ),
-      's3-eu-west-1' => 
       array (
       ),
       's3-sa-east-1' => 
@@ -1772,6 +1781,12 @@ return array (
       's3-us-west-2' => 
       array (
       ),
+      'ap-northeast-2' => 
+      array (
+        's3' => 
+        array (
+        ),
+      ),
       'eu-central-1' => 
       array (
         's3' => 
@@ -1780,6 +1795,12 @@ return array (
       ),
     ),
     'elasticbeanstalk' => 
+    array (
+    ),
+    'on-aptible' => 
+    array (
+    ),
+    'myasustor' => 
     array (
     ),
     'betainabox' => 
@@ -1849,6 +1870,9 @@ return array (
     array (
     ),
     'co' => 
+    array (
+    ),
+    'xenapponazure' => 
     array (
     ),
     'cloudcontrolled' => 
@@ -2313,17 +2337,74 @@ return array (
     'writesthisblog' => 
     array (
     ),
+    'evennode' => 
+    array (
+      'eu-1' => 
+      array (
+      ),
+      'eu-2' => 
+      array (
+      ),
+      'us-1' => 
+      array (
+      ),
+      'us-2' => 
+      array (
+      ),
+    ),
+    'fbsbx' => 
+    array (
+      'apps' => 
+      array (
+      ),
+    ),
     'firebaseapp' => 
     array (
     ),
     'flynnhub' => 
     array (
     ),
+    'freebox-os' => 
+    array (
+    ),
+    'freeboxos' => 
+    array (
+    ),
     'githubusercontent' => 
     array (
     ),
+    'githubcloud' => 
+    array (
+      'api' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+      'ext' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+      'gist' => 
+      array (
+      ),
+    ),
+    'githubcloudusercontent' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
     'ro' => 
     array (
+    ),
+    '0emm' => 
+    array (
+      '*' => 
+      array (
+      ),
     ),
     'appspot' => 
     array (
@@ -2355,16 +2436,148 @@ return array (
     'herokussl' => 
     array (
     ),
+    'joyent' => 
+    array (
+      'cns' => 
+      array (
+        '*' => 
+        array (
+        ),
+      ),
+    ),
+    'meteorapp' => 
+    array (
+      'eu' => 
+      array (
+      ),
+    ),
     '4u' => 
     array (
     ),
     'nfshost' => 
     array (
     ),
+    'blogsyte' => 
+    array (
+    ),
+    'ciscofreak' => 
+    array (
+    ),
+    'damnserver' => 
+    array (
+    ),
+    'ditchyourip' => 
+    array (
+    ),
+    'dnsiskinky' => 
+    array (
+    ),
+    'dynns' => 
+    array (
+    ),
+    'geekgalaxy' => 
+    array (
+    ),
+    'health-carereform' => 
+    array (
+    ),
+    'homesecuritymac' => 
+    array (
+    ),
+    'homesecuritypc' => 
+    array (
+    ),
+    'myactivedirectory' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'net-freaks' => 
+    array (
+    ),
+    'onthewifi' => 
+    array (
+    ),
+    'point2this' => 
+    array (
+    ),
+    'quicksytes' => 
+    array (
+    ),
+    'securitytactics' => 
+    array (
+    ),
+    'serveexchange' => 
+    array (
+    ),
+    'servehumour' => 
+    array (
+    ),
+    'servep2p' => 
+    array (
+    ),
+    'servesarcasm' => 
+    array (
+    ),
+    'stufftoread' => 
+    array (
+    ),
+    'unusualperson' => 
+    array (
+    ),
+    'workisboring' => 
+    array (
+    ),
+    '3utilities' => 
+    array (
+    ),
+    'ddnsking' => 
+    array (
+    ),
+    'myvnc' => 
+    array (
+    ),
+    'servebeer' => 
+    array (
+    ),
+    'servecounterstrike' => 
+    array (
+    ),
+    'serveftp' => 
+    array (
+    ),
+    'servegame' => 
+    array (
+    ),
+    'servehalflife' => 
+    array (
+    ),
+    'servehttp' => 
+    array (
+    ),
+    'serveirc' => 
+    array (
+    ),
+    'servemp3' => 
+    array (
+    ),
+    'servepics' => 
+    array (
+    ),
+    'servequake' => 
+    array (
+    ),
     'operaunite' => 
     array (
     ),
     'outsystemscloud' => 
+    array (
+    ),
+    'ownprovider' => 
+    array (
+    ),
+    'pgfog' => 
     array (
     ),
     'pagefrontapp' => 
@@ -2382,10 +2595,25 @@ return array (
     'qa2' => 
     array (
     ),
+    'dev-myqnapcloud' => 
+    array (
+    ),
+    'alpha-myqnapcloud' => 
+    array (
+    ),
+    'myqnapcloud' => 
+    array (
+    ),
     'rackmaze' => 
     array (
     ),
     'rhcloud' => 
+    array (
+    ),
+    'logoip' => 
+    array (
+    ),
+    'myshopblocks' => 
     array (
     ),
     'sinaapp' => 
@@ -2397,10 +2625,25 @@ return array (
     '1kapp' => 
     array (
     ),
+    'bounty-full' => 
+    array (
+      'alpha' => 
+      array (
+      ),
+      'beta' => 
+      array (
+      ),
+    ),
     'dsmynas' => 
     array (
     ),
     'familyds' => 
+    array (
+    ),
+    'bloxcms' => 
+    array (
+    ),
+    'townnews-staging' => 
     array (
     ),
     'hk' => 
@@ -2538,6 +2781,12 @@ return array (
     'co' => 
     array (
     ),
+    'realm' => 
+    array (
+    ),
+    'e4' => 
+    array (
+    ),
     'blogspot' => 
     array (
     ),
@@ -2545,6 +2794,9 @@ return array (
   'de' => 
   array (
     'com' => 
+    array (
+    ),
+    'dnshome' => 
     array (
     ),
     'fuettertdasnetz' => 
@@ -2565,7 +2817,13 @@ return array (
     'traeumtgerade' => 
     array (
     ),
+    'goip' => 
+    array (
+    ),
     'blogspot' => 
+    array (
+    ),
+    'logoip' => 
     array (
     ),
   ),
@@ -2574,6 +2832,21 @@ return array (
   ),
   'dk' => 
   array (
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'firm' => 
+    array (
+    ),
+    'reg' => 
+    array (
+    ),
+    'store' => 
+    array (
+    ),
     'blogspot' => 
     array (
     ),
@@ -2823,10 +3096,16 @@ return array (
   ),
   'eu' => 
   array (
+    'mycd' => 
+    array (
+    ),
   ),
   'fi' => 
   array (
     'aland' => 
+    array (
+    ),
+    'dy' => 
     array (
     ),
     'blogspot' => 
@@ -2925,7 +3204,22 @@ return array (
     'veterinaire' => 
     array (
     ),
+    'fbx-os' => 
+    array (
+    ),
+    'fbxos' => 
+    array (
+    ),
+    'freebox-os' => 
+    array (
+    ),
+    'freeboxos' => 
+    array (
+    ),
     'blogspot' => 
+    array (
+    ),
+    'chirurgiens-dentistes-en-france' => 
     array (
     ),
   ),
@@ -3540,6 +3834,9 @@ return array (
     'tv' => 
     array (
     ),
+    'ro' => 
+    array (
+    ),
   ),
   'in' => 
   array (
@@ -3615,6 +3912,18 @@ return array (
     'webhop' => 
     array (
     ),
+    'nsupdate' => 
+    array (
+    ),
+    'dvrcam' => 
+    array (
+    ),
+    'ilovecollege' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
   ),
   'int' => 
   array (
@@ -3627,7 +3936,28 @@ return array (
     'com' => 
     array (
     ),
+    'backplaneapp' => 
+    array (
+    ),
+    'boxfuse' => 
+    array (
+    ),
+    'browsersafetymark' => 
+    array (
+    ),
+    'dedyn' => 
+    array (
+    ),
+    'drud' => 
+    array (
+    ),
     'github' => 
+    array (
+    ),
+    'gitlab' => 
+    array (
+    ),
+    'hasura-app' => 
     array (
     ),
     'ngrok' => 
@@ -3636,10 +3966,19 @@ return array (
     'nid' => 
     array (
     ),
-    'pantheon' => 
+    'pantheonsite' => 
+    array (
+    ),
+    'protonet' => 
+    array (
+    ),
+    'hzc' => 
     array (
     ),
     'sandcats' => 
+    array (
+    ),
+    'spacekit' => 
     array (
     ),
   ),
@@ -7391,9 +7730,6 @@ return array (
       'kikuchi' => 
       array (
       ),
-      'kosa' => 
-      array (
-      ),
       'kumamoto' => 
       array (
       ),
@@ -7653,9 +7989,6 @@ return array (
       array (
       ),
       'kawasaki' => 
-      array (
-      ),
-      'kesennuma' => 
       array (
       ),
       'marumori' => 
@@ -10612,6 +10945,9 @@ return array (
     'org' => 
     array (
     ),
+    'bnr' => 
+    array (
+    ),
     'c' => 
     array (
     ),
@@ -10652,6 +10988,9 @@ return array (
     array (
     ),
     'gov' => 
+    array (
+    ),
+    'oy' => 
     array (
     ),
   ),
@@ -10871,6 +11210,30 @@ return array (
     array (
     ),
     'priv' => 
+    array (
+    ),
+    'daplie' => 
+    array (
+    ),
+    'brasilia' => 
+    array (
+    ),
+    'ddns' => 
+    array (
+    ),
+    'dnsfor' => 
+    array (
+    ),
+    'hopto' => 
+    array (
+    ),
+    'loginto' => 
+    array (
+    ),
+    'noip' => 
+    array (
+    ),
+    'webhop' => 
     array (
     ),
     'diskstation' => 
@@ -12874,12 +13237,29 @@ return array (
   ),
   'mz' => 
   array (
-    '*' => 
+    'ac' => 
     array (
     ),
-    'teledata' => 
+    'adv' => 
     array (
-      '!' => '',
+    ),
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
     ),
   ),
   'na' => 
@@ -12965,6 +13345,9 @@ return array (
     'cloudfront' => 
     array (
     ),
+    'myfritz' => 
+    array (
+    ),
     'gb' => 
     array (
     ),
@@ -12989,6 +13372,12 @@ return array (
     'cdn77' => 
     array (
       'r' => 
+      array (
+      ),
+    ),
+    'cryptonomic' => 
+    array (
+      '*' => 
       array (
       ),
     ),
@@ -13097,6 +13486,9 @@ return array (
     'webhop' => 
     array (
     ),
+    'dynv6' => 
+    array (
+    ),
     'fastly' => 
     array (
       'ssl' => 
@@ -13131,6 +13523,54 @@ return array (
     array (
     ),
     'cloudapp' => 
+    array (
+    ),
+    'eating-organic' => 
+    array (
+    ),
+    'mydissent' => 
+    array (
+    ),
+    'myeffect' => 
+    array (
+    ),
+    'mymediapc' => 
+    array (
+    ),
+    'mypsx' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'nhlfan' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+    'pgafan' => 
+    array (
+    ),
+    'privatizehealthinsurance' => 
+    array (
+    ),
+    'bounceme' => 
+    array (
+    ),
+    'ddns' => 
+    array (
+    ),
+    'redirectme' => 
+    array (
+    ),
+    'serveblog' => 
+    array (
+    ),
+    'serveminecraft' => 
+    array (
+    ),
+    'sytes' => 
     array (
     ),
     'rackmaze' => 
@@ -13263,6 +13703,9 @@ return array (
   'nl' => 
   array (
     'bv' => 
+    array (
+    ),
+    'virtueeldomein' => 
     array (
     ),
     'co' => 
@@ -15701,10 +16144,25 @@ return array (
   ),
   'org' => 
   array (
+    'pimienta' => 
+    array (
+    ),
+    'poivron' => 
+    array (
+    ),
+    'potager' => 
+    array (
+    ),
+    'sweetpepper' => 
+    array (
+    ),
     'ae' => 
     array (
     ),
     'us' => 
+    array (
+    ),
+    'certmgr' => 
     array (
     ),
     'cdn77' => 
@@ -15726,6 +16184,9 @@ return array (
       ),
     ),
     'duckdns' => 
+    array (
+    ),
+    'tunk' => 
     array (
     ),
     'dyndns' => 
@@ -16052,7 +16513,49 @@ return array (
       array (
       ),
     ),
+    'hepforge' => 
+    array (
+    ),
+    'js' => 
+    array (
+    ),
     'bmoattachments' => 
+    array (
+    ),
+    'cable-modem' => 
+    array (
+    ),
+    'collegefan' => 
+    array (
+    ),
+    'couchpotatofries' => 
+    array (
+    ),
+    'mlbfan' => 
+    array (
+    ),
+    'mysecuritycamera' => 
+    array (
+    ),
+    'nflfan' => 
+    array (
+    ),
+    'read-books' => 
+    array (
+    ),
+    'ufcfan' => 
+    array (
+    ),
+    'hopto' => 
+    array (
+    ),
+    'myftp' => 
+    array (
+    ),
+    'no-ip' => 
+    array (
+    ),
+    'zapto' => 
     array (
     ),
     'dsmynas' => 
@@ -16061,7 +16564,13 @@ return array (
     'familyds' => 
     array (
     ),
+    'tuxfamily' => 
+    array (
+    ),
     'hk' => 
+    array (
+    ),
+    'wmflabs' => 
     array (
     ),
     'za' => 
@@ -16823,6 +17332,9 @@ return array (
     'zgorzelec' => 
     array (
     ),
+    'beep' => 
+    array (
+    ),
     'co' => 
     array (
     ),
@@ -16928,13 +17440,25 @@ return array (
   ),
   'pro' => 
   array (
+    'aaa' => 
+    array (
+    ),
     'aca' => 
+    array (
+    ),
+    'acct' => 
+    array (
+    ),
+    'avocat' => 
     array (
     ),
     'bar' => 
     array (
     ),
     'cpa' => 
+    array (
+    ),
+    'eng' => 
     array (
     ),
     'jur' => 
@@ -16946,7 +17470,7 @@ return array (
     'med' => 
     array (
     ),
-    'eng' => 
+    'recht' => 
     array (
     ),
   ),
@@ -17127,6 +17651,9 @@ return array (
     array (
     ),
     'www' => 
+    array (
+    ),
+    'shop' => 
     array (
     ),
     'blogspot' => 
@@ -18841,6 +19368,9 @@ return array (
       'blogspot' => 
       array (
       ),
+      'no-ip' => 
+      array (
+      ),
     ),
     'gov' => 
     array (
@@ -19547,6 +20077,9 @@ return array (
       array (
       ),
     ),
+    'drud' => 
+    array (
+    ),
     'is-by' => 
     array (
     ),
@@ -19554,6 +20087,15 @@ return array (
     array (
     ),
     'stuff-4-sale' => 
+    array (
+    ),
+    'golffan' => 
+    array (
+    ),
+    'noip' => 
+    array (
+    ),
+    'pointto' => 
     array (
     ),
   ),
@@ -19806,6 +20348,9 @@ return array (
   'xn--wgbh1c' => 
   array (
   ),
+  'xn--e1a4c' => 
+  array (
+  ),
   'xn--node' => 
   array (
   ),
@@ -20033,7 +20578,37 @@ return array (
   ),
   'zm' => 
   array (
-    '*' => 
+    'ac' => 
+    array (
+    ),
+    'biz' => 
+    array (
+    ),
+    'co' => 
+    array (
+    ),
+    'com' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
+    'gov' => 
+    array (
+    ),
+    'info' => 
+    array (
+    ),
+    'mil' => 
+    array (
+    ),
+    'net' => 
+    array (
+    ),
+    'org' => 
+    array (
+    ),
+    'sch' => 
     array (
     ),
   ),
@@ -20116,9 +20691,6 @@ return array (
   array (
   ),
   'africa' => 
-  array (
-  ),
-  'africamagic' => 
   array (
   ),
   'agakhan' => 
@@ -20224,6 +20796,9 @@ return array (
   array (
   ),
   'army' => 
+  array (
+  ),
+  'art' => 
   array (
   ),
   'arte' => 
@@ -20520,6 +21095,9 @@ return array (
   'calvinklein' => 
   array (
   ),
+  'cam' => 
+  array (
+  ),
   'camera' => 
   array (
   ),
@@ -20693,6 +21271,12 @@ return array (
   ),
   'cloud' => 
   array (
+    'magentosite' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
   ),
   'club' => 
   array (
@@ -20820,6 +21404,9 @@ return array (
   'dance' => 
   array (
   ),
+  'data' => 
+  array (
+  ),
   'date' => 
   array (
   ),
@@ -20916,6 +21503,9 @@ return array (
   'docs' => 
   array (
   ),
+  'doctor' => 
+  array (
+  ),
   'dodge' => 
   array (
   ),
@@ -20928,9 +21518,6 @@ return array (
   'domains' => 
   array (
   ),
-  'doosan' => 
-  array (
-  ),
   'dot' => 
   array (
   ),
@@ -20938,9 +21525,6 @@ return array (
   array (
   ),
   'drive' => 
-  array (
-  ),
-  'dstv' => 
   array (
   ),
   'dtv' => 
@@ -20967,6 +21551,9 @@ return array (
   'dvag' => 
   array (
   ),
+  'dvr' => 
+  array (
+  ),
   'dwg' => 
   array (
   ),
@@ -20974,6 +21561,9 @@ return array (
   array (
   ),
   'eat' => 
+  array (
+  ),
+  'eco' => 
   array (
   ),
   'edeka' => 
@@ -21023,6 +21613,12 @@ return array (
   ),
   'estate' => 
   array (
+    'compute' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
   ),
   'esurance' => 
   array (
@@ -21159,13 +21755,13 @@ return array (
   'flowers' => 
   array (
   ),
-  'flsmidth' => 
-  array (
-  ),
   'fly' => 
   array (
   ),
   'foo' => 
+  array (
+  ),
+  'food' => 
   array (
   ),
   'foodnetwork' => 
@@ -21217,6 +21813,9 @@ return array (
   array (
   ),
   'fujixerox' => 
+  array (
+  ),
+  'fun' => 
   array (
   ),
   'fund' => 
@@ -21306,6 +21905,9 @@ return array (
   'gmail' => 
   array (
   ),
+  'gmbh' => 
+  array (
+  ),
   'gmo' => 
   array (
   ),
@@ -21345,9 +21947,6 @@ return array (
   'got' => 
   array (
   ),
-  'gotv' => 
-  array (
-  ),
   'grainger' => 
   array (
   ),
@@ -21361,6 +21960,9 @@ return array (
   array (
   ),
   'gripe' => 
+  array (
+  ),
+  'grocery' => 
   array (
   ),
   'group' => 
@@ -21481,6 +22083,9 @@ return array (
   array (
   ),
   'hoteles' => 
+  array (
+  ),
+  'hotels' => 
   array (
   ),
   'hotmail' => 
@@ -21716,14 +22321,17 @@ return array (
   ),
   'krd' => 
   array (
+    'co' => 
+    array (
+    ),
+    'edu' => 
+    array (
+    ),
   ),
   'kred' => 
   array (
   ),
   'kuokgroup' => 
-  array (
-  ),
-  'kyknet' => 
   array (
   ),
   'kyoto' => 
@@ -21752,6 +22360,15 @@ return array (
   ),
   'land' => 
   array (
+    'static' => 
+    array (
+      'dev' => 
+      array (
+      ),
+      'sites' => 
+      array (
+      ),
+    ),
   ),
   'landrover' => 
   array (
@@ -21839,6 +22456,12 @@ return array (
   ),
   'link' => 
   array (
+    'cyon' => 
+    array (
+    ),
+    'mypep' => 
+    array (
+    ),
   ),
   'lipsy' => 
   array (
@@ -21926,8 +22549,14 @@ return array (
   ),
   'management' => 
   array (
+    'router' => 
+    array (
+    ),
   ),
   'mango' => 
+  array (
+  ),
+  'map' => 
   array (
   ),
   'market' => 
@@ -21990,6 +22619,9 @@ return array (
   'meo' => 
   array (
   ),
+  'merckmsd' => 
+  array (
+  ),
   'metlife' => 
   array (
   ),
@@ -22020,7 +22652,7 @@ return array (
   'mma' => 
   array (
   ),
-  'mnet' => 
+  'mobile' => 
   array (
   ),
   'mobily' => 
@@ -22089,16 +22721,10 @@ return array (
   'mtr' => 
   array (
   ),
-  'multichoice' => 
-  array (
-  ),
   'mutual' => 
   array (
   ),
   'mutuelle' => 
-  array (
-  ),
-  'mzansimagic' => 
   array (
   ),
   'nab' => 
@@ -22108,9 +22734,6 @@ return array (
   array (
   ),
   'nagoya' => 
-  array (
-  ),
-  'naspers' => 
   array (
   ),
   'nationwide' => 
@@ -22136,6 +22759,12 @@ return array (
   ),
   'network' => 
   array (
+    'alces' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
   ),
   'neustar' => 
   array (
@@ -22292,6 +22921,9 @@ return array (
   ),
   'ovh' => 
   array (
+    'nerdpol' => 
+    array (
+    ),
   ),
   'page' => 
   array (
@@ -22326,9 +22958,6 @@ return array (
   'pay' => 
   array (
   ),
-  'payu' => 
-  array (
-  ),
   'pccw' => 
   array (
   ),
@@ -22341,7 +22970,13 @@ return array (
   'pharmacy' => 
   array (
   ),
+  'phd' => 
+  array (
+  ),
   'philips' => 
+  array (
+  ),
+  'phone' => 
   array (
   ),
   'photo' => 
@@ -22477,6 +23112,9 @@ return array (
   array (
   ),
   'racing' => 
+  array (
+  ),
+  'radio' => 
   array (
   ),
   'raid' => 
@@ -22701,6 +23339,9 @@ return array (
   'scot' => 
   array (
   ),
+  'search' => 
+  array (
+  ),
   'seat' => 
   array (
   ),
@@ -22761,6 +23402,12 @@ return array (
   'shoes' => 
   array (
   ),
+  'shop' => 
+  array (
+  ),
+  'shopping' => 
+  array (
+  ),
   'shouji' => 
   array (
   ),
@@ -22784,6 +23431,9 @@ return array (
   ),
   'site' => 
   array (
+    'cyon' => 
+    array (
+    ),
   ),
   'ski' => 
   array (
@@ -22841,6 +23491,9 @@ return array (
   ),
   'space' => 
   array (
+    'stackspace' => 
+    array (
+    ),
   ),
   'spiegel' => 
   array (
@@ -22893,6 +23546,9 @@ return array (
   'store' => 
   array (
   ),
+  'stream' => 
+  array (
+  ),
   'studio' => 
   array (
   ),
@@ -22903,9 +23559,6 @@ return array (
   array (
   ),
   'sucks' => 
-  array (
-  ),
-  'supersport' => 
   array (
   ),
   'supplies' => 
@@ -23645,6 +24298,9 @@ return array (
   ),
   'xyz' => 
   array (
+    'fhapp' => 
+    array (
+    ),
   ),
   'yachts' => 
   array (
@@ -23693,6 +24349,12 @@ return array (
   ),
   'zone' => 
   array (
+    'triton' => 
+    array (
+      '*' => 
+      array (
+      ),
+    ),
   ),
   'zuerich' => 
   array (

--- a/data/public-suffix-list.txt
+++ b/data/public-suffix-list.txt
@@ -1,10 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
+// rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
+
+// Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
 // ===BEGIN ICANN DOMAINS===
 
-// ac : http://en.wikipedia.org/wiki/.ac
+// ac : https://en.wikipedia.org/wiki/.ac
 ac
 com.ac
 edu.ac
@@ -13,11 +18,11 @@ net.ac
 mil.ac
 org.ac
 
-// ad : http://en.wikipedia.org/wiki/.ad
+// ad : https://en.wikipedia.org/wiki/.ad
 ad
 nom.ad
 
-// ae : http://en.wikipedia.org/wiki/.ae
+// ae : https://en.wikipedia.org/wiki/.ae
 // see also: "Domain Name Eligibility Policy" at http://www.aeda.ae/eng/aepolicy.php
 ae
 co.ae
@@ -28,7 +33,7 @@ ac.ae
 gov.ae
 mil.ae
 
-// aero : see http://www.information.aero/index.php?id=66
+// aero : see https://www.information.aero/index.php?id=66
 aero
 accident-investigation.aero
 accident-prevention.aero
@@ -150,10 +155,10 @@ mil.al
 net.al
 org.al
 
-// am : http://en.wikipedia.org/wiki/.am
+// am : https://en.wikipedia.org/wiki/.am
 am
 
-// ao : http://en.wikipedia.org/wiki/.ao
+// ao : https://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
 ao
 ed.ao
@@ -163,7 +168,7 @@ co.ao
 pb.ao
 it.ao
 
-// aq : http://en.wikipedia.org/wiki/.aq
+// aq : https://en.wikipedia.org/wiki/.aq
 aq
 
 // ar : https://nic.ar/normativa-vigente.xhtml
@@ -178,7 +183,7 @@ net.ar
 org.ar
 tur.ar
 
-// arpa : http://en.wikipedia.org/wiki/.arpa
+// arpa : https://en.wikipedia.org/wiki/.arpa
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 arpa
 e164.arpa
@@ -188,14 +193,14 @@ iris.arpa
 uri.arpa
 urn.arpa
 
-// as : http://en.wikipedia.org/wiki/.as
+// as : https://en.wikipedia.org/wiki/.as
 as
 gov.as
 
-// asia : http://en.wikipedia.org/wiki/.asia
+// asia : https://en.wikipedia.org/wiki/.asia
 asia
 
-// at : http://en.wikipedia.org/wiki/.at
+// at : https://en.wikipedia.org/wiki/.at
 // Confirmed by registry <it@nic.at> 2008-06-17
 at
 ac.at
@@ -203,7 +208,7 @@ co.at
 gv.at
 or.at
 
-// au : http://en.wikipedia.org/wiki/.au
+// au : https://en.wikipedia.org/wiki/.au
 // http://www.auda.org.au/
 au
 // 2LDs
@@ -245,14 +250,14 @@ tas.gov.au
 vic.gov.au
 wa.gov.au
 
-// aw : http://en.wikipedia.org/wiki/.aw
+// aw : https://en.wikipedia.org/wiki/.aw
 aw
 com.aw
 
-// ax : http://en.wikipedia.org/wiki/.ax
+// ax : https://en.wikipedia.org/wiki/.ax
 ax
 
-// az : http://en.wikipedia.org/wiki/.az
+// az : https://en.wikipedia.org/wiki/.az
 az
 com.az
 net.az
@@ -267,20 +272,16 @@ name.az
 pro.az
 biz.az
 
-// ba : http://en.wikipedia.org/wiki/.ba
+// ba : http://nic.ba/users_data/files/pravilnik_o_registraciji.pdf
 ba
-org.ba
-net.ba
+com.ba
 edu.ba
 gov.ba
 mil.ba
-unsa.ba
-unbi.ba
-co.ba
-com.ba
-rs.ba
+net.ba
+org.ba
 
-// bb : http://en.wikipedia.org/wiki/.bb
+// bb : https://en.wikipedia.org/wiki/.bb
 bb
 biz.bb
 co.bb
@@ -293,19 +294,19 @@ org.bb
 store.bb
 tv.bb
 
-// bd : http://en.wikipedia.org/wiki/.bd
+// bd : https://en.wikipedia.org/wiki/.bd
 *.bd
 
-// be : http://en.wikipedia.org/wiki/.be
+// be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be
 ac.be
 
-// bf : http://en.wikipedia.org/wiki/.bf
+// bf : https://en.wikipedia.org/wiki/.bf
 bf
 gov.bf
 
-// bg : http://en.wikipedia.org/wiki/.bg
+// bg : https://en.wikipedia.org/wiki/.bg
 // https://www.register.bg/user/static/rules/en/index.html
 bg
 a.bg
@@ -345,7 +346,7 @@ z.bg
 8.bg
 9.bg
 
-// bh : http://en.wikipedia.org/wiki/.bh
+// bh : https://en.wikipedia.org/wiki/.bh
 bh
 com.bh
 edu.bh
@@ -353,7 +354,7 @@ net.bh
 org.bh
 gov.bh
 
-// bi : http://en.wikipedia.org/wiki/.bi
+// bi : https://en.wikipedia.org/wiki/.bi
 // http://whois.nic.bi/
 bi
 co.bi
@@ -362,10 +363,10 @@ edu.bi
 or.bi
 org.bi
 
-// biz : http://en.wikipedia.org/wiki/.biz
+// biz : https://en.wikipedia.org/wiki/.biz
 biz
 
-// bj : http://en.wikipedia.org/wiki/.bj
+// bj : https://en.wikipedia.org/wiki/.bj
 bj
 asso.bj
 barreau.bj
@@ -379,7 +380,7 @@ gov.bm
 net.bm
 org.bm
 
-// bn : http://en.wikipedia.org/wiki/.bn
+// bn : https://en.wikipedia.org/wiki/.bn
 *.bn
 
 // bo : http://www.nic.bo/
@@ -476,7 +477,7 @@ org.bs
 edu.bs
 gov.bs
 
-// bt : http://en.wikipedia.org/wiki/.bt
+// bt : https://en.wikipedia.org/wiki/.bt
 bt
 com.bt
 edu.bt
@@ -488,14 +489,14 @@ org.bt
 // Submitted by registry <jarle@uninett.no>
 bv
 
-// bw : http://en.wikipedia.org/wiki/.bw
+// bw : https://en.wikipedia.org/wiki/.bw
 // http://www.gobin.info/domainname/bw.doc
 // list of other 2nd level tlds ?
 bw
 co.bw
 org.bw
 
-// by : http://en.wikipedia.org/wiki/.by
+// by : https://en.wikipedia.org/wiki/.by
 // http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
 by
@@ -509,7 +510,7 @@ com.by
 // http://hoster.by/
 of.by
 
-// bz : http://en.wikipedia.org/wiki/.bz
+// bz : https://en.wikipedia.org/wiki/.bz
 // http://www.belizenic.bz/
 bz
 com.bz
@@ -518,7 +519,7 @@ org.bz
 edu.bz
 gov.bz
 
-// ca : http://en.wikipedia.org/wiki/.ca
+// ca : https://en.wikipedia.org/wiki/.ca
 ca
 // ca geographical names
 ab.ca
@@ -535,31 +536,31 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: http://en.wikipedia.org/wiki/.gc.ca
+// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
 // see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
 
-// cat : http://en.wikipedia.org/wiki/.cat
+// cat : https://en.wikipedia.org/wiki/.cat
 cat
 
-// cc : http://en.wikipedia.org/wiki/.cc
+// cc : https://en.wikipedia.org/wiki/.cc
 cc
 
-// cd : http://en.wikipedia.org/wiki/.cd
+// cd : https://en.wikipedia.org/wiki/.cd
 // see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1
 cd
 gov.cd
 
-// cf : http://en.wikipedia.org/wiki/.cf
+// cf : https://en.wikipedia.org/wiki/.cf
 cf
 
-// cg : http://en.wikipedia.org/wiki/.cg
+// cg : https://en.wikipedia.org/wiki/.cg
 cg
 
-// ch : http://en.wikipedia.org/wiki/.ch
+// ch : https://en.wikipedia.org/wiki/.ch
 ch
 
-// ci : http://en.wikipedia.org/wiki/.ci
+// ci : https://en.wikipedia.org/wiki/.ci
 // http://www.nic.ci/index.php?page=charte
 ci
 org.ci
@@ -578,25 +579,25 @@ presse.ci
 md.ci
 gouv.ci
 
-// ck : http://en.wikipedia.org/wiki/.ck
+// ck : https://en.wikipedia.org/wiki/.ck
 *.ck
 !www.ck
 
-// cl : http://en.wikipedia.org/wiki/.cl
+// cl : https://en.wikipedia.org/wiki/.cl
 cl
 gov.cl
 gob.cl
 co.cl
 mil.cl
 
-// cm : http://en.wikipedia.org/wiki/.cm plus bug 981927
+// cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
 cm
 co.cm
 com.cm
 gov.cm
 net.cm
 
-// cn : http://en.wikipedia.org/wiki/.cn
+// cn : https://en.wikipedia.org/wiki/.cn
 // Submitted by registry <tanyaling@cnnic.cn>
 cn
 ac.cn
@@ -645,7 +646,7 @@ hk.cn
 mo.cn
 tw.cn
 
-// co : http://en.wikipedia.org/wiki/.co
+// co : https://en.wikipedia.org/wiki/.co
 // Submitted by registry <tecnico@uniandes.edu.co>
 co
 arts.co
@@ -662,10 +663,10 @@ org.co
 rec.co
 web.co
 
-// com : http://en.wikipedia.org/wiki/.com
+// com : https://en.wikipedia.org/wiki/.com
 com
 
-// coop : http://en.wikipedia.org/wiki/.coop
+// coop : https://en.wikipedia.org/wiki/.coop
 coop
 
 // cr : http://www.nic.cr/niccr_publico/showRegistroDominiosScreen.do
@@ -678,7 +679,7 @@ go.cr
 or.cr
 sa.cr
 
-// cu : http://en.wikipedia.org/wiki/.cu
+// cu : https://en.wikipedia.org/wiki/.cu
 cu
 com.cu
 edu.cu
@@ -687,7 +688,7 @@ net.cu
 gov.cu
 inf.cu
 
-// cv : http://en.wikipedia.org/wiki/.cv
+// cv : https://en.wikipedia.org/wiki/.cv
 cv
 
 // cw : http://www.una.cw/cw_registry/
@@ -698,12 +699,12 @@ edu.cw
 net.cw
 org.cw
 
-// cx : http://en.wikipedia.org/wiki/.cx
+// cx : https://en.wikipedia.org/wiki/.cx
 // list of other 2nd level tlds ?
 cx
 gov.cx
 
-// cy : http://en.wikipedia.org/wiki/.cy
+// cy : https://en.wikipedia.org/wiki/.cy
 ac.cy
 biz.cy
 com.cy
@@ -718,22 +719,22 @@ press.cy
 pro.cy
 tm.cy
 
-// cz : http://en.wikipedia.org/wiki/.cz
+// cz : https://en.wikipedia.org/wiki/.cz
 cz
 
-// de : http://en.wikipedia.org/wiki/.de
+// de : https://en.wikipedia.org/wiki/.de
 // Confirmed by registry <ops@denic.de> (with technical
 // reservations) 2008-07-01
 de
 
-// dj : http://en.wikipedia.org/wiki/.dj
+// dj : https://en.wikipedia.org/wiki/.dj
 dj
 
-// dk : http://en.wikipedia.org/wiki/.dk
+// dk : https://en.wikipedia.org/wiki/.dk
 // Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17
 dk
 
-// dm : http://en.wikipedia.org/wiki/.dm
+// dm : https://en.wikipedia.org/wiki/.dm
 dm
 com.dm
 net.dm
@@ -741,7 +742,7 @@ org.dm
 edu.dm
 gov.dm
 
-// do : http://en.wikipedia.org/wiki/.do
+// do : https://en.wikipedia.org/wiki/.do
 do
 art.do
 com.do
@@ -754,7 +755,7 @@ org.do
 sld.do
 web.do
 
-// dz : http://en.wikipedia.org/wiki/.dz
+// dz : https://en.wikipedia.org/wiki/.dz
 dz
 com.dz
 org.dz
@@ -781,7 +782,7 @@ gov.ec
 gob.ec
 mil.ec
 
-// edu : http://en.wikipedia.org/wiki/.edu
+// edu : https://en.wikipedia.org/wiki/.edu
 edu
 
 // ee : http://www.eenet.ee/EENet/dom_reeglid.html#lisa_B
@@ -797,7 +798,7 @@ aip.ee
 org.ee
 fie.ee
 
-// eg : http://en.wikipedia.org/wiki/.eg
+// eg : https://en.wikipedia.org/wiki/.eg
 eg
 com.eg
 edu.eg
@@ -809,7 +810,7 @@ net.eg
 org.eg
 sci.eg
 
-// er : http://en.wikipedia.org/wiki/.er
+// er : https://en.wikipedia.org/wiki/.er
 *.er
 
 // es : https://www.nic.es/site_ingles/ingles/dominios/index.html
@@ -820,7 +821,7 @@ org.es
 gob.es
 edu.es
 
-// et : http://en.wikipedia.org/wiki/.et
+// et : https://en.wikipedia.org/wiki/.et
 et
 com.et
 gov.et
@@ -831,28 +832,28 @@ name.et
 info.et
 net.et
 
-// eu : http://en.wikipedia.org/wiki/.eu
+// eu : https://en.wikipedia.org/wiki/.eu
 eu
 
-// fi : http://en.wikipedia.org/wiki/.fi
+// fi : https://en.wikipedia.org/wiki/.fi
 fi
-// aland.fi : http://en.wikipedia.org/wiki/.ax
+// aland.fi : https://en.wikipedia.org/wiki/.ax
 // This domain is being phased out in favor of .ax. As there are still many
 // domains under aland.fi, we still keep it on the list until aland.fi is
 // completely removed.
 // TODO: Check for updates (expected to be phased out around Q1/2009)
 aland.fi
 
-// fj : http://en.wikipedia.org/wiki/.fj
+// fj : https://en.wikipedia.org/wiki/.fj
 *.fj
 
-// fk : http://en.wikipedia.org/wiki/.fk
+// fk : https://en.wikipedia.org/wiki/.fk
 *.fk
 
-// fm : http://en.wikipedia.org/wiki/.fm
+// fm : https://en.wikipedia.org/wiki/.fm
 fm
 
-// fo : http://en.wikipedia.org/wiki/.fo
+// fo : https://en.wikipedia.org/wiki/.fo
 fo
 
 // fr : http://www.afnic.fr/
@@ -883,14 +884,14 @@ pharmacien.fr
 port.fr
 veterinaire.fr
 
-// ga : http://en.wikipedia.org/wiki/.ga
+// ga : https://en.wikipedia.org/wiki/.ga
 ga
 
 // gb : This registry is effectively dormant
 // Submitted by registry <Damien.Shaw@ja.net>
 gb
 
-// gd : http://en.wikipedia.org/wiki/.gd
+// gd : https://en.wikipedia.org/wiki/.gd
 gd
 
 // ge : http://www.nic.net.ge/policy_en.pdf
@@ -903,7 +904,7 @@ mil.ge
 net.ge
 pvt.ge
 
-// gf : http://en.wikipedia.org/wiki/.gf
+// gf : https://en.wikipedia.org/wiki/.gf
 gf
 
 // gg : http://www.channelisles.net/register-domains/
@@ -913,7 +914,7 @@ co.gg
 net.gg
 org.gg
 
-// gh : http://en.wikipedia.org/wiki/.gh
+// gh : https://en.wikipedia.org/wiki/.gh
 // see also: http://www.nic.gh/reg_now.php
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
@@ -933,7 +934,7 @@ mod.gi
 edu.gi
 org.gi
 
-// gl : http://en.wikipedia.org/wiki/.gl
+// gl : https://en.wikipedia.org/wiki/.gl
 // http://nic.gl
 gl
 co.gl
@@ -955,7 +956,7 @@ gov.gn
 org.gn
 net.gn
 
-// gov : http://en.wikipedia.org/wiki/.gov
+// gov : https://en.wikipedia.org/wiki/.gov
 gov
 
 // gp : http://www.nic.gp/index.php?lang=en
@@ -967,7 +968,7 @@ edu.gp
 org.gp
 asso.gp
 
-// gq : http://en.wikipedia.org/wiki/.gq
+// gq : https://en.wikipedia.org/wiki/.gq
 gq
 
 // gr : https://grweb.ics.forth.gr/english/1617-B-2005.html
@@ -979,7 +980,7 @@ net.gr
 org.gr
 gov.gr
 
-// gs : http://en.wikipedia.org/wiki/.gs
+// gs : https://en.wikipedia.org/wiki/.gs
 gs
 
 // gt : http://www.gt/politicas_de_registro.html
@@ -995,10 +996,10 @@ org.gt
 // gu : http://gadao.gov.gu/registration.txt
 *.gu
 
-// gw : http://en.wikipedia.org/wiki/.gw
+// gw : https://en.wikipedia.org/wiki/.gw
 gw
 
-// gy : http://en.wikipedia.org/wiki/.gy
+// gy : https://en.wikipedia.org/wiki/.gy
 // http://registry.gy/
 gy
 co.gy
@@ -1033,7 +1034,7 @@ org.hk
 組織.hk
 組织.hk
 
-// hm : http://en.wikipedia.org/wiki/.hm
+// hm : https://en.wikipedia.org/wiki/.hm
 hm
 
 // hn : http://www.nic.hn/politicas/ps02,,05.html
@@ -1121,7 +1122,7 @@ or.id
 sch.id
 web.id
 
-// ie : http://en.wikipedia.org/wiki/.ie
+// ie : https://en.wikipedia.org/wiki/.ie
 ie
 gov.ie
 
@@ -1149,7 +1150,7 @@ plc.co.im
 tt.im
 tv.im
 
-// in : http://en.wikipedia.org/wiki/.in
+// in : https://en.wikipedia.org/wiki/.in
 // see also: https://registry.in/Policies
 // Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
@@ -1167,10 +1168,10 @@ res.in
 gov.in
 mil.in
 
-// info : http://en.wikipedia.org/wiki/.info
+// info : https://en.wikipedia.org/wiki/.info
 info
 
-// int : http://en.wikipedia.org/wiki/.int
+// int : https://en.wikipedia.org/wiki/.int
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 int
 eu.int
@@ -1215,7 +1216,7 @@ gov.is
 org.is
 int.is
 
-// it : http://en.wikipedia.org/wiki/.it
+// it : https://en.wikipedia.org/wiki/.it
 it
 gov.it
 edu.it
@@ -1613,10 +1614,10 @@ gov.jo
 mil.jo
 name.jo
 
-// jobs : http://en.wikipedia.org/wiki/.jobs
+// jobs : https://en.wikipedia.org/wiki/.jobs
 jobs
 
-// jp : http://en.wikipedia.org/wiki/.jp
+// jp : https://en.wikipedia.org/wiki/.jp
 // http://jprs.co.jp/en/jpdomain.html
 // Submitted by registry <info@jprs.jp>
 jp
@@ -2549,7 +2550,6 @@ hitoyoshi.kumamoto.jp
 kamiamakusa.kumamoto.jp
 kashima.kumamoto.jp
 kikuchi.kumamoto.jp
-kosa.kumamoto.jp
 kumamoto.kumamoto.jp
 mashiki.kumamoto.jp
 mifune.kumamoto.jp
@@ -2634,7 +2634,6 @@ iwanuma.miyagi.jp
 kakuda.miyagi.jp
 kami.miyagi.jp
 kawasaki.miyagi.jp
-kesennuma.miyagi.jp
 marumori.miyagi.jp
 matsushima.miyagi.jp
 minamisanriku.miyagi.jp
@@ -3445,7 +3444,7 @@ gov.ki
 info.ki
 com.ki
 
-// km : http://en.wikipedia.org/wiki/.km
+// km : https://en.wikipedia.org/wiki/.km
 // http://www.domaine.km/documents/charte.doc
 km
 org.km
@@ -3458,7 +3457,7 @@ mil.km
 ass.km
 com.km
 // These are only mentioned as proposed suggestions at domaine.km, but
-// http://en.wikipedia.org/wiki/.km says they're available for registration:
+// https://en.wikipedia.org/wiki/.km says they're available for registration:
 coop.km
 asso.km
 presse.km
@@ -3468,7 +3467,7 @@ pharmaciens.km
 veterinaire.km
 gouv.km
 
-// kn : http://en.wikipedia.org/wiki/.kn
+// kn : https://en.wikipedia.org/wiki/.kn
 // http://www.dot.kn/domainRules.html
 kn
 net.kn
@@ -3485,7 +3484,7 @@ org.kp
 rep.kp
 tra.kp
 
-// kr : http://en.wikipedia.org/wiki/.kr
+// kr : https://en.wikipedia.org/wiki/.kr
 // see also: http://domain.nida.or.kr/eng/registration.jsp
 kr
 ac.kr
@@ -3519,7 +3518,7 @@ jeonnam.kr
 seoul.kr
 ulsan.kr
 
-// kw : http://en.wikipedia.org/wiki/.kw
+// kw : https://en.wikipedia.org/wiki/.kw
 *.kw
 
 // ky : http://www.icta.ky/da_ky_reg_dom.php
@@ -3531,7 +3530,7 @@ com.ky
 org.ky
 net.ky
 
-// kz : http://en.wikipedia.org/wiki/.kz
+// kz : https://en.wikipedia.org/wiki/.kz
 // see also: http://www.nic.kz/rules/index.jsp
 kz
 org.kz
@@ -3541,7 +3540,7 @@ gov.kz
 mil.kz
 com.kz
 
-// la : http://en.wikipedia.org/wiki/.la
+// la : https://en.wikipedia.org/wiki/.la
 // Submitted by registry <gavin.brown@nic.la>
 la
 int.la
@@ -3553,7 +3552,7 @@ per.la
 com.la
 org.la
 
-// lb : http://en.wikipedia.org/wiki/.lb
+// lb : https://en.wikipedia.org/wiki/.lb
 // Submitted by registry <randy@psg.com>
 lb
 com.lb
@@ -3562,7 +3561,7 @@ gov.lb
 net.lb
 org.lb
 
-// lc : http://en.wikipedia.org/wiki/.lc
+// lc : https://en.wikipedia.org/wiki/.lc
 // see also: http://www.nic.lc/rules.htm
 lc
 com.lc
@@ -3572,7 +3571,7 @@ org.lc
 edu.lc
 gov.lc
 
-// li : http://en.wikipedia.org/wiki/.li
+// li : https://en.wikipedia.org/wiki/.li
 li
 
 // lk : http://www.nic.lk/seclevpr.html
@@ -3602,12 +3601,12 @@ gov.lr
 org.lr
 net.lr
 
-// ls : http://en.wikipedia.org/wiki/.ls
+// ls : https://en.wikipedia.org/wiki/.ls
 ls
 co.ls
 org.ls
 
-// lt : http://en.wikipedia.org/wiki/.lt
+// lt : https://en.wikipedia.org/wiki/.lt
 lt
 // gov.lt : http://www.gov.lt/index_en.php
 gov.lt
@@ -3639,7 +3638,7 @@ med.ly
 org.ly
 id.ly
 
-// ma : http://en.wikipedia.org/wiki/.ma
+// ma : https://en.wikipedia.org/wiki/.ma
 // http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
 co.ma
@@ -3654,10 +3653,10 @@ mc
 tm.mc
 asso.mc
 
-// md : http://en.wikipedia.org/wiki/.md
+// md : https://en.wikipedia.org/wiki/.md
 md
 
-// me : http://en.wikipedia.org/wiki/.me
+// me : https://en.wikipedia.org/wiki/.me
 me
 co.me
 net.me
@@ -3680,13 +3679,13 @@ mil.mg
 com.mg
 co.mg
 
-// mh : http://en.wikipedia.org/wiki/.mh
+// mh : https://en.wikipedia.org/wiki/.mh
 mh
 
-// mil : http://en.wikipedia.org/wiki/.mil
+// mil : https://en.wikipedia.org/wiki/.mil
 mil
 
-// mk : http://en.wikipedia.org/wiki/.mk
+// mk : https://en.wikipedia.org/wiki/.mk
 // see also: http://dns.marnet.net.mk/postapka.php
 mk
 com.mk
@@ -3698,7 +3697,7 @@ inf.mk
 name.mk
 
 // ml : http://www.gobin.info/domainname/ml-template.doc
-// see also: http://en.wikipedia.org/wiki/.ml
+// see also: https://en.wikipedia.org/wiki/.ml
 ml
 com.ml
 edu.ml
@@ -3708,10 +3707,10 @@ net.ml
 org.ml
 presse.ml
 
-// mm : http://en.wikipedia.org/wiki/.mm
+// mm : https://en.wikipedia.org/wiki/.mm
 *.mm
 
-// mn : http://en.wikipedia.org/wiki/.mn
+// mn : https://en.wikipedia.org/wiki/.mn
 mn
 gov.mn
 edu.mn
@@ -3725,17 +3724,17 @@ org.mo
 edu.mo
 gov.mo
 
-// mobi : http://en.wikipedia.org/wiki/.mobi
+// mobi : https://en.wikipedia.org/wiki/.mobi
 mobi
 
 // mp : http://www.dot.mp/
 // Confirmed by registry <dcamacho@saipan.com> 2008-06-17
 mp
 
-// mq : http://en.wikipedia.org/wiki/.mq
+// mq : https://en.wikipedia.org/wiki/.mq
 mq
 
-// mr : http://en.wikipedia.org/wiki/.mr
+// mr : https://en.wikipedia.org/wiki/.mr
 mr
 gov.mr
 
@@ -3755,7 +3754,7 @@ edu.mt
 net.mt
 org.mt
 
-// mu : http://en.wikipedia.org/wiki/.mu
+// mu : https://en.wikipedia.org/wiki/.mu
 mu
 com.mu
 net.mu
@@ -4317,7 +4316,7 @@ zoology.museum
 ירושלים.museum
 иком.museum
 
-// mv : http://en.wikipedia.org/wiki/.mv
+// mv : https://en.wikipedia.org/wiki/.mv
 // "mv" included because, contra Wikipedia, google.mv exists.
 mv
 aero.mv
@@ -4368,9 +4367,17 @@ edu.my
 mil.my
 name.my
 
-// mz : http://www.gobin.info/domainname/mz-template.doc
-*.mz
-!teledata.mz
+// mz : http://www.uem.mz/
+// Submitted by registry <antonio@uem.mz>
+mz
+ac.mz
+adv.mz
+co.mz
+edu.mz
+gov.mz
+mil.mz
+net.mz
+org.mz
 
 // na : http://www.na-nic.com.na/
 // http://www.info.na/domain/
@@ -4400,13 +4407,13 @@ name
 nc
 asso.nc
 
-// ne : http://en.wikipedia.org/wiki/.ne
+// ne : https://en.wikipedia.org/wiki/.ne
 ne
 
-// net : http://en.wikipedia.org/wiki/.net
+// net : https://en.wikipedia.org/wiki/.net
 net
 
-// nf : http://en.wikipedia.org/wiki/.nf
+// nf : https://en.wikipedia.org/wiki/.nf
 nf
 com.nf
 net.nf
@@ -4448,7 +4455,7 @@ ac.ni
 in.ni
 info.ni
 
-// nl : http://en.wikipedia.org/wiki/.nl
+// nl : https://en.wikipedia.org/wiki/.nl
 //      https://www.sidn.nl/
 //      ccTLD for the Netherlands
 nl
@@ -5237,10 +5244,10 @@ org.nr
 net.nr
 com.nr
 
-// nu : http://en.wikipedia.org/wiki/.nu
+// nu : https://en.wikipedia.org/wiki/.nu
 nu
 
-// nz : http://en.wikipedia.org/wiki/.nz
+// nz : https://en.wikipedia.org/wiki/.nz
 // Submitted by registry <jay@nzrs.net.nz>
 nz
 ac.nz
@@ -5260,7 +5267,7 @@ org.nz
 parliament.nz
 school.nz
 
-// om : http://en.wikipedia.org/wiki/.om
+// om : https://en.wikipedia.org/wiki/.om
 om
 co.om
 com.om
@@ -5272,7 +5279,7 @@ net.om
 org.om
 pro.om
 
-// org : http://en.wikipedia.org/wiki/.org
+// org : https://en.wikipedia.org/wiki/.org
 org
 
 // pa : http://www.nic.pa/
@@ -5307,7 +5314,7 @@ com.pf
 org.pf
 edu.pf
 
-// pg : http://en.wikipedia.org/wiki/.pg
+// pg : https://en.wikipedia.org/wiki/.pg
 *.pg
 
 // ph : http://www.domains.ph/FAQ2.asp
@@ -5557,7 +5564,7 @@ org.pn
 edu.pn
 net.pn
 
-// post : http://en.wikipedia.org/wiki/.post
+// post : https://en.wikipedia.org/wiki/.post
 post
 
 // pr : http://www.nic.pr/index.asp?f=1
@@ -5572,22 +5579,26 @@ pro.pr
 biz.pr
 info.pr
 name.pr
-// these aren't mentioned on nic.pr, but on http://en.wikipedia.org/wiki/.pr
+// these aren't mentioned on nic.pr, but on https://en.wikipedia.org/wiki/.pr
 est.pr
 prof.pr
 ac.pr
 
-// pro : http://www.nic.pro/support_faq.htm
+// pro : http://registry.pro/get-pro
 pro
+aaa.pro
 aca.pro
+acct.pro
+avocat.pro
 bar.pro
 cpa.pro
+eng.pro
 jur.pro
 law.pro
 med.pro
-eng.pro
+recht.pro
 
-// ps : http://en.wikipedia.org/wiki/.ps
+// ps : https://en.wikipedia.org/wiki/.ps
 // http://www.nic.ps/registration/policy.html#reg
 ps
 edu.ps
@@ -5609,7 +5620,7 @@ publ.pt
 com.pt
 nome.pt
 
-// pw : http://en.wikipedia.org/wiki/.pw
+// pw : https://en.wikipedia.org/wiki/.pw
 pw
 co.pw
 ne.pw
@@ -5860,7 +5871,7 @@ tv.sd
 gov.sd
 info.sd
 
-// se : http://en.wikipedia.org/wiki/.se
+// se : https://en.wikipedia.org/wiki/.se
 // Submitted by registry <patrik.wallstrom@iis.se>
 se
 a.se
@@ -5920,14 +5931,14 @@ gov.sh
 org.sh
 mil.sh
 
-// si : http://en.wikipedia.org/wiki/.si
+// si : https://en.wikipedia.org/wiki/.si
 si
 
 // sj : No registrations at this time.
 // Submitted by registry <jarle@uninett.no>
 sj
 
-// sk : http://en.wikipedia.org/wiki/.sk
+// sk : https://en.wikipedia.org/wiki/.sk
 // list of 2nd level domains ?
 sk
 
@@ -5940,10 +5951,10 @@ edu.sl
 gov.sl
 org.sl
 
-// sm : http://en.wikipedia.org/wiki/.sm
+// sm : https://en.wikipedia.org/wiki/.sm
 sm
 
-// sn : http://en.wikipedia.org/wiki/.sn
+// sn : https://en.wikipedia.org/wiki/.sn
 sn
 art.sn
 com.sn
@@ -5959,7 +5970,7 @@ com.so
 net.so
 org.so
 
-// sr : http://en.wikipedia.org/wiki/.sr
+// sr : https://en.wikipedia.org/wiki/.sr
 sr
 
 // st : http://www.nic.st/html/policyrules/
@@ -5977,7 +5988,7 @@ principe.st
 saotome.st
 store.st
 
-// su : http://en.wikipedia.org/wiki/.su
+// su : https://en.wikipedia.org/wiki/.su
 su
 adygeya.su
 arkhangelsk.su
@@ -6020,12 +6031,12 @@ gob.sv
 org.sv
 red.sv
 
-// sx : http://en.wikipedia.org/wiki/.sx
+// sx : https://en.wikipedia.org/wiki/.sx
 // Submitted by registry <jcvignes@openregistry.com>
 sx
 gov.sx
 
-// sy : http://en.wikipedia.org/wiki/.sy
+// sy : https://en.wikipedia.org/wiki/.sy
 // see also: http://www.gobin.info/domainname/sy.doc
 sy
 edu.sy
@@ -6035,31 +6046,31 @@ mil.sy
 com.sy
 org.sy
 
-// sz : http://en.wikipedia.org/wiki/.sz
+// sz : https://en.wikipedia.org/wiki/.sz
 // http://www.sispa.org.sz/
 sz
 co.sz
 ac.sz
 org.sz
 
-// tc : http://en.wikipedia.org/wiki/.tc
+// tc : https://en.wikipedia.org/wiki/.tc
 tc
 
-// td : http://en.wikipedia.org/wiki/.td
+// td : https://en.wikipedia.org/wiki/.td
 td
 
-// tel: http://en.wikipedia.org/wiki/.tel
+// tel: https://en.wikipedia.org/wiki/.tel
 // http://www.telnic.org/
 tel
 
-// tf : http://en.wikipedia.org/wiki/.tf
+// tf : https://en.wikipedia.org/wiki/.tf
 tf
 
-// tg : http://en.wikipedia.org/wiki/.tg
+// tg : https://en.wikipedia.org/wiki/.tg
 // http://www.nic.tg/
 tg
 
-// th : http://en.wikipedia.org/wiki/.th
+// th : https://en.wikipedia.org/wiki/.th
 // Submitted by registry <krit@thains.co.th>
 th
 ac.th
@@ -6088,10 +6099,10 @@ org.tj
 test.tj
 web.tj
 
-// tk : http://en.wikipedia.org/wiki/.tk
+// tk : https://en.wikipedia.org/wiki/.tk
 tk
 
-// tl : http://en.wikipedia.org/wiki/.tl
+// tl : https://en.wikipedia.org/wiki/.tl
 tl
 gov.tl
 
@@ -6106,7 +6117,7 @@ gov.tm
 mil.tm
 edu.tm
 
-// tn : http://en.wikipedia.org/wiki/.tn
+// tn : https://en.wikipedia.org/wiki/.tn
 // http://whois.ati.tn/
 tn
 com.tn
@@ -6130,7 +6141,7 @@ agrinet.tn
 defense.tn
 turen.tn
 
-// to : http://en.wikipedia.org/wiki/.to
+// to : https://en.wikipedia.org/wiki/.to
 // Submitted by registry <egullich@colo.to>
 to
 com.to
@@ -6171,7 +6182,7 @@ nc.tr
 // Used by government agencies of Northern Cyprus
 gov.nc.tr
 
-// travel : http://en.wikipedia.org/wiki/.travel
+// travel : https://en.wikipedia.org/wiki/.travel
 travel
 
 // tt : http://www.nic.tt/
@@ -6194,12 +6205,12 @@ name.tt
 gov.tt
 edu.tt
 
-// tv : http://en.wikipedia.org/wiki/.tv
+// tv : https://en.wikipedia.org/wiki/.tv
 // Not listing any 2LDs as reserved since none seem to exist in practice,
 // Wikipedia notwithstanding.
 tv
 
-// tw : http://en.wikipedia.org/wiki/.tw
+// tw : https://en.wikipedia.org/wiki/.tw
 tw
 edu.tw
 gov.tw
@@ -6325,7 +6336,7 @@ ne.ug
 com.ug
 org.ug
 
-// uk : http://en.wikipedia.org/wiki/.uk
+// uk : https://en.wikipedia.org/wiki/.uk
 // Submitted by registry <Michael.Daly@nominet.org.uk>
 uk
 ac.uk
@@ -6340,7 +6351,7 @@ plc.uk
 police.uk
 *.sch.uk
 
-// us : http://en.wikipedia.org/wiki/.us
+// us : https://en.wikipedia.org/wiki/.us
 us
 dni.us
 fed.us
@@ -6528,7 +6539,7 @@ lib.ca.us
 lib.co.us
 lib.ct.us
 lib.dc.us
-lib.de.us
+// lib.de.us  Issue #243 - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
 lib.fl.us
 lib.ga.us
 lib.gu.us
@@ -6598,10 +6609,10 @@ com.uz
 net.uz
 org.uz
 
-// va : http://en.wikipedia.org/wiki/.va
+// va : https://en.wikipedia.org/wiki/.va
 va
 
-// vc : http://en.wikipedia.org/wiki/.vc
+// vc : https://en.wikipedia.org/wiki/.vc
 // Submitted by registry <kshah@ca.afilias.info>
 vc
 com.vc
@@ -6632,7 +6643,7 @@ store.ve
 tec.ve
 web.ve
 
-// vg : http://en.wikipedia.org/wiki/.vg
+// vg : https://en.wikipedia.org/wiki/.vg
 vg
 
 // vi : http://www.nic.vi/newdomainform.htm
@@ -6661,7 +6672,7 @@ name.vn
 pro.vn
 health.vn
 
-// vu : http://en.wikipedia.org/wiki/.vu
+// vu : https://en.wikipedia.org/wiki/.vu
 // http://www.vunic.vu/
 vu
 com.vu
@@ -6672,7 +6683,7 @@ org.vu
 // wf : http://www.afnic.fr/medias/documents/AFNIC-naming-policy2012.pdf
 wf
 
-// ws : http://en.wikipedia.org/wiki/.ws
+// ws : https://en.wikipedia.org/wiki/.ws
 // http://samoanic.ws/index.dhtml
 ws
 com.ws
@@ -6722,6 +6733,9 @@ yt
 // xn--wgbh1c ("Egypt/Masr", Arabic) : EG
 // http://www.dotmasr.eg/
 مصر
+
+// xn--e1a4c ("eu", Cyrillic) : EU
+ею
 
 // xn--node ("ge", Georgian Mkhedruli) : GE
 გე
@@ -6922,14 +6936,26 @@ school.za
 tm.za
 web.za
 
-// zm : http://en.wikipedia.org/wiki/.zm
-*.zm
+// zm : https://zicta.zm/
+// Submitted by registry <info@zicta.zm>
+zm
+ac.zm
+biz.zm
+co.zm
+com.zm
+edu.zm
+gov.zm
+info.zm
+mil.zm
+net.zm
+org.zm
+sch.zm
 
-// zw : http://en.wikipedia.org/wiki/.zw
+// zw : https://en.wikipedia.org/wiki/.zw
 *.zw
 
 
-// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2016-01-04T22:39:54Z
+// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2016-08-17T00:17:46Z
 
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -7005,9 +7031,6 @@ afl
 
 // africa : 2014-03-24 ZA Central Registry NPC trading as Registry.Africa
 africa
-
-// africamagic : 2015-03-05 Electronic Media Network (Pty) Ltd
-africamagic
 
 // agakhan : 2015-04-23 Fondation Aga Khan (Aga Khan Foundation)
 agakhan
@@ -7113,6 +7136,9 @@ archi
 
 // army : 2014-03-06 United TLD Holdco Ltd.
 army
+
+// art : 2016-03-24 UK Creative Ideas Limited
+art
 
 // arte : 2014-12-11 Association Relative à la Télévision Européenne G.E.I.E.
 arte
@@ -7285,7 +7311,7 @@ blanco
 // blockbuster : 2015-07-30 Dish DBS Corporation
 blockbuster
 
-// blog : 2015-05-14 PRIMER NIVEL S.A.
+// blog : 2015-05-14
 blog
 
 // bloomberg : 2014-07-17 Bloomberg IP Holdings LLC
@@ -7407,6 +7433,9 @@ call
 
 // calvinklein : 2015-07-30 PVH gTLD Holdings LLC
 calvinklein
+
+// cam : 2016-04-21 AC Webconnecting Holding B.V.
+cam
 
 // camera : 2013-08-27 Atomic Maple, LLC
 camera
@@ -7708,6 +7737,9 @@ dad
 // dance : 2013-10-24 United TLD Holdco Ltd.
 dance
 
+// data : 2016-06-02 Dish DBS Corporation
+data
+
 // date : 2014-11-20 dot Date Limited
 date
 
@@ -7804,6 +7836,9 @@ dnp
 // docs : 2014-10-16 Charleston Road Registry Inc.
 docs
 
+// doctor : 2016-06-02 Brice Trail, LLC
+doctor
+
 // dodge : 2015-07-30 FCA US LLC.
 dodge
 
@@ -7816,9 +7851,6 @@ doha
 // domains : 2013-10-17 Sugar Cross, LLC
 domains
 
-// doosan : 2014-04-03 Doosan Corporation
-doosan
-
 // dot : 2015-05-21 Dish DBS Corporation
 dot
 
@@ -7827,9 +7859,6 @@ download
 
 // drive : 2015-03-05 Charleston Road Registry Inc.
 drive
-
-// dstv : 2015-03-12 MultiChoice (Proprietary) Limited
-dstv
 
 // dtv : 2015-06-04 Dish DBS Corporation
 dtv
@@ -7846,7 +7875,7 @@ dunlop
 // duns : 2015-08-06 The Dun & Bradstreet Corporation
 duns
 
-// dupont : 2015-06-25 E.I. du Pont de Nemours and Company
+// dupont : 2015-06-25 E. I. du Pont de Nemours and Company
 dupont
 
 // durban : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
@@ -7854,6 +7883,9 @@ durban
 
 // dvag : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
 dvag
+
+// dvr : 2016-05-26 Hughes Satellite Systems Corporation
+dvr
 
 // dwg : 2015-07-23 Autodesk, Inc.
 dwg
@@ -7863,6 +7895,9 @@ earth
 
 // eat : 2014-01-23 Charleston Road Registry Inc.
 eat
+
+// eco : 2016-07-08 Big Room Inc.
+eco
 
 // edeka : 2014-12-18 EDEKA Verband kaufmännischer Genossenschaften e.V.
 edeka
@@ -8047,14 +8082,14 @@ florist
 // flowers : 2014-10-09 Uniregistry, Corp.
 flowers
 
-// flsmidth : 2014-07-24 FLSmidth A/S
-flsmidth
-
 // fly : 2014-05-08 Charleston Road Registry Inc.
 fly
 
 // foo : 2014-01-23 Charleston Road Registry Inc.
 foo
+
+// food : 2016-04-21 Lifestyle Domain Holdings, Inc.
+food
 
 // foodnetwork : 2015-07-02 Lifestyle Domain Holdings, Inc.
 foodnetwork
@@ -8107,6 +8142,9 @@ fujitsu
 // fujixerox : 2015-07-23 Xerox DNHC LLC
 fujixerox
 
+// fun : 2016-01-14 Oriental Trading Company, Inc.
+fun
+
 // fund : 2014-03-20 John Castle, LLC
 fund
 
@@ -8134,7 +8172,7 @@ gallup
 // game : 2015-05-28 Uniregistry, Corp.
 game
 
-// games : 2015-05-28 Foggy Beach, LLC
+// games : 2015-05-28
 games
 
 // gap : 2015-07-31 The Gap, Inc.
@@ -8194,6 +8232,9 @@ globo
 // gmail : 2014-05-01 Charleston Road Registry Inc.
 gmail
 
+// gmbh : 2016-01-29 Extra Dynamite, LLC
+gmbh
+
 // gmo : 2014-01-09 GMO Internet, Inc.
 gmo
 
@@ -8233,9 +8274,6 @@ gop
 // got : 2014-12-18 Amazon EU S.à r.l.
 got
 
-// gotv : 2015-03-12 MultiChoice (Proprietary) Limited
-gotv
-
 // grainger : 2015-05-07 Grainger Registry Services, LLC
 grainger
 
@@ -8250,6 +8288,9 @@ green
 
 // gripe : 2014-03-06 Corn Sunset, LLC
 gripe
+
+// grocery : 2016-06-16 Wal-Mart Stores, Inc.
+grocery
 
 // group : 2014-08-15 Romeo Town, LLC
 group
@@ -8370,6 +8411,9 @@ hot
 
 // hoteles : 2015-03-05 Travel Reservations SRL
 hoteles
+
+// hotels : 2016-04-07 Booking.com B.V.
+hotels
 
 // hotmail : 2014-12-18 Microsoft Corporation
 hotmail
@@ -8509,7 +8553,7 @@ jcp
 // jeep : 2015-07-30 FCA US LLC.
 jeep
 
-// jetzt : 2014-01-09 New TLD Company AB
+// jetzt : 2014-01-09
 jetzt
 
 // jewelry : 2015-03-05 Wild Bloom, LLC
@@ -8610,9 +8654,6 @@ kred
 
 // kuokgroup : 2015-04-09 Kerry Trading Co. Limited
 kuokgroup
-
-// kyknet : 2015-03-05 Electronic Media Network (Pty) Ltd
-kyknet
 
 // kyoto : 2014-11-07 Academic Institution: Kyoto Jyoho Gakuen
 kyoto
@@ -8818,6 +8859,9 @@ management
 // mango : 2013-10-24 PUNTO FA S.L.
 mango
 
+// map : 2016-06-09 Charleston Road Registry Inc.
+map
+
 // market : 2014-03-06
 market
 
@@ -8878,6 +8922,9 @@ menu
 // meo : 2014-11-07 PT Comunicacoes S.A.
 meo
 
+// merckmsd : 2016-07-14 MSD Registry Holdings, Inc.
+merckmsd
+
 // metlife : 2015-05-07 MetLife Services and Solutions, LLC
 metlife
 
@@ -8908,8 +8955,8 @@ mls
 // mma : 2014-11-07 MMA IARD
 mma
 
-// mnet : 2015-03-05 Electronic Media Network (Pty) Ltd
-mnet
+// mobile : 2016-06-02 Dish DBS Corporation
+mobile
 
 // mobily : 2014-12-18 GreenTech Consultancy Company W.L.L.
 mobily
@@ -8977,17 +9024,11 @@ mtpc
 // mtr : 2015-03-12 MTR Corporation Limited
 mtr
 
-// multichoice : 2015-03-12 MultiChoice (Proprietary) Limited
-multichoice
-
 // mutual : 2015-04-02 Northwestern Mutual MU TLD Registry, LLC
 mutual
 
 // mutuelle : 2015-06-18 Fédération Nationale de la Mutualité Française
 mutuelle
-
-// mzansimagic : 2015-03-05 Electronic Media Network (Pty) Ltd
-mzansimagic
 
 // nab : 2015-08-20 National Australia Bank Limited
 nab
@@ -8997,9 +9038,6 @@ nadex
 
 // nagoya : 2013-10-24 GMO Registry, Inc.
 nagoya
-
-// naspers : 2015-02-12 Intelprop (Proprietary) Limited
-naspers
 
 // nationwide : 2015-07-23 Nationwide Mutual Insurance Company
 nationwide
@@ -9163,7 +9201,7 @@ orange
 // organic : 2014-03-27 Afilias Limited
 organic
 
-// orientexpress : 2015-02-05 Belmond Ltd.
+// orientexpress : 2015-02-05
 orientexpress
 
 // origins : 2015-10-01 The Estée Lauder Companies Inc.
@@ -9214,9 +9252,6 @@ passagens
 // pay : 2015-08-27 Amazon EU S.à r.l.
 pay
 
-// payu : 2015-02-12 MIH PayU B.V.
-payu
-
 // pccw : 2015-05-14 PCCW Enterprises Limited
 pccw
 
@@ -9229,8 +9264,14 @@ pfizer
 // pharmacy : 2014-06-19 National Association of Boards of Pharmacy
 pharmacy
 
+// phd : 2016-07-28 Charleston Road Registry Inc.
+phd
+
 // philips : 2014-11-07 Koninklijke Philips N.V.
 philips
+
+// phone : 2016-06-02 Dish DBS Corporation
+phone
 
 // photo : 2013-11-14 Uniregistry, Corp.
 photo
@@ -9366,6 +9407,9 @@ qvc
 
 // racing : 2014-12-04 Premier Registry Limited
 racing
+
+// radio : 2016-07-21 European Broadcasting Union (EBU)
+radio
 
 // raid : 2015-07-23 Johnson Shareholdings, Inc.
 raid
@@ -9589,6 +9633,9 @@ scor
 // scot : 2014-01-23 Dot Scot Registry Limited
 scot
 
+// search : 2016-06-09 Charleston Road Registry Inc.
+search
+
 // seat : 2014-05-22 SEAT, S.A. (Sociedad Unipersonal)
 seat
 
@@ -9648,6 +9695,12 @@ shiksha
 
 // shoes : 2013-10-02 Binky Galley, LLC
 shoes
+
+// shop : 2016-04-08 GMO Registry, Inc.
+shop
+
+// shopping : 2016-03-31
+shopping
 
 // shouji : 2015-01-08 QIHOO 360 TECHNOLOGY CO. LTD.
 shouji
@@ -9781,6 +9834,9 @@ storage
 // store : 2015-04-09 DotStore Inc.
 store
 
+// stream : 2016-01-08 dot Stream Limited
+stream
+
 // studio : 2015-02-11
 studio
 
@@ -9792,9 +9848,6 @@ style
 
 // sucks : 2014-12-22 Vox Populi Registry Inc.
 sucks
-
-// supersport : 2015-03-05 SuperSport International Holdings Proprietary Limited
-supersport
 
 // supplies : 2013-12-19 Atomic Fields, LLC
 supplies
@@ -10590,28 +10643,38 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 // (Note: these are in alphabetical order by company name)
 
+// Agnat sp. z o.o. : https://domena.pl
+// Submitted by Przemyslaw Plewa <it-admin@domena.pl>
+beep.pl
+
+// Alces Software Ltd : http://alces-software.com
+// Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
+*.compute.estate
+*.alces.network
+
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>
 cloudfront.net
 
 // Amazon Elastic Compute Cloud: https://aws.amazon.com/ec2/
-// Submitted by Osman Surkatty <osmans@amazon.com>
+// Submitted by Philip Allchin <pallchin@amazon.com>
+compute.amazonaws.com
 ap-northeast-1.compute.amazonaws.com
+ap-northeast-2.compute.amazonaws.com
 ap-southeast-1.compute.amazonaws.com
 ap-southeast-2.compute.amazonaws.com
-cn-north-1.compute.amazonaws.cn
-compute.amazonaws.cn
-compute.amazonaws.com
-compute-1.amazonaws.com
-eu-west-1.compute.amazonaws.com
 eu-central-1.compute.amazonaws.com
+eu-west-1.compute.amazonaws.com
 sa-east-1.compute.amazonaws.com
-us-east-1.amazonaws.com
 us-gov-west-1.compute.amazonaws.com
 us-west-1.compute.amazonaws.com
 us-west-2.compute.amazonaws.com
+compute-1.amazonaws.com
 z-1.compute-1.amazonaws.com
 z-2.compute-1.amazonaws.com
+us-east-1.amazonaws.com
+compute.amazonaws.com.cn
+cn-north-1.compute.amazonaws.com.cn
 
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
 // Submitted by Adam Stein <astein@amazon.com>
@@ -10622,26 +10685,67 @@ elasticbeanstalk.com
 elb.amazonaws.com
 
 // Amazon S3 : https://aws.amazon.com/s3/
-// Submitted by Eric Kinolik <kilo@amazon.com>
+// Submitted by Luke Wells <lawells@amazon.com>
 s3.amazonaws.com
 s3-ap-northeast-1.amazonaws.com
+s3-ap-northeast-2.amazonaws.com
 s3-ap-southeast-1.amazonaws.com
 s3-ap-southeast-2.amazonaws.com
+s3-eu-central-1.amazonaws.com
+s3-eu-west-1.amazonaws.com
 s3-external-1.amazonaws.com
 s3-external-2.amazonaws.com
 s3-fips-us-gov-west-1.amazonaws.com
-s3-eu-central-1.amazonaws.com
-s3-eu-west-1.amazonaws.com
 s3-sa-east-1.amazonaws.com
 s3-us-gov-west-1.amazonaws.com
 s3-us-west-1.amazonaws.com
 s3-us-west-2.amazonaws.com
+s3.ap-northeast-2.amazonaws.com
 s3.cn-north-1.amazonaws.com.cn
 s3.eu-central-1.amazonaws.com
+
+// Aptible : https://www.aptible.com/
+// Submitted by Thomas Orozco <thomas@aptible.com>
+on-aptible.com
+
+// Association potager.org : https://potager.org/
+// Submitted by Lunar <jardiniers@potager.org>
+pimienta.org
+poivron.org
+potager.org
+sweetpepper.org
+
+// ASUSTOR Inc. : http://www.asustor.com
+// Submitted by Vincent Tseng <vincenttseng@asustor.com>
+myasustor.com
+
+// AVM : https://avm.de
+// Submitted by Andreas Weise <a.weise@avm.de>
+myfritz.net
+
+// backplane : https://www.backplane.io
+// Submitted by Anthony Voutas <anthony@backplane.io>
+backplaneapp.io
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
+
+// BinaryLane : http://www.binarylane.com
+// Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
+bnr.la
+
+// Boxfuse : https://boxfuse.com
+// Submitted by Axel Fontaine <axel@boxfuse.com>
+boxfuse.io
+
+// BrowserSafetyMark
+// Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
+browsersafetymark.io
+
+// callidomus: https://www.callidomus.com/
+// Submitted by Marcus Popp <admin@callidomus.com>
+mycd.eu
 
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
@@ -10697,6 +10801,18 @@ co.com
 // c.la : http://www.c.la/
 c.la
 
+// certmgr.org : https://certmgr.org
+// Submitted by B. Blechschmidt <hostmaster@certmgr.org>
+certmgr.org
+
+// Citrix : https://citrix.com
+// Submitted by Alex Stoddard <alex.stoddard@citrix.com>
+xenapponazure.com
+
+// ClearVox : http://www.clearvox.nl/
+// Submitted by Leon Rowland <leon@clearvox.nl>
+virtueeldomein.nl
+
 // cloudControl : https://www.cloudcontrol.com/
 // Submitted by Tobias Wilken <tw@cloudcontrol.com>
 cloudcontrolled.com
@@ -10725,9 +10841,42 @@ co.no
 // Submitted by Damien Tournoud <damien@commerceguys.com>
 *.platform.sh
 
+// Craynic, s.r.o. : http://www.craynic.com/
+// Submitted by Ales Krajnik <ales.krajnik@craynic.com>
+realm.cz
+
+// Cryptonomic : https://cryptonomic.net/
+// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
+*.cryptonomic.net
+
 // Cupcake : https://cupcake.io/
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
+
+// cyon GmbH : https://www.cyon.ch/
+// Submitted by Dominic Luechinger <dol@cyon.ch>
+cyon.link
+cyon.site
+
+// Daplie, Inc : https://daplie.com
+// Submitted by AJ ONeal <aj@daplie.com>
+daplie.me
+
+// Dansk.net : http://www.dansk.net/
+// Submitted by Anani Voule <digital@digital.co.dk>
+biz.dk
+co.dk
+firm.dk
+reg.dk
+store.dk
+
+// deSEC : https://desec.io/
+// Submitted by Peter Thomassen <peter@desec.io>
+dedyn.io
+
+// DNShome : https://www.dnshome.de/
+// Submitted by Norbert Auler <mail@dnshome.de>
+dnshome.de
 
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
@@ -10737,9 +10886,19 @@ dreamhosters.com
 // Submitted by Ricardo Padilha <rpadilha@drobo.com>
 mydrobo.com
 
+// Drud Holdings, LLC. : https://www.drud.com/
+// Submitted by Kevin Bridges <kevin@drud.com>
+drud.io
+drud.us
+
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org
+
+// dy.fi : http://dy.fi/
+// Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
+dy.fi
+tunk.org
 
 // DynDNS.com : http://www.dyndns.com/services/dns/dyndns/
 dyndns-at-home.com
@@ -11022,6 +11181,14 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
+// dynv6 : https://dynv6.com
+// Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
+dynv6.net
+
+// E4YOU spol. s.r.o. : https://e4you.cz/
+// Submitted by Vladimir Dudr <info@e4you.cz>
+e4.cz
+
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org
@@ -11081,6 +11248,17 @@ tr.eu.org
 uk.eu.org
 us.eu.org
 
+// Evennode : http://www.evennode.com/
+// Submitted by Michal Kralik <support@evennode.com>
+eu-1.evennode.com
+eu-2.evennode.com
+us-1.evennode.com
+us-2.evennode.com
+
+// Facebook, Inc.
+// Submitted by Peter Ruibal <public-suffix@fb.com>
+apps.fbsbx.com
+
 // Fastly Inc. http://www.fastly.com/
 // Submitted by Vladimir Vuksan <vladimir@fastly.com>
 a.ssl.fastly.net
@@ -11088,6 +11266,10 @@ b.ssl.fastly.net
 global.ssl.fastly.net
 a.prod.fastly.net
 global.prod.fastly.net
+
+// Featherhead : https://featherhead.xyz/
+// Submitted by Simon Menke <simon@featherhead.xyz>
+fhapp.xyz
 
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>
@@ -11097,21 +11279,46 @@ firebaseapp.com
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io>
 flynnhub.com
 
+// Freebox : http://www.freebox.fr
+// Submitted by Romain Fliedel <rfliedel@freebox.fr>
+freebox-os.com
+freeboxos.com
+fbx-os.fr
+fbxos.fr
+freebox-os.fr
+freeboxos.fr
+
 // GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
 // Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk>
 service.gov.uk
 
 // GitHub, Inc.
-// Submitted by Ben Toews <btoews@github.com>
+// Submitted by Patrick Toomey <security@github.com>
 github.io
 githubusercontent.com
+githubcloud.com
+*.api.githubcloud.com
+*.ext.githubcloud.com
+gist.githubcloud.com
+*.githubcloudusercontent.com
+
+// GitLab, Inc.
+// Submitted by Alex Hanselka <alex@gitlab.com>
+gitlab.io
 
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.com
+ro.im
+shop.ro
+
+// GoIP DNS Services : http://www.goip.de
+// Submitted by Christian Poulter <milchstrasse@goip.de>
+goip.de
 
 // Google, Inc.
 // Submitted by Eduardo Vela <evn@google.com>
+*.0emm.com
 appspot.com
 blogspot.ae
 blogspot.al
@@ -11198,6 +11405,14 @@ withyoutube.com
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
+// Hasura : https://hasura.io
+// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura-app.io
+
+// Hepforge : https://www.hepforge.org
+// Submitted by David Grellscheid <admin@hepforge.org>
+hepforge.org
+
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com>
 herokuapp.com
@@ -11210,6 +11425,28 @@ iki.fi
 // info.at : http://www.info.at/
 biz.at
 info.at
+
+// Joyent : https://www.joyent.com/
+// Submitted by Brian Bennett <brian.bennett@joyent.com>
+*.triton.zone
+*.cns.joyent.com
+
+// JS.ORG : http://dns.js.org
+// Submitted by Stefan Keim <admin@js.org>
+js.org
+
+// .KRD : http://nic.krd/data/krd/Registration%20Policy.pdf
+co.krd
+edu.krd
+
+// Magento Commerce
+// Submitted by Damien Tournoud <dtournoud@magento.cloud>
+*.magentosite.cloud
+
+// Meteor Development Group : https://www.meteor.com/hosting
+// Submitted by Pierre Carrier <pierre@meteor.com>
+meteorapp.com
+eu.meteorapp.com
 
 // Michau Enterprises Limited : http://www.co.pl/
 co.pl
@@ -11236,6 +11473,99 @@ ngrok.io
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com
 
+// nsupdate.info : https://www.nsupdate.info/
+// Submitted by Thomas Waldmann <info@nsupdate.info>
+nsupdate.info
+nerdpol.ovh
+
+// No-IP.com : https://noip.com/
+// Submitted by Deven Reza <publicsuffixlist@noip.com>
+blogsyte.com
+brasilia.me
+cable-modem.org
+ciscofreak.com
+collegefan.org
+couchpotatofries.org
+damnserver.com
+ddns.me
+ditchyourip.com
+dnsfor.me
+dnsiskinky.com
+dvrcam.info
+dynns.com
+eating-organic.net
+fantasyleague.cc
+geekgalaxy.com
+golffan.us
+health-carereform.com
+homesecuritymac.com
+homesecuritypc.com
+hopto.me
+ilovecollege.info
+loginto.me
+mlbfan.org
+mmafan.biz
+myactivedirectory.com
+mydissent.net
+myeffect.net
+mymediapc.net
+mypsx.net
+mysecuritycamera.com
+mysecuritycamera.net
+mysecuritycamera.org
+net-freaks.com
+nflfan.org
+nhlfan.net
+no-ip.ca
+no-ip.co.uk
+no-ip.net
+noip.us
+onthewifi.com
+pgafan.net
+point2this.com
+pointto.us
+privatizehealthinsurance.net
+quicksytes.com
+read-books.org
+securitytactics.com
+serveexchange.com
+servehumour.com
+servep2p.com
+servesarcasm.com
+stufftoread.com
+ufcfan.org
+unusualperson.com
+workisboring.com
+3utilities.com
+bounceme.net
+ddns.net
+ddnsking.com
+gotdns.ch
+hopto.org
+myftp.biz
+myftp.org
+myvnc.com
+no-ip.biz
+no-ip.info
+no-ip.org
+noip.me
+redirectme.net
+servebeer.com
+serveblog.net
+servecounterstrike.com
+serveftp.com
+servegame.com
+servehalflife.com
+servehttp.com
+serveirc.com
+serveminecraft.net
+servemp3.com
+servepics.com
+servequake.com
+sytes.net
+webhop.me
+zapto.org
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
@@ -11252,6 +11582,18 @@ operaunite.com
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
 outsystemscloud.com
 
+// OwnProvider : http://www.ownprovider.com
+// Submitted by Jan Moennich <jan.moennich@ownprovider.com>
+ownprovider.com
+
+// oy.lc
+// Submitted by Charly Coste <changaco@changaco.oy.lc>
+oy.lc
+
+// Pagefog : https://pagefog.com/
+// Submitted by Derek Myers <derek@pagefog.com>
+pgfog.com
+
 // Pagefront : https://www.pagefronthq.com/
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com
@@ -11266,8 +11608,12 @@ zakopane.pl
 
 // Pantheon Systems, Inc. : https://pantheon.io/
 // Submitted by Gary Dylina <gary@pantheon.io>
-pantheon.io
+pantheonsite.io
 gotpantheon.com
+
+// Peplink | Pepwave : http://peplink.com/
+// Submitted by Steve Leung <steveleung@peplink.com>
+mypep.link
 
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
@@ -11277,9 +11623,23 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// Protonet GmbH : http://protonet.io
+// Submitted by Martin Meier <admin@protonet.io>
+protonet.io
+
+// Publication Presse Communication SARL : https://ppcom.fr
+// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+chirurgiens-dentistes-en-france.fr
+
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com
+
+// QNAP System Inc : https://www.qnap.com
+// Submitted by Nick Chang <nickchang@qnap.com>
+dev-myqnapcloud.com
+alpha-myqnapcloud.com
+myqnapcloud.com
 
 // Rackmaze LLC : https://www.rackmaze.com
 // Submitted by Kirill Pertsev <kika@rackmaze.com>
@@ -11290,9 +11650,18 @@ rackmaze.net
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
 
+// RethinkDB : https://www.rethinkdb.com/
+// Submitted by Chris Kastorff <info@rethinkdb.com>
+hzc.io
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io
+
+// SBE network solutions GmbH : https://www.sbe.de/
+// Submitted by Norman Meilick <nm@sbe.de>
+logoip.de
+logoip.com
 
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
@@ -11300,11 +11669,35 @@ biz.ua
 co.ua
 pp.ua
 
+// Shopblocks : http://www.shopblocks.com/
+// Submitted by Alex Bowers <alex@shopblocks.com>
+myshopblocks.com
+
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com>
 sinaapp.com
 vipsinaapp.com
 1kapp.com
+
+// Skyhat : http://www.skyhat.io
+// Submitted by Shante Adam <shante@skyhat.io>
+bounty-full.com
+alpha.bounty-full.com
+beta.bounty-full.com
+
+// staticland : https://static.land
+// Submitted by Seth Vincent <sethvincent@gmail.com>
+static.land
+dev.static.land
+sites.static.land
+
+// SpaceKit : https://www.spacekit.io/
+// Submitted by Reza Akhavan <spacekit.io@gmail.com>
+spacekit.io
+
+// Stackspace : https://www.stackspace.io/
+// Submitted by Lina He <info@stackspace.io>
+stackspace.space
 
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
@@ -11329,12 +11722,33 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// TownNews.com : http://www.townnews.com
+// Submitted by Dustin Ward <dward@townnews.com>
+bloxcms.com
+townnews-staging.com
+
+// TuxFamily : http://tuxfamily.org
+// Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
+tuxfamily.org
+
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>
 hk.com
 hk.org
 ltd.hk
 inc.hk
+
+// .US
+// Submitted by Ed Moore <Ed.Moore@lib.de.us>
+lib.de.us
+
+// Viprinet Europe GmbH : http://www.viprinet.com
+// Submitted by Simon Kissel <hostmaster@viprinet.com>
+router.management
+
+// Wikimedia Labs : https://wikitech.wikimedia.org
+// Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
+wmflabs.org
 
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>

--- a/src/Pdp/PublicSuffixListManager.php
+++ b/src/Pdp/PublicSuffixListManager.php
@@ -10,6 +10,8 @@
  */
 namespace Pdp;
 
+use SplFileObject;
+
 /**
  * Public Suffix List Manager.
  *
@@ -18,13 +20,14 @@ namespace Pdp;
  */
 class PublicSuffixListManager
 {
+    const ALL_DOMAINS = 'ALL';
     const PDP_PSL_TEXT_FILE = 'public-suffix-list.txt';
     const PDP_PSL_PHP_FILE = 'public-suffix-list.php';
 
-    const ICANN_SECTION = 'ICANN';
+    const ICANN_DOMAINS = 'ICANN';
     const ICANN_PSL_PHP_FILE = 'icann-public-suffix-list.php';
 
-    const PRIVATE_SECTION = 'PRIVATE';
+    const PRIVATE_DOMAINS = 'PRIVATE';
     const PRIVATE_PSL_PHP_FILE = 'private-public-suffix-list.php';
 
     /**
@@ -40,7 +43,11 @@ class PublicSuffixListManager
     /**
      * @var PublicSuffixList Public Suffix List
      */
-    protected $list;
+    protected static $domainList = array(
+        self::ALL_DOMAINS => self::PDP_PSL_PHP_FILE,
+        self::ICANN_DOMAINS => self::ICANN_PSL_PHP_FILE,
+        self::PRIVATE_DOMAINS => self::PRIVATE_PSL_PHP_FILE,
+    );
 
     /**
      * @var \Pdp\HttpAdapter\HttpAdapterInterface Http adapter
@@ -71,21 +78,10 @@ class PublicSuffixListManager
     {
         $this->fetchListFromSource();
         $cacheFile = $this->cacheDir . '/' . self::PDP_PSL_TEXT_FILE;
-
-        $this->varExportToFile(
-            self::PDP_PSL_PHP_FILE,
-            $this->parseListToArray($cacheFile)
-        );
-
-        $this->varExportToFile(
-            self::ICANN_PSL_PHP_FILE,
-            $this->parseSectionToArray(self::ICANN_SECTION, $cacheFile)
-        );
-
-        $this->varExportToFile(
-            self::PRIVATE_PSL_PHP_FILE,
-            $this->parseSectionToArray(self::PRIVATE_SECTION, $cacheFile)
-        );
+        $publicSuffixListArray = $this->convertListToArray($cacheFile);
+        foreach ($publicSuffixListArray as $domain => $data) {
+            $this->varExportToFile(self::$domainList[$domain], $data);
+        }
     }
 
     /**
@@ -104,8 +100,105 @@ class PublicSuffixListManager
     /**
      * Parses text representation of list to associative, multidimensional array.
      *
+     * @param string $textFile Public Suffix List text filename
+     *
+     * @return array Associative, multidimensional array representation of the
+     *               public suffx list
+     */
+    protected function convertListToArray($textFile)
+    {
+        $addDomain = array(
+            self::ICANN_DOMAINS => false,
+            self::PRIVATE_DOMAINS => false,
+        );
+
+        $publicSuffixListArray = array(
+            self::ALL_DOMAINS => array(),
+            self::ICANN_DOMAINS => array(),
+            self::PRIVATE_DOMAINS => array(),
+        );
+
+        $data = new SplFileObject($textFile);
+        $data->setFlags(SplFileObject::DROP_NEW_LINE | SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY);
+        foreach ($data as $line) {
+            $addDomain = $this->validateDomainAddition($line, $addDomain);
+            if (strstr($line, '//') !== false) {
+                continue;
+            }
+            $publicSuffixListArray = $this->convertLineToArray($line, $publicSuffixListArray, $addDomain);
+        }
+
+        return $publicSuffixListArray;
+    }
+
+    /**
+     * Update the addition status for a given line against the domain list (ICANN and PRIVATE).
+     *
+     * @param string $line      the current file line
+     * @param array  $addDomain the domain addition status
+     */
+    protected function validateDomainAddition($line, array $addDomain)
+    {
+        foreach ($addDomain as $section => $status) {
+            $addDomain[$section] = $this->isValidSection($status, $line, $section);
+        }
+
+        return $addDomain;
+    }
+
+    /**
+     * Tell whether the line can be converted for a given domain.
+     *
+     * @param bool   $previousStatus the previous status
+     * @param string $line           the current file line
+     * @param string $section        the section to be considered
+     *
+     * @return bool
+     */
+    protected function isValidSection($previousStatus, $line, $section)
+    {
+        if (!$previousStatus && 0 === strpos($line, '// ===BEGIN ' . $section . ' DOMAINS===')) {
+            return true;
+        }
+
+        if ($previousStatus && 0 === strpos($line, '// ===END ' . $section . ' DOMAINS===')) {
+            return false;
+        }
+
+        return $previousStatus;
+    }
+
+    /**
+     * Convert a line from the Public Suffix list.
+     *
+     * @param string $textLine              Public Suffix List text line
+     * @param array  $publicSuffixListArray Associative, multidimensional array representation of the
+     *                                      public suffx list
+     * @param array  $addDomain             Tell which section should be converted
+     *
+     * @return array Associative, multidimensional array representation of the
+     *               public suffx list
+     */
+    protected function convertLineToArray($textLine, array $publicSuffixListArray, array $addDomain)
+    {
+        $ruleParts = explode('.', $textLine);
+        $this->buildArray($publicSuffixListArray[self::ALL_DOMAINS], $ruleParts);
+        $domainNames = array_keys(array_filter($addDomain));
+        foreach ($domainNames as $domainName) {
+            $this->buildArray($publicSuffixListArray[$domainName], $ruleParts);
+        }
+
+        return $publicSuffixListArray;
+    }
+
+    /**
+     * Parses text representation of list to associative, multidimensional array.
+     *
      * This method is based heavily on the code found in generateEffectiveTLDs.php
      *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 3.1.0
      * @link https://github.com/usrflo/registered-domain-libs/blob/master/generateEffectiveTLDs.php
      * A copy of the Apache License, Version 2.0, is provided with this
      * distribution
@@ -117,63 +210,18 @@ class PublicSuffixListManager
      */
     public function parseListToArray($textFile)
     {
-        return $this->parseSectionToArray('', $textFile);
-    }
-
-    /**
-     * Parses text representation of the Public suffix list to associative, multidimensional array.
-     *
-     * This method is based heavily on the code found in generateEffectiveTLDs.php
-     *
-     * @link https://github.com/usrflo/registered-domain-libs/blob/master/generateEffectiveTLDs.php
-     * A copy of the Apache License, Version 2.0, is provided with this
-     * distribution
-     *
-     * @param string $section  Public Suffix List section name
-     * @param string $textFile Public Suffix List text filename
-     *
-     * @return array Associative, multidimensional array representation of the
-     *               public suffx list
-     */
-    protected function parseSectionToArray($section, $textFile)
-    {
-        $publicSuffixListArray = array();
         $data = file($textFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        $filter = $this->getLineFilter($section);
+        $filter = function ($line) {
+            return strstr($line, '//') === false;
+        };
+
+        $publicSuffixListArray = array();
         foreach (array_filter($data, $filter) as $line) {
             $ruleParts = explode('.', $line);
             $this->buildArray($publicSuffixListArray, $ruleParts);
         }
 
         return $publicSuffixListArray;
-    }
-
-    /**
-     * Return the PSL line filter.
-     *
-     * @param string $section Public Suffix List section name
-     *
-     * @return Closure
-     */
-    protected function getLineFilter($section)
-    {
-        $section = trim($section);
-        $add = empty($section);
-        if ($add) {
-            return function ($line) {
-                return strstr($line, '//') === false;
-            };
-        }
-
-        return function ($line) use (&$add, $section) {
-            if (!$add && 0 === strpos($line, '// ===BEGIN ' . $section . ' DOMAINS===')) {
-                $add = true;
-            } elseif ($add && 0 === strpos($line, '// ===END ' . $section . ' DOMAINS===')) {
-                $add = false;
-            }
-
-            return $add && strstr($line, '//') === false;
-        };
     }
 
     /**
@@ -250,26 +298,19 @@ class PublicSuffixListManager
     /**
      * Gets Public Suffix List.
      *
-     * @param string|null $section the Public Suffix List type
+     * @param string $list the Public Suffix List type
      *
      * @return PublicSuffixList Instance of Public Suffix List
      */
-    public function getList($section = null)
+    public function getList($list = self::ALL_DOMAINS)
     {
-        $sectionList = array(
-            self::ICANN_SECTION => self::ICANN_PSL_PHP_FILE,
-            self::PRIVATE_SECTION => self::PRIVATE_PSL_PHP_FILE,
-        );
-
-        $cacheBasename = isset($sectionList[$section]) ? $sectionList[$section] : self::PDP_PSL_PHP_FILE;
-        $psl_php_file = $this->cacheDir . '/' . $cacheBasename;
-        if (!file_exists($psl_php_file)) {
+        $cacheBasename = isset(self::$domainList[$list]) ? self::$domainList[$list] : self::PDP_PSL_PHP_FILE;
+        $cacheFile = $this->cacheDir . '/' . $cacheBasename;
+        if (!file_exists($cacheFile)) {
             $this->refreshPublicSuffixList();
         }
 
-        $this->list = new PublicSuffixList($psl_php_file);
-
-        return $this->list;
+        return new PublicSuffixList($cacheFile);
     }
 
     /**
@@ -285,15 +326,12 @@ class PublicSuffixListManager
     protected function write($filename, $data)
     {
         $path = $this->cacheDir . '/' . $filename;
-        $level = error_reporting(0);
-        $result = file_put_contents($path, $data);
-        error_reporting($level);
+        $result = @file_put_contents($path, $data);
         if ($result !== false) {
             return $result;
         }
-        $error = error_get_last();
 
-        throw new \Exception(sprintf("Cannot write '%s' : %s", $path, $error['message']));
+        throw new \Exception(sprintf("Cannot write '%s'", $path));
     }
 
     /**

--- a/tests/src/Pdp/PublicSuffixListManagerTest.php
+++ b/tests/src/Pdp/PublicSuffixListManagerTest.php
@@ -214,4 +214,20 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('stuff-4-sale', $publicSuffixList['org']) !== false);
         $this->assertTrue(array_key_exists('net', $publicSuffixList['ac']) !== false);
     }
+
+    public function testGetDifferentPublicList()
+    {
+        $listManager = new PublicSuffixListManager();
+        $publicSuffixList = $listManager->getList();
+        $icannSuffixList = $listManager->getList(PublicSuffixListManager::ICANN_SECTION);
+        $privateSuffixList = $listManager->getList(PublicSuffixListManager::PRIVATE_SECTION);
+        $invalidSuffixList = $listManager->getList('invalid type');
+        $this->assertInstanceOf('\Pdp\PublicSuffixList', $icannSuffixList);
+        $this->assertInstanceOf('\Pdp\PublicSuffixList', $privateSuffixList);
+        $this->assertInstanceOf('\Pdp\PublicSuffixList', $invalidSuffixList);
+        $this->assertEquals($invalidSuffixList, $publicSuffixList);
+        $this->assertNotEquals($privateSuffixList, $icannSuffixList);
+        $this->assertNotEquals($publicSuffixList, $icannSuffixList);
+        $this->assertNotEquals($publicSuffixList, $privateSuffixList);
+    }
 }

--- a/tests/src/Pdp/PublicSuffixListManagerTest.php
+++ b/tests/src/Pdp/PublicSuffixListManagerTest.php
@@ -218,16 +218,24 @@ class PublicSuffixListManagerTest extends \PHPUnit_Framework_TestCase
     public function testGetDifferentPublicList()
     {
         $listManager = new PublicSuffixListManager();
-        $publicSuffixList = $listManager->getList();
-        $icannSuffixList = $listManager->getList(PublicSuffixListManager::ICANN_SECTION);
-        $privateSuffixList = $listManager->getList(PublicSuffixListManager::PRIVATE_SECTION);
-        $invalidSuffixList = $listManager->getList('invalid type');
-        $this->assertInstanceOf('\Pdp\PublicSuffixList', $icannSuffixList);
-        $this->assertInstanceOf('\Pdp\PublicSuffixList', $privateSuffixList);
-        $this->assertInstanceOf('\Pdp\PublicSuffixList', $invalidSuffixList);
-        $this->assertEquals($invalidSuffixList, $publicSuffixList);
-        $this->assertNotEquals($privateSuffixList, $icannSuffixList);
-        $this->assertNotEquals($publicSuffixList, $icannSuffixList);
-        $this->assertNotEquals($publicSuffixList, $privateSuffixList);
+        $publicList = $listManager->getList();
+        $invalidList = $listManager->getList('invalid type');
+        $this->assertEquals($publicList, $invalidList);
+    }
+
+    public function testParserWithDifferentPublicList()
+    {
+        $listManager = new PublicSuffixListManager();
+        $icannList = $listManager->getList(PublicSuffixListManager::ICANN_DOMAINS);
+        $privateList = $listManager->getList(PublicSuffixListManager::PRIVATE_DOMAINS);
+        $host = 'thephpleague.github.io';
+
+        $icannParser = new Parser($icannList);
+        $icannSubdomain = $icannParser->parseHost($host)->getSubdomain();
+        $this->assertSame('thephpleague', $icannSubdomain);
+
+        $privateParser = new Parser($privateList);
+        $privateSubdomain = $privateParser->parseHost($host)->getSubdomain();
+        $this->assertSame(null, $privateSubdomain);
     }
 }


### PR DESCRIPTION
## Introduction

This PR resolves #179, a recent post on [reddit](https://www.reddit.com/r/PHP/comments/52www5/tldextract_library_for_extraction_of_domain_parts/d7oyhe3) highlighted that the current library can not distinguish beetwen ICANN and Private Domains, although the PSL contains two distinctive sections to highlight the difference. 
## Proposal
### Describe the new feature

This proposal introduces an optional parameter to `PublicSuffixListManager::getList` to enable loading each specific section from the PSL:
- `PublicSuffixListManager::ICANN_SECTION` to load the ICANN section
- `PublicSuffixListManager::PRIVATE_SECTION` to cache the PRIVATE section

**before:**

``` php
<?php

use Pdp\PublicSuffixListManager;
use Pdp\Parser;

$manager = new PublicSuffixListManager();
$list = $manager->getList(); //obtain the Full psl
$host = 'thephpleague.github.io';
$parser = new Parser($list);
var_dump($parser->parserHost($host)->toArray());
// returns
// array (
//  'subdomain' => NULL,
//  'registrableDomain' => 'thephpleague.github.io',
//  'publicSuffix' => 'github.io',
//  'host' => 'thephpleague.github.io',
//)
```

**after:**

``` php
<?php

use Pdp\PublicSuffixListManager;
use Pdp\Parser;

$manager = new PublicSuffixListManager();
$list = $manager->getList(PublicSuffixListManager::ICANN_SECTION);
$host = 'thephpleague.github.io';
$parser = new Parser($list);
var_dump($parser->parserHost($host)->toArray());
// returns
// array (
//  'subdomain' => 'thephpleague',
//  'registrableDomain' => 'github.io',
//  'publicSuffix' => 'io',
//  'host' => 'thephpleague.github.io',
//)
```

To avoid BC break when using an invalid section name the `PublicSuffixListManager::getList` will return a `PublicSuffixList` object containing the full PSL list.

Calling the `PublicSuffixListManager::refreshPublicSuffixList` will create or update each  section cache file in the cache directory. This means that:
- 2 new files are added to the cache directory
- 2 new constants to specify the cache file basename are added
  - `PublicSuffixListManager::ICANN_PSL_PHP_FILE` for the ICANN section
  - `PublicSuffixListManager::PRIVATE_PSL_PHP_FILE` for the PRIVATE section
### Backward Incompatible Changes
- None
### Targeted release version

next minor version
## Open issues

The `PublicSuffixListManager::$list` protected property is set when using the `PublicSuffixListManager::getList` method but is never used. What should be its value in this new system ? Should this property be deprecated ?
