### PR TITLE
only use INTL_IDNA_VARIANT_UTS46 constant only when exists

### DIFF
--- a/src/Pdp/Parser.php
+++ b/src/Pdp/Parser.php
@@ -303,7 +303,11 @@ class Parser
         $punycoded = (strpos($part, 'xn--') !== false);
 
         if ($punycoded === false) {
-            $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+            if (defined('INTL_IDNA_VARIANT_UTS46')) {
+                $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+            } else {
+                $part = idn_to_ascii($part);
+            }
             $this->isNormalized = true;
         }
 

--- a/src/Pdp/PublicSuffixListManager.php
+++ b/src/Pdp/PublicSuffixListManager.php
@@ -141,7 +141,11 @@ class PublicSuffixListManager
         // of https://publicsuffix.org/list/
         // "The domain and all rules must be canonicalized in the normal way
         // for hostnames - lower-case, Punycode (RFC 3492)."
-        $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+        } else {
+            $part = idn_to_ascii($part);
+        }
 
         if (strpos($part, '!') === 0) {
             $part = substr($part, 1);


### PR DESCRIPTION
ref to zend-validator issue https://github.com/zendframework/zend-validator/issues/193 that uses its constant while the system doesn't know the constant.