### PR TITLE
updated cache-key to be universally psr-16 compliant

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -81,9 +81,9 @@ final class Manager
      */
     private function getCacheKey(string $str): string
     {
-        static $cacheKeyPrefix = 'PSL-FULL';
+        static $cacheKeyPrefix = 'PSL_FULL';
 
-        return $cacheKeyPrefix.'-'.md5(strtolower($str));
+        return $cacheKeyPrefix.'_'.md5(strtolower($str));
     }
 
     /**


### PR DESCRIPTION
## Introduction

Currently the library uses  cache keys that contain hyphens. According to the [PSR specification](https://www.php-fig.org/psr/psr-6/) only the characters `A-Z`, `a-z`, `0-9`,  `_`, and `.` are required to be supported, and in the case of many implementations (specifically some of the psr-endorsed libraries such as `cache/filesystem-adapter`) they set a hard requirement that your key must only use those characters.

## Proposal

### Describe the new/updated/fixed feature

Switching the use of the hyphen to an underscore instead. This will allow all PSR-16 compatible libraries to be used. See Issue #213 

### Backward Incompatible Changes

Anything in the cache will currently be lost? Nothing really.

### Targeted release version

Depending on your cycle I guess 5.1.1 or 5.2.0

### PR Impact

None.

## Open issues

Mone