### PR TITLE
fix: hostname corruption of PSL data

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -104,7 +104,7 @@ final class Converter
         // "The domain and all rules must be canonicalized in the normal way
         // for hostnames - lower-case, Punycode (RFC 3492)."
 
-        $part = $this->idnToAscii(strtolower($part));
+        $part = $this->idnToAscii(mb_strtolower($part));
         $isDomain = true;
         if (0 === strpos($part, '!')) {
             $part = substr($part, 1);

--- a/src/IDNAConverterTrait.php
+++ b/src/IDNAConverterTrait.php
@@ -133,7 +133,7 @@ trait IDNAConverterTrait
             throw new Exception(sprintf('The domain `%s` is invalid: this is an IPv4 host', $domain));
         }
 
-        $formatted_domain = strtolower(rawurldecode($domain));
+        $formatted_domain = mb_strtolower(rawurldecode($domain));
 
         // Note that unreserved is purposely missing . as it is used to separate labels.
         static $domain_name = '/(?(DEFINE)

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -86,7 +86,7 @@ final class Manager
     {
         static $cacheKeyPrefix = 'PSL_FULL';
 
-        return $cacheKeyPrefix.'_'.md5(strtolower($str));
+        return $cacheKeyPrefix.'_'.md5(mb_strtolower($str));
     }
 
     /**


### PR DESCRIPTION
## Introduction

Issue #216 issues with the parser failing when `idnToAscii();` encounters illegal characters from an apparently good download of public_suffix_list.dat.

## Proposal

Use multibyte strtolower();

### Describe the new/upated/fixed feature

Change from `strtolower()` to `mb_strtolower` for the parser.

### Backward Incompatible Changes.

None known, function is recommended in the php manual for working with multibyte unicode strings.

### Targeted release version

Next patch release.

### PR Impact

Possibility that it will resolve some other edge behaviors where strings may be mangled.

## Open issues

No open issues, relates to closed question #216. Possible future project, update all string functions to their multibyte variants.