### PR TITLE
Fix UTF-8 characters convertation

### DIFF
--- a/src/IDNAConverterTrait.php
+++ b/src/IDNAConverterTrait.php
@@ -75,7 +75,7 @@ trait IDNAConverterTrait
     {
         static $pattern = '/[^\x20-\x7f]/';
         if (!preg_match($pattern, $domain)) {
-            return strtolower($domain);
+            return mb_strtolower($domain);
         }
 
         $output = idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46, $arr);


### PR DESCRIPTION
## Introduction

Before this PR, when trying to parse some domains with hieroglyphs, the IDN to ASCII converter returned false, when tried to convert those domains, or converted them wrong, and as a result, Public Suffix List rules couldn't be converted to JSON and saved.

## Proposal

I propose to change strtolower() in IDNAConverterTrait to mb_strtolower() to convert domains to lowercase properly.

### Describe the new/upated/fixed feature

Changed strtolower() to mb_strtolower() in method idnToAscii() of IDNAConverterTrait

### Targeted release version

Version 5.2.0
