### PR TITLE
Create ManagerInterface; implement on Manager

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -27,10 +27,8 @@ use Psr\SimpleCache\CacheInterface;
  * @author Jeremy Kendall <jeremy@jeremykendall.net>
  * @author Ignace Nyamagana Butera <nyamsprod@gmail.com>
  */
-final class Manager
+final class Manager implements ManagerInterface
 {
-    const PSL_URL = 'https://publicsuffix.org/list/public_suffix_list.dat';
-
     /**
      * @var CacheInterface
      */
@@ -54,13 +52,7 @@ final class Manager
     }
 
     /**
-     * Gets the Public Suffix List Rules.
-     *
-     * @param string $source_url the Public Suffix List URL
-     *
-     * @throws CouldNotLoadRules If the PSL rules can not be loaded
-     *
-     * @return Rules
+     * {@inheritdoc}
      */
     public function getRules(string $source_url = self::PSL_URL): Rules
     {
@@ -92,15 +84,7 @@ final class Manager
     }
 
     /**
-     * Downloads, converts and cache the Public Suffix.
-     *
-     * If a local cache already exists, it will be overwritten.
-     *
-     * Returns true if the refresh was successful
-     *
-     * @param string $source_url the Public Suffix List URL
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function refreshRules(string $source_url = self::PSL_URL): bool
     {

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * PHP Domain Parser: Public Suffix List based URL parsing.
+ *
+ * @see http://github.com/jeremykendall/php-domain-parser for the canonical source repository
+ *
+ * @copyright Copyright (c) 2017 Jeremy Kendall (http://jeremykendall.net)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Pdp;
+
+use Pdp\Exception\CouldNotLoadRules;
+
+/**
+ * Manager Interface.
+ */
+interface ManagerInterface
+{
+    const PSL_URL = 'https://publicsuffix.org/list/public_suffix_list.dat';
+
+    /**
+     * Gets the Public Suffix List Rules.
+     *
+     * @param string $source_url the Public Suffix List URL
+     *
+     * @throws CouldNotLoadRules If the PSL rules can not be loaded
+     *
+     * @return Rules
+     */
+    public function getRules(string $source_url = self::PSL_URL);
+
+    /**
+     * Downloads, converts and cache the Public Suffix.
+     *
+     * If a local cache already exists, it will be overwritten.
+     *
+     * Returns true if the refresh was successful
+     *
+     * @param string $source_url the Public Suffix List URL
+     *
+     * @return bool
+     */
+    public function refreshRules(string $source_url = self::PSL_URL);
+}


### PR DESCRIPTION
## Introduction

Fixes #225 

## Proposal

### Describe the new/upated/fixed feature

Creates `ManagerInterface` which `Pdp\Manager` then implements. This allows mocks to be easily created against `ManagerInterface` for use in unit tests in external projects that make use of `Pdp\Manager` instances.

See PR #225 for detail.

### Backward Incompatible Changes

No backward incompatible changes.

### Targeted release version

The next release version, whatever that might be.

Since this is an incremental change adding no new functionality, a minor release 5.3.1 seems fine to me.

### PR Impact

No changes to the public API

## Open issues

None
