### PR TITLE
fix #234

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -98,6 +98,7 @@ final class Domain implements DomainInterface, JsonSerializable
      * @var bool
     */
     private $isTransitionalDifferent;
+    
     /**
      * {@inheritdoc}
      */
@@ -127,6 +128,7 @@ final class Domain implements DomainInterface, JsonSerializable
         $this->asciiIDNAOption = $asciiIDNAOption;
         $this->unicodeIDNAOption = $unicodeIDNAOption;
         $this->labels = $this->setLabels($domain, $asciiIDNAOption, $unicodeIDNAOption);
+        $this->isTransitionalDifferent = $this->hasTransitionalDifference($domain);
         if ([] !== $this->labels) {
             $this->domain = implode('.', array_reverse($this->labels));
         }
@@ -375,7 +377,7 @@ final class Domain implements DomainInterface, JsonSerializable
      */
     public function isResolvable(): bool
     {
-        return 1 < count($this->labels ?? []) && '.' !== substr($this->domain, -1, 1);
+        return 1 < count($this->labels) && '.' !== substr($this->domain, -1, 1);
     }
 
     /**
@@ -761,13 +763,6 @@ final class Domain implements DomainInterface, JsonSerializable
      **/
     public function isTransitionalDifferent(): bool
     {
-        if ($this->isTransitionalDifferent === null) {
-            try {
-                $this->idnToAscii($this->getContent(), $this->asciiIDNAOption);
-            } catch (Throwable $e) {
-                $this->isTransitionalDifferent = false;
-            }
-        }
         return $this->isTransitionalDifferent;
     }
 }

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -106,8 +106,8 @@ final class Domain implements DomainInterface, JsonSerializable
         return new self(
             $properties['domain'],
             $properties['publicSuffix'],
-            $properties['asciiIDNAOption'],
-            $properties['unicodeIDNAOption']
+            $properties['asciiIDNAOption'] ?? IDNA_DEFAULT,
+            $properties['unicodeIDNAOption'] ?? IDNA_DEFAULT
         );
     }
     

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -124,7 +124,8 @@ final class Domain implements DomainInterface, JsonSerializable
         int $asciiIDNAOption = IDNA_DEFAULT,
         int $unicodeIDNAOption = IDNA_DEFAULT
     ) {
-        $this->setIDNAOptions($asciiIDNAOption, $unicodeIDNAOption);
+        $this->asciiIDNAOption = $asciiIDNAOption;
+        $this->unicodeIDNAOption = $unicodeIDNAOption;
         $this->labels = $this->setLabels($domain, $asciiIDNAOption, $unicodeIDNAOption);
         if ([] !== $this->labels) {
             $this->domain = implode('.', array_reverse($this->labels));
@@ -748,11 +749,9 @@ final class Domain implements DomainInterface, JsonSerializable
      * @param  int   $forUnicode
      * @return $this
      */
-    public function setIDNAOptions(int $forAscii, int $forUnicode)
+    public function withIDNAOptions(int $forAscii, int $forUnicode)
     {
-        $this->asciiIDNAOption = $forAscii;
-        $this->unicodeIDNAOption = $forUnicode;
-        return $this;
+        return new self($this->domain, $this->publicSuffix, $forAscii, $forUnicode);
     }
     
     /**

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -421,7 +421,7 @@ final class Domain implements DomainInterface, JsonSerializable
             return $this;
         }
 
-        return new self($domain, $this->publicSuffix, ...$this->getIDNAOptions());
+        return new self($domain, $this->publicSuffix, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
     }
 
     /**
@@ -436,7 +436,8 @@ final class Domain implements DomainInterface, JsonSerializable
         return new self(
             $this->idnToUnicode($this->domain, $this->unicodeIDNAOption),
             $this->publicSuffix,
-            ...$this->getIDNAOptions()
+            $this->getAsciiIDNAOption(),
+            $this->getUnicodeIDNAOption()
         );
     }
 
@@ -458,7 +459,12 @@ final class Domain implements DomainInterface, JsonSerializable
     public function resolve($publicSuffix): self
     {
         if (!$publicSuffix instanceof PublicSuffix) {
-            $publicSuffix = new PublicSuffix($publicSuffix, '', ...$this->getIDNAOptions());
+            $publicSuffix = new PublicSuffix(
+                $publicSuffix,
+                '',
+                $this->getAsciiIDNAOption(),
+                $this->getUnicodeIDNAOption()
+            );
         }
 
         $publicSuffix = $this->normalize($publicSuffix);
@@ -466,7 +472,7 @@ final class Domain implements DomainInterface, JsonSerializable
             return $this;
         }
 
-        return new self($this->domain, $publicSuffix, ...$this->getIDNAOptions());
+        return new self($this->domain, $publicSuffix, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
     }
 
     /**
@@ -485,7 +491,12 @@ final class Domain implements DomainInterface, JsonSerializable
     public function withPublicSuffix($publicSuffix): self
     {
         if (!$publicSuffix instanceof PublicSuffix) {
-            $publicSuffix = new PublicSuffix($publicSuffix, '', ...$this->getIDNAOptions());
+            $publicSuffix = new PublicSuffix(
+                $publicSuffix,
+                '',
+                $this->getAsciiIDNAOption(),
+                $this->getUnicodeIDNAOption()
+            );
         }
 
         $publicSuffix = $this->normalize($publicSuffix);
@@ -495,10 +506,15 @@ final class Domain implements DomainInterface, JsonSerializable
 
         $domain = implode('.', array_reverse(array_slice($this->labels, count($this->publicSuffix))));
         if (null === $publicSuffix->getContent()) {
-            return new self($domain, null, ...$this->getIDNAOptions());
+            return new self($domain, null, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
         }
 
-        return new self($domain.'.'.$publicSuffix->getContent(), $publicSuffix, ...$this->getIDNAOptions());
+        return new self(
+            $domain.'.'.$publicSuffix->getContent(),
+            $publicSuffix,
+            $this->getAsciiIDNAOption(),
+            $this->getUnicodeIDNAOption()
+        );
     }
 
 
@@ -526,13 +542,19 @@ final class Domain implements DomainInterface, JsonSerializable
         }
 
         if (null === $subDomain) {
-            return new self($this->registrableDomain, $this->publicSuffix, ...$this->getIDNAOptions());
+            return new self(
+                $this->registrableDomain,
+                $this->publicSuffix,
+                $this->getAsciiIDNAOption(),
+                $this->getUnicodeIDNAOption()
+            );
         }
 
         return new self(
             $subDomain.'.'.$this->registrableDomain,
             $this->publicSuffix,
-            ...$this->getIDNAOptions()
+            $this->getAsciiIDNAOption(),
+            $this->getUnicodeIDNAOption()
         );
     }
 
@@ -641,13 +663,19 @@ final class Domain implements DomainInterface, JsonSerializable
         ksort($labels);
 
         if (null !== $this->publicSuffix->getLabel($key)) {
-            return new self(implode('.', array_reverse($labels)), null, ...$this->getIDNAOptions());
+            return new self(
+                implode('.', array_reverse($labels)),
+                null,
+                $this->getAsciiIDNAOption(),
+                $this->getUnicodeIDNAOption()
+            );
         }
 
         return new self(
             implode('.', array_reverse($labels)),
             $this->publicSuffix,
-            ...$this->getIDNAOptions()
+            $this->getAsciiIDNAOption(),
+            $this->getUnicodeIDNAOption()
         );
     }
 
@@ -691,25 +719,18 @@ final class Domain implements DomainInterface, JsonSerializable
         }
 
         if ([] === $labels) {
-            return new self(null, null, ...$this->getIDNAOptions());
+            return new self(null, null, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
         }
 
         $domain = implode('.', array_reverse($labels));
         $psContent = $this->publicSuffix->getContent();
         if (null === $psContent || '.'.$psContent !== substr($domain, - strlen($psContent) - 1)) {
-            return new self($domain, null, ...$this->getIDNAOptions());
+            return new self($domain, null, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
         }
 
-        return new self($domain, $this->publicSuffix, ...$this->getIDNAOptions());
+        return new self($domain, $this->publicSuffix, $this->getAsciiIDNAOption(), $this->getUnicodeIDNAOption());
     }
     
-    /**
-     * @return array
-     */
-    public function getIDNAOptions(): array
-    {
-        return [$this->asciiIDNAOption, $this->unicodeIDNAOption];
-    }
     
     public function getAsciiIDNAOption(): int
     {

--- a/src/DomainInterface.php
+++ b/src/DomainInterface.php
@@ -99,4 +99,11 @@ interface DomainInterface extends Countable, IteratorAggregate
      * from the right-most label to the left-most label.
      */
     public function getIterator();
+    
+    /**
+     * return true if domain contains deviation characters.
+     * @see http://unicode.org/reports/tr46/#Transition_Considerations
+     * @return bool
+     **/
+    public function isTransitionalDifferent(): bool;
 }

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -108,7 +108,12 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
             $section = self::PRIVATE_DOMAINS;
         }
         
-        return new self($domain->getPublicSuffix(), $section, ...$domain->getIDNAOptions());
+        return new self(
+            $domain->getPublicSuffix(),
+            $section,
+            $domain->getAsciiIDNAOption(),
+            $domain->getUnicodeIDNAOption()
+        );
     }
 
     /**
@@ -316,14 +321,15 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
         return $clone;
     }
     
-    /**
-     * @return array
-     */
-    public function getIDNAOptions(): array
+    public function getAsciiIDNAOption(): int
     {
-        return [$this->asciiIDNAOption, $this->unicodeIDNAOption];
+        return $this->asciiIDNAOption;
     }
     
+    public function getUnicodeIDNAOption(): int
+    {
+        return $this->unicodeIDNAOption;
+    }
     /**
      * return true if domain contains deviation characters.
      * @see http://unicode.org/reports/tr46/#Transition_Considerations

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -130,6 +130,7 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
         int $unicodeIDNAOption = IDNA_DEFAULT
     ) {
         $this->labels = $this->setLabels($publicSuffix, $asciiIDNAOption, $unicodeIDNAOption);
+        $this->isTransitionalDifferent = $this->hasTransitionalDifference($publicSuffix);
         $this->publicSuffix = $this->setPublicSuffix();
         $this->section = $this->setSection($section);
         $this->asciiIDNAOption = $asciiIDNAOption;
@@ -330,6 +331,7 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     {
         return $this->unicodeIDNAOption;
     }
+    
     /**
      * return true if domain contains deviation characters.
      * @see http://unicode.org/reports/tr46/#Transition_Considerations
@@ -337,13 +339,6 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
      **/
     public function isTransitionalDifferent(): bool
     {
-        if ($this->isTransitionalDifferent === null) {
-            try {
-                $this->idnToAscii($this->getContent());
-            } catch (Throwable $e) {
-                $this->isTransitionalDifferent = false;
-            }
-        }
         return $this->isTransitionalDifferent;
     }
 }

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -135,21 +135,27 @@ final class Rules implements PublicSuffixListSection
 
     /**
      * Returns PSL info for a given domain.
-     *
-     * @param mixed  $domain
-     * @param string $section
-     *
+     * @param  mixed  $domain
+     * @param  string $section
+     * @param  int    $asciiIDNAOption
+     * @param  int    $unicodeIDNAOption
      * @return Domain
      */
-    public function resolve($domain, string $section = self::ALL_DOMAINS): Domain
-    {
+    public function resolve(
+        $domain,
+        string $section = self::ALL_DOMAINS,
+        int $asciiIDNAOption = IDNA_DEFAULT,
+        int $unicodeIDNAOption = IDNA_DEFAULT
+    ): Domain {
         $section = $this->validateSection($section);
         try {
-            $domain = $domain instanceof Domain ? $domain : new Domain($domain);
+            $domain = $domain instanceof Domain
+                ? $domain
+                : new Domain($domain, null, $asciiIDNAOption, $unicodeIDNAOption);
             if (!$domain->isResolvable()) {
                 return $domain;
             }
-
+            
             return $domain->resolve($this->findPublicSuffix($domain, $section));
         } catch (Exception $e) {
             return new Domain();

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -213,15 +213,17 @@ final class TopLevelDomains implements Countable, IteratorAggregate
 
     /**
      * Returns a domain where its public suffix is the found TLD.
-     *
-     * @param mixed $domain
-     *
+     * @param  mixed  $domain
+     * @param  int    $asciiIDNAOption
+     * @param  int    $unicodeIDNAOption
      * @return Domain
      */
-    public function resolve($domain): Domain
+    public function resolve($domain, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): Domain
     {
         try {
-            $domain = $domain instanceof Domain ? $domain : new Domain($domain);
+            $domain = $domain instanceof Domain
+                      ? $domain
+                      : new Domain($domain, null, $asciiIDNAOption, $unicodeIDNAOption);
         } catch (Exception $e) {
             return new Domain();
         }

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -985,8 +985,6 @@ class DomainTest extends TestCase
     
     /**
      * @covers ::__construct
-     * @covers ::setIDNAOptions
-     * @covers ::getIDNAOptions
      */
     public function testConstructWithCustomIDNAOptions()
     {

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -677,6 +677,14 @@ class DomainTest extends TestCase
                 'isICANN' => false,
                 'isPrivate' => false,
             ],
+            'with custom IDNA domain options' =>[
+                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), 16, 32),
+                'publicSuffix' => null,
+                'expected' => null,
+                'isKnown' => false,
+                'isICANN' => false,
+                'isPrivate' => false,
+            ],
         ];
     }
 
@@ -973,5 +981,151 @@ class DomainTest extends TestCase
     public function testwithoutLabelWorksWithMultipleKeys()
     {
         self::assertNull((new Domain('www.example.com'))->withoutLabel(0, 1, 2)->getContent());
+    }
+    
+    /**
+     * @covers ::__construct
+     * @covers ::setIDNAOptions
+     * @covers ::getIDNAOptions
+     */
+    public function testConstructWithCustomIDNAOptions()
+    {
+        $domain = new Domain('example.com', null, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
+        self::assertSame([16, 32], $domain->getIDNAOptions());
+    }
+    
+    /**
+     * @dataProvider resolveCustomIDNAOptionsProvider
+     * @param string      $domainName
+     * @param string      $publicSuffix
+     * @param string      $withLabel
+     * @param null|string $expectedContent
+     * @param null|string $expectedAscii
+     * @param null|string $expectedUnicode
+     * @param null|string $expectedRegistrable
+     * @param null|string $expectedSubDomain
+     * @param null|string $expectedWithLabel
+     */
+    public function testResolveWorksWithCustomIDNAOptions(
+        string $domainName,
+        string $publicSuffix,
+        string $withLabel,
+        $expectedContent,
+        $expectedAscii,
+        $expectedUnicode,
+        $expectedRegistrable,
+        $expectedSubDomain,
+        $expectedWithLabel
+    ) {
+        $domain = new Domain(
+            $domainName,
+            new PublicSuffix($publicSuffix),
+            IDNA_NONTRANSITIONAL_TO_ASCII,
+            IDNA_NONTRANSITIONAL_TO_UNICODE
+        );
+        self::assertSame($expectedContent, $domain->getContent());
+        self::assertSame($expectedAscii, $domain->toAscii()->getContent());
+        self::assertSame($expectedUnicode, $domain->toUnicode()->getContent());
+        self::assertSame($expectedRegistrable, $domain->getRegistrableDomain());
+        self::assertSame($expectedSubDomain, $domain->getSubDomain());
+        self::assertSame($expectedWithLabel, $domain->withLabel(-1, $withLabel)->getContent());
+    }
+    
+    public function resolveCustomIDNAOptionsProvider()
+    {
+        return [
+            'without deviation characters'=>[
+                'example.com',
+                'com',
+                'größe',
+                'example.com',
+                'example.com',
+                'example.com',
+                'example.com',
+                 null,
+                'xn--gre-6ka8i.com',
+            ],
+            'without deviation characters with label'=>[
+                'www.example.com',
+                'com',
+                'größe',
+                'www.example.com',
+                'www.example.com',
+                'www.example.com',
+                'example.com',
+                'www',
+                'xn--gre-6ka8i.example.com',
+            ],
+            'with deviation in domain'=>[
+                'www.faß.de',
+                'de',
+                'größe',
+                'www.faß.de',
+                'www.xn--fa-hia.de',
+                'www.faß.de',
+                'faß.de',
+                'www',
+                'größe.faß.de',
+            ],
+            'with deviation in label'=>[
+                'faß.test.de',
+                'de',
+                'größe',
+                'faß.test.de',
+                'xn--fa-hia.test.de',
+                'faß.test.de',
+                'test.de',
+                'faß',
+                'größe.test.de',
+            ],
+        ];
+    }
+    
+   
+    public function testInstanceCreationWithCustomIDNAOptions()
+    {
+        $domain = new Domain('example.com', new PublicSuffix('com'), 16, 32);
+        $instance = $domain->toAscii();
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->toUnicode();
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->withLabel(0, 'foo');
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->withoutLabel(0);
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->withPublicSuffix(new PublicSuffix('us'));
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->withSubDomain('foo');
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->append('bar');
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->prepend('bar');
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        $instance = $domain->resolve('com');
+        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+    }
+    
+    /**
+     * @covers ::isTransitionalDifferent
+     * @dataProvider transitionalProvider
+     * @param \Pdp\Domain $domain
+     * @param bool        $expected
+     */
+    public function testIsTransitionalDifference(Domain $domain, bool $expected)
+    {
+        self::assertSame($expected, $domain->isTransitionalDifferent());
+    }
+    
+    public function transitionalProvider()
+    {
+        return [
+            'simple' => [new Domain('example.com', new PublicSuffix('com')), false],
+            'idna' => [new Domain('français.fr', new PublicSuffix('fr')), false],
+            'in domain' => [new Domain('faß.de', new PublicSuffix('de')), true],
+            'in domain 2' => [new Domain('βόλος.com', new PublicSuffix('com')), true],
+            'in domain 3' => [new Domain('ශ්‍රී.com', new PublicSuffix('com')), true],
+            'in domain 4' => [new Domain('نامه‌ای.com', new PublicSuffix('com')), true],
+            'in label' => [new Domain('faß.test.de', new PublicSuffix('de')), true],
+        ];
     }
 }

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -991,7 +991,7 @@ class DomainTest extends TestCase
     public function testConstructWithCustomIDNAOptions()
     {
         $domain = new Domain('example.com', null, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
-        self::assertSame([16, 32], $domain->getIDNAOptions());
+        self::assertSame([16, 32], [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()]);
     }
     
     /**
@@ -1086,23 +1086,50 @@ class DomainTest extends TestCase
     {
         $domain = new Domain('example.com', new PublicSuffix('com'), 16, 32);
         $instance = $domain->toAscii();
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->toUnicode();
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->withLabel(0, 'foo');
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->withoutLabel(0);
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->withPublicSuffix(new PublicSuffix('us'));
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->withSubDomain('foo');
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->append('bar');
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->prepend('bar');
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         $instance = $domain->resolve('com');
-        self::assertSame($domain->getIDNAOptions(), $instance->getIDNAOptions());
+        self::assertSame(
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
     }
     
     /**

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 
 namespace Pdp\Tests;
 
+use function array_map;
+use function array_reduce;
+use function ord;
 use Pdp\Domain;
 use Pdp\Exception\CouldNotResolvePublicSuffix;
 use Pdp\Exception\CouldNotResolveSubDomain;
@@ -24,6 +27,8 @@ use Pdp\Exception\InvalidLabelKey;
 use Pdp\PublicSuffix;
 use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
+use function print_r;
+use function str_split;
 use TypeError;
 
 /**

--- a/tests/PublicSuffixTest.php
+++ b/tests/PublicSuffixTest.php
@@ -241,7 +241,10 @@ class PublicSuffixTest extends TestCase
         self::assertSame($result->isKnown(), $domain->isKnown());
         self::assertSame($result->isICANN(), $domain->isICANN());
         self::assertSame($result->isPrivate(), $domain->isPrivate());
-        self::assertSame($result->getIDNAOptions(), $domain->getIDNAOptions());
+        self::assertSame(
+            [$result->getAsciiIDNAOption(), $result->getUnicodeIDNAOption()],
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()]
+        );
     }
 
     public function createFromDomainProvider()
@@ -287,7 +290,11 @@ class PublicSuffixTest extends TestCase
         self::assertSame($expectedContent, $publicSuffix->getContent());
         self::assertSame($expectedAscii, $publicSuffix->toAscii()->getContent());
         self::assertSame($expectedUnicode, $publicSuffix->toUnicode()->getContent());
-        self::assertSame($publicSuffix->getIDNAOptions(), $publicSuffix->toUnicode()->getIDNAOptions());
+        $instance = $publicSuffix->toUnicode();
+        self::assertSame(
+            [$publicSuffix->getAsciiIDNAOption(), $publicSuffix->getUnicodeIDNAOption()],
+            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+        );
         self::assertSame($publicSuffix->isTransitionalDifferent(), $publicSuffix->toAscii()->isTransitionalDifferent());
     }
     

--- a/tests/PublicSuffixTest.php
+++ b/tests/PublicSuffixTest.php
@@ -241,6 +241,7 @@ class PublicSuffixTest extends TestCase
         self::assertSame($result->isKnown(), $domain->isKnown());
         self::assertSame($result->isICANN(), $domain->isICANN());
         self::assertSame($result->isPrivate(), $domain->isPrivate());
+        self::assertSame($result->getIDNAOptions(), $domain->getIDNAOptions());
     }
 
     public function createFromDomainProvider()
@@ -258,6 +259,90 @@ class PublicSuffixTest extends TestCase
                 'domain' => new Domain('www.bébé.be'),
                 'expected' => null,
             ],
+            [
+                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), 16, 32),
+                'expected' => 'be',
+            ],
+        ];
+    }
+    
+    /**
+     * @covers ::getIDNAOptions
+     * @covers ::isTransitionalDifferent
+     *
+     * @dataProvider customIDNAProvider
+     *
+     * @param string $name
+     * @param string $expectedContent
+     * @param string $expectedAscii
+     * @param string $expectedUnicode
+     */
+    public function testResolveWithCustomIDNAOptions(
+        string $name,
+        string $expectedContent,
+        string $expectedAscii,
+        string $expectedUnicode
+    ) {
+        $publicSuffix = new PublicSuffix($name, '', 16, 32);
+        self::assertSame($expectedContent, $publicSuffix->getContent());
+        self::assertSame($expectedAscii, $publicSuffix->toAscii()->getContent());
+        self::assertSame($expectedUnicode, $publicSuffix->toUnicode()->getContent());
+        self::assertSame($publicSuffix->getIDNAOptions(), $publicSuffix->toUnicode()->getIDNAOptions());
+        self::assertSame($publicSuffix->isTransitionalDifferent(), $publicSuffix->toAscii()->isTransitionalDifferent());
+    }
+    
+    public function customIDNAProvider()
+    {
+        return [
+            'without deviation characters'=>[
+                'example.com',
+                'example.com',
+                'example.com',
+                'example.com',
+            ],
+            'without deviation characters with label'=>[
+                'www.example.com',
+                'www.example.com',
+                'www.example.com',
+                'www.example.com',
+            ],
+            'with deviation in domain'=>[
+                'www.faß.de',
+                'www.faß.de',
+                'www.xn--fa-hia.de',
+                'www.faß.de',
+            ],
+            'with deviation in label'=>[
+                'faß.test.de',
+                'faß.test.de',
+                'xn--fa-hia.test.de',
+                'faß.test.de',
+            ],
+        ];
+    }
+    
+    /**
+     * @covers ::isTransitionalDifferent
+     *
+     * @dataProvider transitionalProvider
+     * @param \Pdp\PublicSuffix $publicSuffix
+     * @param bool              $expected
+     */
+    public function testIsTransitionalDifference(PublicSuffix $publicSuffix, bool $expected)
+    {
+        self::assertSame($expected, $publicSuffix->isTransitionalDifferent());
+    }
+    
+    public function transitionalProvider()
+    {
+        return [
+            'simple' => [new PublicSuffix('example.com'), false],
+            'idna' => [new PublicSuffix('français.fr'), false],
+            'in domain' => [new PublicSuffix('faß.de'), true],
+            'in domain 2' => [new PublicSuffix('βόλος.com'), true],
+            'in domain 3' => [new PublicSuffix('ශ්‍රී.com'), true],
+            'in domain 4' => [new PublicSuffix('نامه‌ای.com'), true],
+            'in label' => [new PublicSuffix('faß.test.de'), true],
         ];
     }
 }

--- a/tests/PublicSuffixTest.php
+++ b/tests/PublicSuffixTest.php
@@ -270,7 +270,6 @@ class PublicSuffixTest extends TestCase
     }
     
     /**
-     * @covers ::getIDNAOptions
      * @covers ::isTransitionalDifferent
      *
      * @dataProvider customIDNAProvider

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -636,9 +636,10 @@ class RulesTest extends TestCase
     
     public function testResolveWithIDNAOptions()
     {
+        $resolved = $this->rules->resolve('foo.de', Rules::ICANN_DOMAINS, 16, 32);
         self::assertSame(
             [16, 32],
-            $this->rules->resolve('foo.de', Rules::ICANN_DOMAINS, 16, 32)->getIDNAOptions()
+            [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]
         );
     }
 }

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -621,6 +621,7 @@ class RulesTest extends TestCase
         $this->checkPublicSuffix('www.食狮.中国', '食狮.中国');
         $this->checkPublicSuffix('shishi.中国', 'shishi.中国');
         $this->checkPublicSuffix('中国', null);
+        $this->checkPublicSuffix('www.faß.de', 'fass.de');
         // Same as above, but punycoded.
         $this->checkPublicSuffix('xn--85x722f.com.cn', 'xn--85x722f.com.cn');
         $this->checkPublicSuffix('xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn');
@@ -631,5 +632,13 @@ class RulesTest extends TestCase
         $this->checkPublicSuffix('www.xn--85x722f.xn--fiqs8s', 'xn--85x722f.xn--fiqs8s');
         $this->checkPublicSuffix('shishi.xn--fiqs8s', 'shishi.xn--fiqs8s');
         $this->checkPublicSuffix('xn--fiqs8s', null);
+    }
+    
+    public function testResolveWithIDNAOptions()
+    {
+        self::assertSame(
+            [16, 32],
+            $this->rules->resolve('foo.de', Rules::ICANN_DOMAINS, 16, 32)->getIDNAOptions()
+        );
     }
 }

--- a/tests/TopLevelDomainsTest.php
+++ b/tests/TopLevelDomainsTest.php
@@ -151,7 +151,8 @@ class TopLevelDomainsTest extends TestCase
 
     public function testResolveWithIDNAOptions()
     {
-        self::assertSame([16, 32], $this->collection->resolve('foo.de', 16, 32)->getIDNAOptions());
+        $resolved = $this->collection->resolve('foo.de', 16, 32);
+        self::assertSame([16, 32], [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]);
     }
     /**
      * @dataProvider validTldProvider

--- a/tests/TopLevelDomainsTest.php
+++ b/tests/TopLevelDomainsTest.php
@@ -149,6 +149,10 @@ class TopLevelDomainsTest extends TestCase
         self::assertNull($collection->resolve('localhost.locale')->getPublicSuffix());
     }
 
+    public function testResolveWithIDNAOptions()
+    {
+        self::assertSame([16, 32], $this->collection->resolve('foo.de', 16, 32)->getIDNAOptions());
+    }
     /**
      * @dataProvider validTldProvider
      * @param mixed $tld


### PR DESCRIPTION
## Introduction

So, in most cases only Domain VO options enough; There are no way to configure it via PublicSuffix, because it use idn-convertion functions before set PublicSuffix 
https://github.com/jeremykendall/php-domain-parser/blob/develop/src/Domain.php#L102 

PublicSuffix VO also has ability to be configured with custom options, for cases when user want to set some specific PublicSuffix; 


### Backward Incompatible Changes
No

## Open issues

https://github.com/jeremykendall/php-domain-parser/issues/234
