### PR TITLE
IDNA options alternate setters

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -328,7 +328,9 @@ final class Domain implements DomainInterface, JsonSerializable
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii.
+     * Gets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -340,7 +342,9 @@ final class Domain implements DomainInterface, JsonSerializable
     }
     
     /**
-     * Set IDNA_* options for functions idn_to_utf8.
+     * Gets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -352,7 +356,7 @@ final class Domain implements DomainInterface, JsonSerializable
     }
     
     /**
-     * return true if domain contains deviation characters.
+     * Returns true if domain contains deviation characters.
      *
      * @see http://unicode.org/reports/tr46/#Transition_Considerations
      *
@@ -769,40 +773,44 @@ final class Domain implements DomainInterface, JsonSerializable
 
         return new self($domain, $this->publicSuffix, $this->asciiIDNAOption, $this->unicodeIDNAOption);
     }
-    
+
     /**
-     * Set IDNA_* options for idn_to_ascii.
+     * Sets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $asciiIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withAsciiIDNAOption(int $asciiIDNAOption): self
+    public function withAsciiIDNAOption(int $option): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption) {
+        if ($option === $this->asciiIDNAOption) {
             return $this;
         }
 
-        return new self($this->domain, $this->publicSuffix, $asciiIDNAOption, $this->unicodeIDNAOption);
+        return new self($this->domain, $this->publicSuffix, $option, $this->unicodeIDNAOption);
     }
 
     /**
-     * Set IDNA_* options for idn_to_utf8.
+     * Sets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $unicodeIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
+    public function withUnicodeIDNAOption(int $option): self
     {
-        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
+        if ($option === $this->unicodeIDNAOption) {
             return $this;
         }
 
-        return new self($this->domain, $this->publicSuffix, $this->asciiIDNAOption, $unicodeIDNAOption);
+        return new self($this->domain, $this->publicSuffix, $this->asciiIDNAOption, $option);
     }
 }

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -771,22 +771,38 @@ final class Domain implements DomainInterface, JsonSerializable
     }
     
     /**
-     * Set IDNA_* options for functions idn_to_ascii, idn_to_utf8.
+     * Set IDNA_* options for idn_to_ascii.
+     *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
      * @param int $asciiIDNAOption
+     *
+     * @return self
+     */
+    public function withAsciiIDNAOption(int $asciiIDNAOption): self
+    {
+        if ($asciiIDNAOption === $this->asciiIDNAOption) {
+            return $this;
+        }
+
+        return new self($this->domain, $this->publicSuffix, $asciiIDNAOption, $this->unicodeIDNAOption);
+    }
+
+    /**
+     * Set IDNA_* options for idn_to_utf8.
+     *
+     * @see https://www.php.net/manual/en/intl.constants.php
+     *
      * @param int $unicodeIDNAOption
      *
      * @return self
      */
-    public function withIDNAOptions(int $asciiIDNAOption, int $unicodeIDNAOption): self
+    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption
-            && $unicodeIDNAOption === $this->unicodeIDNAOption
-        ) {
+        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
             return $this;
         }
 
-        return new self($this->domain, $this->publicSuffix, $asciiIDNAOption, $unicodeIDNAOption);
+        return new self($this->domain, $this->publicSuffix, $this->asciiIDNAOption, $unicodeIDNAOption);
     }
 }

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -256,7 +256,9 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii.
+     * Gets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -268,7 +270,9 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     }
     
     /**
-     * Set IDNA_* options for functions idn_to_utf8.
+     * Gets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -280,7 +284,7 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     }
     
     /**
-     * return true if domain contains deviation characters.
+     * Returns true if domain contains deviation characters.
      *
      * @see http://unicode.org/reports/tr46/#Transition_Considerations
      *
@@ -359,38 +363,42 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     }
 
     /**
-     * Set IDNA_* options for idn_to_ascii.
+     * Sets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $asciiIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withAsciiIDNAOption(int $asciiIDNAOption): self
+    public function withAsciiIDNAOption(int $option): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption) {
+        if ($option === $this->asciiIDNAOption) {
             return $this;
         }
 
-        return new self($this->publicSuffix, $this->section, $asciiIDNAOption, $this->unicodeIDNAOption);
+        return new self($this->publicSuffix, $this->section, $option, $this->unicodeIDNAOption);
     }
 
     /**
-     * Set IDNA_* options for idn_to_utf8.
+     * Sets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $unicodeIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
+    public function withUnicodeIDNAOption(int $option): self
     {
-        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
+        if ($option === $this->unicodeIDNAOption) {
             return $this;
         }
 
-        return new self($this->publicSuffix, $this->section, $this->asciiIDNAOption, $unicodeIDNAOption);
+        return new self($this->publicSuffix, $this->section, $this->asciiIDNAOption, $option);
     }
 }

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -359,20 +359,38 @@ final class PublicSuffix implements DomainInterface, JsonSerializable, PublicSuf
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii, idn_to_utf8.
+     * Set IDNA_* options for idn_to_ascii.
+     *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
      * @param int $asciiIDNAOption
+     *
+     * @return self
+     */
+    public function withAsciiIDNAOption(int $asciiIDNAOption): self
+    {
+        if ($asciiIDNAOption === $this->asciiIDNAOption) {
+            return $this;
+        }
+
+        return new self($this->publicSuffix, $this->section, $asciiIDNAOption, $this->unicodeIDNAOption);
+    }
+
+    /**
+     * Set IDNA_* options for idn_to_utf8.
+     *
+     * @see https://www.php.net/manual/en/intl.constants.php
+     *
      * @param int $unicodeIDNAOption
      *
      * @return self
      */
-    public function withIDNAOptions(int $asciiIDNAOption, int $unicodeIDNAOption): self
+    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption && $unicodeIDNAOption === $this->unicodeIDNAOption) {
+        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
             return $this;
         }
 
-        return new self($this->publicSuffix, $this->section, $asciiIDNAOption, $unicodeIDNAOption);
+        return new self($this->publicSuffix, $this->section, $this->asciiIDNAOption, $unicodeIDNAOption);
     }
 }

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -144,7 +144,9 @@ final class Rules implements PublicSuffixListSection
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii.
+     * Gets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -156,7 +158,9 @@ final class Rules implements PublicSuffixListSection
     }
     
     /**
-     * Set IDNA_* options for functions idn_to_utf8.
+     * Gets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -193,8 +197,10 @@ final class Rules implements PublicSuffixListSection
 
     /**
      * Returns PSL info for a given domain.
-     * @param  mixed  $domain
-     * @param  string $section
+     *
+     * @param mixed  $domain
+     * @param string $section
+     *
      * @return Domain
      */
     public function resolve($domain, string $section = self::ALL_DOMAINS): Domain
@@ -310,7 +316,9 @@ final class Rules implements PublicSuffixListSection
     }
 
     /**
-     * Set IDNA_* options for idn_to_ascii.
+     * Sets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -331,7 +339,9 @@ final class Rules implements PublicSuffixListSection
     }
 
     /**
-     * Set IDNA_* options for idn_to_utf8.
+     * Sets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -310,22 +310,42 @@ final class Rules implements PublicSuffixListSection
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii, idn_to_utf8.
+     * Set IDNA_* options for idn_to_ascii.
+     *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
      * @param int $asciiIDNAOption
-     * @param int $unicodeIDNAOption
+     *
+     * @return self
      */
-    public function withIDNAOptions(int $asciiIDNAOption, int $unicodeIDNAOption): self
+    public function withAsciiIDNAOption(int $asciiIDNAOption): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption
-            && $unicodeIDNAOption === $this->unicodeIDNAOption
-        ) {
+        if ($asciiIDNAOption === $this->asciiIDNAOption) {
             return $this;
         }
 
         $clone = clone $this;
         $clone->asciiIDNAOption = $asciiIDNAOption;
+
+        return $clone;
+    }
+
+    /**
+     * Set IDNA_* options for idn_to_utf8.
+     *
+     * @see https://www.php.net/manual/en/intl.constants.php
+     *
+     * @param int $unicodeIDNAOption
+     *
+     * @return self
+     */
+    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
+    {
+        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
+            return $this;
+        }
+
+        $clone = clone $this;
         $clone->unicodeIDNAOption = $unicodeIDNAOption;
 
         return $clone;

--- a/src/TLDConverter.php
+++ b/src/TLDConverter.php
@@ -24,6 +24,7 @@ use function sprintf;
 use function strpos;
 use function trim;
 use const DATE_ATOM;
+use const IDNA_DEFAULT;
 
 /**
  * IANA Root Zone Database Parser.

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -311,24 +311,42 @@ final class TopLevelDomains implements Countable, IteratorAggregate
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii, idn_to_utf8.
+     * Set IDNA_* options for idn_to_ascii.
+     *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
      * @param int $asciiIDNAOption
-     * @param int $unicodeIDNAOption
      *
      * @return self
      */
-    public function withIDNAOptions(int $asciiIDNAOption, int $unicodeIDNAOption): self
+    public function withAsciiIDNAOption(int $asciiIDNAOption): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption
-            && $unicodeIDNAOption === $this->unicodeIDNAOption
-        ) {
+        if ($asciiIDNAOption === $this->asciiIDNAOption) {
             return $this;
         }
 
         $clone = clone $this;
         $clone->asciiIDNAOption = $asciiIDNAOption;
+
+        return $clone;
+    }
+
+    /**
+     * Set IDNA_* options for idn_to_utf8.
+     *
+     * @see https://www.php.net/manual/en/intl.constants.php
+     *
+     * @param int $unicodeIDNAOption
+     *
+     * @return self
+     */
+    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
+    {
+        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
+            return $this;
+        }
+
+        $clone = clone $this;
         $clone->unicodeIDNAOption = $unicodeIDNAOption;
 
         return $clone;

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -177,7 +177,9 @@ final class TopLevelDomains implements Countable, IteratorAggregate
     }
 
     /**
-     * Set IDNA_* options for functions idn_to_ascii.
+     * Gets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -189,7 +191,9 @@ final class TopLevelDomains implements Countable, IteratorAggregate
     }
     
     /**
-     * Set IDNA_* options for functions idn_to_utf8.
+     * Gets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
@@ -311,43 +315,47 @@ final class TopLevelDomains implements Countable, IteratorAggregate
     }
 
     /**
-     * Set IDNA_* options for idn_to_ascii.
+     * Sets conversion options for idn_to_ascii.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $asciiIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withAsciiIDNAOption(int $asciiIDNAOption): self
+    public function withAsciiIDNAOption(int $option): self
     {
-        if ($asciiIDNAOption === $this->asciiIDNAOption) {
+        if ($option === $this->asciiIDNAOption) {
             return $this;
         }
 
         $clone = clone $this;
-        $clone->asciiIDNAOption = $asciiIDNAOption;
+        $clone->asciiIDNAOption = $option;
 
         return $clone;
     }
 
     /**
-     * Set IDNA_* options for idn_to_utf8.
+     * Sets conversion options for idn_to_utf8.
+     *
+     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
-     * @param int $unicodeIDNAOption
+     * @param int $option
      *
      * @return self
      */
-    public function withUnicodeIDNAOption(int $unicodeIDNAOption): self
+    public function withUnicodeIDNAOption(int $option): self
     {
-        if ($unicodeIDNAOption === $this->unicodeIDNAOption) {
+        if ($option === $this->unicodeIDNAOption) {
             return $this;
         }
 
         $clone = clone $this;
-        $clone->unicodeIDNAOption = $unicodeIDNAOption;
+        $clone->unicodeIDNAOption = $option;
 
         return $clone;
     }

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -26,6 +26,8 @@ use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 use function date_create;
+use const IDNA_NONTRANSITIONAL_TO_ASCII;
+use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass Pdp\Domain
@@ -691,7 +693,7 @@ class DomainTest extends TestCase
                 'isPrivate' => false,
             ],
             'with custom IDNA domain options' =>[
-                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), 16, 32),
+                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE),
                 'publicSuffix' => null,
                 'expected' => null,
                 'isKnown' => false,
@@ -1002,7 +1004,10 @@ class DomainTest extends TestCase
     public function testConstructWithCustomIDNAOptions()
     {
         $domain = new Domain('example.com', null, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
-        self::assertSame([16, 32], [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()]);
+        self::assertSame(
+            [IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE],
+            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()]
+        );
     }
     
     /**
@@ -1094,7 +1099,13 @@ class DomainTest extends TestCase
        
     public function testInstanceCreationWithCustomIDNAOptions()
     {
-        $domain = new Domain('example.com', new PublicSuffix('com'), 16, 32);
+        $domain = new Domain(
+            'example.com',
+            new PublicSuffix('com'),
+            IDNA_NONTRANSITIONAL_TO_ASCII,
+            IDNA_NONTRANSITIONAL_TO_UNICODE
+        );
+        
         $instance = $domain->toAscii();
         self::assertSame(
             [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
@@ -1181,7 +1192,7 @@ class DomainTest extends TestCase
         ));
 
         self::assertNotEquals($domain, $domain->withAsciiIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_ASCII
         ));
 
         self::assertSame($domain, $domain->withUnicodeIDNAOption(
@@ -1189,7 +1200,7 @@ class DomainTest extends TestCase
         ));
 
         self::assertNotEquals($domain, $domain->withUnicodeIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_UNICODE
         ));
     }
 }

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -1167,15 +1167,29 @@ class DomainTest extends TestCase
     }
 
     /**
-     * @covers ::withIDNAOptions
      * @covers ::getAsciiIDNAOption
      * @covers ::getUnicodeIDNAOption
+     * @covers ::withAsciiIDNAOption
+     * @covers ::withUnicodeIDNAOption
      */
     public function testwithIDNAOptions()
     {
         $domain = new Domain('example.com', new PublicSuffix('com'));
-        self::assertSame($domain, $domain->withIDNAOptions($domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()));
 
-        self::assertNotEquals($domain, $domain->withIDNAOptions($domain->getAsciiIDNAOption(), 128));
+        self::assertSame($domain, $domain->withAsciiIDNAOption(
+            $domain->getAsciiIDNAOption()
+        ));
+
+        self::assertNotEquals($domain, $domain->withAsciiIDNAOption(
+            128
+        ));
+
+        self::assertSame($domain, $domain->withUnicodeIDNAOption(
+            $domain->getUnicodeIDNAOption()
+        ));
+
+        self::assertNotEquals($domain, $domain->withUnicodeIDNAOption(
+            128
+        ));
     }
 }

--- a/tests/PublicSuffixTest.php
+++ b/tests/PublicSuffixTest.php
@@ -353,15 +353,29 @@ class PublicSuffixTest extends TestCase
     }
 
     /**
-     * @covers ::withIDNAOptions
      * @covers ::getAsciiIDNAOption
      * @covers ::getUnicodeIDNAOption
+     * @covers ::withAsciiIDNAOption
+     * @covers ::withUnicodeIDNAOption
      */
     public function testwithIDNAOptions()
     {
         $publicSuffix = new PublicSuffix('com');
-        self::assertSame($publicSuffix, $publicSuffix->withIDNAOptions($publicSuffix->getAsciiIDNAOption(), $publicSuffix->getUnicodeIDNAOption()));
 
-        self::assertNotEquals($publicSuffix, $publicSuffix->withIDNAOptions($publicSuffix->getAsciiIDNAOption(), 128));
+        self::assertSame($publicSuffix, $publicSuffix->withAsciiIDNAOption(
+            $publicSuffix->getAsciiIDNAOption()
+        ));
+
+        self::assertNotEquals($publicSuffix, $publicSuffix->withAsciiIDNAOption(
+            128
+        ));
+
+        self::assertSame($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
+            $publicSuffix->getUnicodeIDNAOption()
+        ));
+
+        self::assertNotEquals($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
+            128
+        ));
     }
 }

--- a/tests/PublicSuffixTest.php
+++ b/tests/PublicSuffixTest.php
@@ -21,6 +21,8 @@ use Pdp\Exception\InvalidDomain;
 use Pdp\PublicSuffix;
 use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
+use const IDNA_NONTRANSITIONAL_TO_ASCII;
+use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass Pdp\PublicSuffix
@@ -263,7 +265,7 @@ class PublicSuffixTest extends TestCase
                 'expected' => null,
             ],
             [
-                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), 16, 32),
+                'domain' => new Domain('www.bébé.be', new PublicSuffix('be', Rules::ICANN_DOMAINS), IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE),
                 'expected' => 'be',
             ],
         ];
@@ -285,7 +287,7 @@ class PublicSuffixTest extends TestCase
         string $expectedAscii,
         string $expectedUnicode
     ) {
-        $publicSuffix = new PublicSuffix($name, '', 16, 32);
+        $publicSuffix = new PublicSuffix($name, '', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
         self::assertSame($expectedContent, $publicSuffix->getContent());
         self::assertSame($expectedAscii, $publicSuffix->toAscii()->getContent());
         self::assertSame($expectedUnicode, $publicSuffix->toUnicode()->getContent());
@@ -367,7 +369,7 @@ class PublicSuffixTest extends TestCase
         ));
 
         self::assertNotEquals($publicSuffix, $publicSuffix->withAsciiIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_ASCII
         ));
 
         self::assertSame($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
@@ -375,7 +377,7 @@ class PublicSuffixTest extends TestCase
         ));
 
         self::assertNotEquals($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_UNICODE
         ));
     }
 }

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -26,6 +26,9 @@ use Pdp\PublicSuffix;
 use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use const IDNA_DEFAULT;
+use const IDNA_NONTRANSITIONAL_TO_ASCII;
+use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass Pdp\Rules
@@ -92,7 +95,7 @@ class RulesTest extends TestCase
         ));
 
         self::assertNotEquals($this->rules, $this->rules->withAsciiIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_ASCII
         ));
 
         self::assertSame($this->rules, $this->rules->withUnicodeIDNAOption(
@@ -100,7 +103,7 @@ class RulesTest extends TestCase
         ));
 
         self::assertNotEquals($this->rules, $this->rules->withUnicodeIDNAOption(
-            128
+            IDNA_NONTRANSITIONAL_TO_UNICODE
         ));
     }
 
@@ -667,11 +670,16 @@ class RulesTest extends TestCase
     {
         $resolvedByDefault = $this->rules->resolve('foo.de', Rules::ICANN_DOMAINS);
         self::assertSame(
-            [0, 0],
+            [IDNA_DEFAULT, IDNA_DEFAULT],
             [$resolvedByDefault->getAsciiIDNAOption(), $resolvedByDefault->getUnicodeIDNAOption()]
         );
         $manager = new Manager(new Cache(), new CurlHttpClient());
-        $rules = $manager->getRules(Manager::PSL_URL, null, 16, 32);
+        $rules = $manager->getRules(
+            Manager::PSL_URL,
+            null,
+            IDNA_NONTRANSITIONAL_TO_ASCII,
+            IDNA_NONTRANSITIONAL_TO_UNICODE
+        );
         $resolved = $rules->resolve('foo.de', Rules::ICANN_DOMAINS);
         self::assertSame(
             [$rules->getAsciiIDNAOption(), $rules->getUnicodeIDNAOption()],

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -26,7 +26,6 @@ use Pdp\PublicSuffix;
 use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
 use TypeError;
-use const IDNA_DEFAULT;
 
 /**
  * @coversDefaultClass Pdp\Rules
@@ -81,12 +80,28 @@ class RulesTest extends TestCase
     }
 
     /**
-     * @covers ::withIDNAOptions
+     * @covers ::getAsciiIDNAOption
+     * @covers ::getUnicodeIDNAOption
+     * @covers ::withAsciiIDNAOption
+     * @covers ::withUnicodeIDNAOption
      */
     public function testwithIDNAOptions()
     {
-        self::assertSame($this->rules, $this->rules->withIDNAOptions(IDNA_DEFAULT, IDNA_DEFAULT));
-        self::assertNotEquals($this->rules, $this->rules->withIDNAOptions(IDNA_DEFAULT, 128));
+        self::assertSame($this->rules, $this->rules->withAsciiIDNAOption(
+            $this->rules->getAsciiIDNAOption()
+        ));
+
+        self::assertNotEquals($this->rules, $this->rules->withAsciiIDNAOption(
+            128
+        ));
+
+        self::assertSame($this->rules, $this->rules->withUnicodeIDNAOption(
+            $this->rules->getUnicodeIDNAOption()
+        ));
+
+        self::assertNotEquals($this->rules, $this->rules->withUnicodeIDNAOption(
+            128
+        ));
     }
 
     /**

--- a/tests/TopLevelDomainsTest.php
+++ b/tests/TopLevelDomainsTest.php
@@ -97,17 +97,24 @@ class TopLevelDomainsTest extends TestCase
     /**
      * @covers ::getAsciiIDNAOption
      * @covers ::getUnicodeIDNAOption
-     * @covers ::withIDNAOptions
+     * @covers ::withAsciiIDNAOption
+     * @covers ::withUnicodeIDNAOption
      */
     public function testwithIDNAOptions()
     {
-        self::assertSame($this->collection, $this->collection->withIDNAOptions(
-            $this->collection->getAsciiIDNAOption(),
+        self::assertSame($this->collection, $this->collection->withAsciiIDNAOption(
+            $this->collection->getAsciiIDNAOption()
+        ));
+
+        self::assertNotEquals($this->collection, $this->collection->withAsciiIDNAOption(
+            128
+        ));
+
+        self::assertSame($this->collection, $this->collection->withUnicodeIDNAOption(
             $this->collection->getUnicodeIDNAOption()
         ));
 
-        self::assertNotEquals($this->collection, $this->collection->withIDNAOptions(
-            $this->collection->getAsciiIDNAOption(),
+        self::assertNotEquals($this->collection, $this->collection->withUnicodeIDNAOption(
             128
         ));
     }

--- a/tests/TopLevelDomainsTest.php
+++ b/tests/TopLevelDomainsTest.php
@@ -24,6 +24,9 @@ use Pdp\TLDConverter;
 use Pdp\TopLevelDomains;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use const IDNA_DEFAULT;
+use const IDNA_NONTRANSITIONAL_TO_ASCII;
+use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass Pdp\TopLevelDomains
@@ -177,10 +180,23 @@ class TopLevelDomainsTest extends TestCase
     public function testResolveWithIDNAOptions()
     {
         $resolved = $this->collection->resolve('foo.de');
-        self::assertSame([0, 0], [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]);
-        $collection = TopLevelDomains::createFromPath(__DIR__.'/data/root_zones.dat', null, 16, 32);
+        self::assertSame(
+            [IDNA_DEFAULT, IDNA_DEFAULT],
+            [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption(),
+        ]
+        );
+        
+        $collection = TopLevelDomains::createFromPath(
+            __DIR__.'/data/root_zones.dat',
+            null,
+            IDNA_NONTRANSITIONAL_TO_ASCII,
+            IDNA_NONTRANSITIONAL_TO_UNICODE
+        );
         $resolved = $collection->resolve('foo.de');
-        self::assertSame([16, 32], [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]);
+        self::assertSame(
+            [IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE],
+            [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]
+        );
     }
     /**
      * @dataProvider validTldProvider


### PR DESCRIPTION
@Insolita while reviewing the #236 I was wondering why not use

`withAsciiIDNAOption` and `withUnicodeDNAOption` instead of `withIDNAOptions`.

This branch apply all the changes to implement this solution. Is there a strong argument against this change ? Depending on your answer I'll merge or close this PR.