### PR TITLE
Allows an optional path parameter in the cache update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,10 +544,10 @@ echo $domain->getPublicSuffix(); // print 'be'
 
 ### Automatic Updates
 
-It is important to always have an up to date PSL. In order to do so the library comes bundle with an auto-update script located in the `bin` directory. An optional path argument allows you to specify the location of the cache.
+It is important to always have an up to date PSL. In order to do so the library comes bundle with an auto-update script located in the `bin` directory. An optional `--cache-path` argument allows you to specify the location of the cache.
 
 ~~~bash
-$ php ./bin/update-psl --path cache/psl-list
+$ php ./bin/update-psl --cache-path cache/psl-list
 ~~~
 
 This script requires:

--- a/README.md
+++ b/README.md
@@ -544,10 +544,10 @@ echo $domain->getPublicSuffix(); // print 'be'
 
 ### Automatic Updates
 
-It is important to always have an up to date PSL. In order to do so the library comes bundle with an auto-update script located in the `bin` directory.
+It is important to always have an up to date PSL. In order to do so the library comes bundle with an auto-update script located in the `bin` directory. An optional path argument allows you to specify the location of the cache.
 
 ~~~bash
-$ php ./bin/update-psl
+$ php ./bin/update-psl --path cache/psl-list
 ~~~
 
 This script requires:

--- a/bin/update-psl
+++ b/bin/update-psl
@@ -3,6 +3,7 @@
 
 require dirname(__DIR__).'/src/Installer.php';
 
-$path = getopt(null, ["path:"])["path"] ?? null;
+use Pdp\Installer;
 
-Pdp\Installer::updateLocalCache(null, $path);
+Installer::setArguments(getopt(null, ["cache-path:"]));
+Installer::updateLocalCache();

--- a/bin/update-psl
+++ b/bin/update-psl
@@ -3,4 +3,6 @@
 
 require dirname(__DIR__).'/src/Installer.php';
 
-Pdp\Installer::updateLocalCache();
+$path = getopt(null, ["path:"])["path"] ?? null;
+
+Pdp\Installer::updateLocalCache(null, $path);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -152,7 +152,7 @@ final class Installer
     }
 
     /**
-     * @param string[] $arguments
+     * @param array $arguments
      */
     public static function setArguments(array $arguments = [])
     {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -37,8 +37,9 @@ final class Installer
      * Script to update the local cache using composer hook.
      *
      * @param Event $event
+     * @param string $cachePath
      */
-    public static function updateLocalCache(Event $event = null)
+    public static function updateLocalCache(Event $event = null, string $cachePath = null)
     {
         $io = static::getIO($event);
         $vendor = static::getVendorPath($event);
@@ -62,7 +63,8 @@ final class Installer
         }
 
         try {
-            $manager = new Manager(new Cache(), new CurlHttpClient());
+            $cache = $cachePath === null ? new Cache() : new Cache($cachePath);
+            $manager = new Manager($cache, new CurlHttpClient());
             if ($manager->refreshRules() && $manager->refreshTLDs()) {
                 $io->write([
                     '💪 💪 💪 Your local cache has been successfully updated. 💪 💪 💪',

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -36,7 +36,7 @@ final class Installer
     /**
      * Script to update the local cache using composer hook.
      *
-     * @param Event $event
+     * @param Event  $event
      * @param string $cachePath
      */
     public static function updateLocalCache(Event $event = null, string $cachePath = null)

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -33,14 +33,16 @@ use const STDOUT;
  */
 final class Installer
 {
+    private static $arguments;
+
     /**
      * Script to update the local cache using composer hook.
      *
-     * @param Event  $event
-     * @param string $cachePath
+     * @param Event $event
      */
-    public static function updateLocalCache(Event $event = null, string $cachePath = null)
+    public static function updateLocalCache(Event $event = null)
     {
+        $arguments = static::getArguments($event);
         $io = static::getIO($event);
         $vendor = static::getVendorPath($event);
         if (null === $vendor) {
@@ -63,7 +65,7 @@ final class Installer
         }
 
         try {
-            $cache = $cachePath === null ? new Cache() : new Cache($cachePath);
+            $cache = !isset($arguments['cache-path']) ? new Cache() : new Cache($arguments['cache-path']);
             $manager = new Manager($cache, new CurlHttpClient());
             if ($manager->refreshRules() && $manager->refreshTLDs()) {
                 $io->write([
@@ -138,5 +140,22 @@ final class Installer
                 );
             }
         };
+    }
+
+    /**
+     * @param  Event|null $event
+     * @return array
+     */
+    private static function getArguments(Event $event = null)
+    {
+        return null !== $event ? $event->getArguments() : static::$arguments;
+    }
+
+    /**
+     * @param string[] $arguments
+     */
+    public static function setArguments(array $arguments = [])
+    {
+        static::$arguments = $arguments;
     }
 }


### PR DESCRIPTION
The cache class allows for you to use a custom path which is very helpful, but the installer currently doesn't support this. So now you can use an optional parameter path when calling the bin/update-psl to specify the cache location. This seems like a preferable alternative to having people copy and edit the installer file as it's an optional improvement getting the installer up to date with the cache's already existing functionality.
