### PR TITLE
ext-curl should be required on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require": {
         "php": ">=7.0",
         "ext-intl": "*",
+        "ext-curl": "*",
         "psr/simple-cache": "^1.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
## Introduction

This library sets `ext-intl` as a dependency to work, but does not check if `ext-curl` is installed as it seems to be. It throws an `Error: Undefined constant 'CURLOPT_FAILONERROR'` until I install the extension.

## Proposal

### Updating `composer.json`

I would add the requirement as a dependency on `composer.json` to make people aware of it.
