### PR TITLE
Remove publicsuffix related methods from Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 All Notable changes to `PHP Domain Parser` **5.x** series will be documented in this file
 
-## Next - TBD
+## 5.7.0 - TBD
 
 ### Added
 
-- `Rules::resolveCookieDomain`
-- `Rules::resolveICANNDomain`
-- `Rules::resolvePrivateDomain`
-- `Rules::getCookieEffectiveTLD`
-- `Rules::getICANNEffectiveTLD`
-- `Rules::getPrivateeEffectiveTLD`
+- `Rules::getCookieDomain`
+- `Rules::getICANNDomain`
+- `Rules::getPrivateDomain`
 - `CouldNotResolvePublicSuffix::dueToUnresolvableDomain`
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -46,52 +46,23 @@ $ composer require jeremykendall/php-domain-parser
 Usage
 --------
 
-### Public suffix resolution.
+### Domain part resolutions
 
-The first objective of the library is using the [Public Suffix List](http://publicsuffix.org/) to easily return the ICANN, the Cookie or
-the Private Effective TLD as a `Pdp\PublicSuffix` object using the following methods:
-
-~~~php
-use Pdp\Rules;
-
-$rules = Rules::createFromPath('/path/to/mozilla/public-suffix.dat');
-
-echo $rules->getICANNEffectiveTLD('www.ulb.ac.be'); //display 'ac.be';
-echo $rules->getCookieEffectiveTLD('www.ulb.ac.be'); //display 'ac.be';
-echo $rules->getPrivateEffectiveTLD('www.ulb.ac.be'); //display 'be';
-~~~
-
-The methods are available since version `5.7.0` to ease the package usage. Prior to this version you could use the 
-`Rules::getPublicSuffix` method with an optional `$section` argument to get the same results:
+The first objective of the library is using the [Public Suffix List](http://publicsuffix.org/) to easily resolve domain information.
 
 ~~~php
 use Pdp\Rules;
 
 $rules = Rules::createFromPath('/path/to/mozilla/public-suffix.dat');
 
-echo $rules->getPublicSuffix('www.ulb.ac.be'); // get the cookie effective TLD, display 'ac.be';
-echo $rules->getPublicSuffix('www.ulb.ac.be', Rules::ICANN_DOMAINS); //get the ICANN effective TLD, display 'ac.be';
-echo $rules->getPublicSuffix('www.ulb.ac.be', Rules::PRIVATE_DOMAINS); //get the Private effective TLD, display 'be';
+echo $rules->getCookieDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'ac.be';
+echo $rules->getICANNDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'ac.be';
+echo $rules->getPrivateDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'be';
 ~~~
 
+* Warning: If the Domain is not found an exception is thrown. *
 
-If the Public Suffix is not found or in case of error an exception which extends `Pdp\Exception` is thrown.
-
-### Domain resolution.
-
-Apart the Public Suffix the package can resolve domain and their information also using Mozilla's [Public Suffix List](http://publicsuffix.org/)
-
-~~~php
-use Pdp\Rules;
-
-$rules = Rules::createFromPath('/path/to/mozilla/public-suffix.dat');
-
-echo $rules->resolveCookieDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'ac.be';
-echo $rules->resolveICANNDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'ac.be';
-echo $rules->resolvePrivateDomain('www.ulb.ac.be'); // returns a Pdp\Domain object whose Public Suffix is 'be';
-~~~
-
-The methods are available since version `5.7.0` to ease the package usage. Prior to this version you could use the 
+These methods are available since version `5.7.0` to ease the package usage. Prior to this version you could use the 
 `Rules::resolve` method with an optional `$section` argument to get the same results:
 
 ~~~php
@@ -104,7 +75,7 @@ echo $rules->resolve('www.ulb.ac.be', Rules::ICANN_DOMAINS); // returns a Pdp\Do
 echo $rules->resolve('www.ulb.ac.be', Rules::PRIVATE_DOMAINS); // returns a Pdp\Domain object whose Public Suffix is 'be';
 ~~~
 
-If the Domain is not resolved or in case of error a null `Pdp\Domain` is returned.
+* Warning: If the Domain can not be resolved or in case of error a null `Pdp\Domain` is returned. *
 
 ### Top Level Domains resolution
 
@@ -127,11 +98,11 @@ If the Domain is not resolved or in case of error a null `Pdp\Domain` is returne
 ~~~php
 <?php
 
-use Pdp\Rules;
+use Pdp\Rules;use Pdp\TopLevelDomains;
 
 $rules = Rules::createFromPath('/path/to/mozilla/public-suffix.dat'); //$rules is a Pdp\Rules object
 
-$domain = $rules->resolveICANNDomain('www.ulb.ac.be'); //$domain is a Pdp\Domain object
+$domain = $rules->getICANNDomain('www.ulb.ac.be'); //$domain is a Pdp\Domain object
 echo $domain->getContent();            // 'www.ulb.ac.be'
 echo $domain->getPublicSuffix();       // 'ac.be'
 echo $domain->getRegistrableDomain();  // 'ulb.ac.be'
@@ -142,20 +113,7 @@ $domain->isICANN();                    // returns true
 $domain->isPrivate();                  // returns false
 $domain->labels();                     // returns ['be', 'ac', 'ulb', 'www']
 
-$publicSuffix = $rules->getPrivateEffectiveTLD('mydomain.github.io'); //$publicSuffix is a Pdp\PublicSuffix object
-echo $publicSuffix->getContent(); // 'github.io'
-$publicSuffix->isKnown();         // returns true
-$publicSuffix->isICANN();         // returns false
-$publicSuffix->isPrivate();       // returns true
-$publicSuffix->labels();          // returns ['io', 'github']
-
-$altSuffix = $rules->getICANNEffectiveTLD('mydomain.github.io');
-echo $altSuffix->getContent(); // 'io'
-$altSuffix->isKnown();         // returns true
-$altSuffix->isICANN();         // returns true
-$altSuffix->isPrivate();       // returns false
-
-$tldList = $manager->getTLDs(); //$tldList is a Pdp\TopLevelDomains object
+$tldList = TopLevelDomains::createFromPath('/path/to/IANA/RootZoneDatabase.txt'); //$tldList is a Pdp\TopLevelDomains object
 $domain = $tldList->resolve('www.ulb.ac.be'); //$domain is a Pdp\Domain object
 $tldList->contains('be'); //returns true
 $tldList->contains('localhost'); //return false

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -201,42 +201,6 @@ final class Rules implements PublicSuffixListSection
     }
 
     /**
-     * Determines the public suffix for a given domain against the PSL rules for cookie domain detection..
-     *
-     * @param mixed $domain
-     *
-     * @throws CouldNotResolvePublicSuffix If the PublicSuffix can not be resolve.
-     */
-    public function getCookieEffectiveTLD($domain): PublicSuffix
-    {
-        return $this->getPublicSuffix($domain, '');
-    }
-
-    /**
-     * Determines the public suffix for a given domain against the PSL rules for ICANN domain detection..
-     *
-     * @param mixed $domain
-     *
-     * @throws CouldNotResolvePublicSuffix If the PublicSuffix can not be resolve.
-     */
-    public function getICANNEffectiveTLD($domain): PublicSuffix
-    {
-        return $this->getPublicSuffix($domain, self::ICANN_DOMAINS);
-    }
-
-    /**
-     * Determines the public suffix for a given domain against the PSL rules for private domain detection..
-     *
-     * @param mixed $domain
-     *
-     * @throws CouldNotResolvePublicSuffix If the PublicSuffix can not be resolve.
-     */
-    public function getPrivateEffectiveTLD($domain): PublicSuffix
-    {
-        return $this->getPublicSuffix($domain, self::PRIVATE_DOMAINS);
-    }
-
-    /**
      * Returns PSL info for a given domain.
      *
      * @param mixed  $domain
@@ -249,12 +213,12 @@ final class Rules implements PublicSuffixListSection
         $section = $this->validateSection($section);
         try {
             if ('' === $section) {
-                return $this->resolveCookieDomain($domain);
+                return $this->getCookieDomain($domain);
             } elseif (self::ICANN_DOMAINS === $section) {
-                return $this->resolveICANNDomain($domain);
+                return $this->getICANNDomain($domain);
             }
 
-            return $this->resolvePrivateDomain($domain);
+            return $this->getPrivateDomain($domain);
         } catch (CouldNotResolvePublicSuffix $exception) {
             if ($exception->hasDomain()) {
                 /** @var Domain */
@@ -274,7 +238,7 @@ final class Rules implements PublicSuffixListSection
      *
      * @param mixed $domain the domain value
      */
-    public function resolveCookieDomain($domain): Domain
+    public function getCookieDomain($domain): Domain
     {
         $domain = $this->validateDomain($domain);
 
@@ -286,7 +250,7 @@ final class Rules implements PublicSuffixListSection
      *
      * @param mixed $domain
      */
-    public function resolveICANNDomain($domain): Domain
+    public function getICANNDomain($domain): Domain
     {
         $domain = $this->validateDomain($domain);
 
@@ -298,7 +262,7 @@ final class Rules implements PublicSuffixListSection
      *
      * @param mixed $domain
      */
-    public function resolvePrivateDomain($domain): Domain
+    public function getPrivateDomain($domain): Domain
     {
         $domain = $this->validateDomain($domain);
 

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -32,7 +32,7 @@ use const IDNA_NONTRANSITIONAL_TO_ASCII;
 use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
- * @coversDefaultClass Pdp\Rules
+ * @coversDefaultClass \Pdp\Rules
  */
 class RulesTest extends TestCase
 {
@@ -114,9 +114,9 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveCookieDomain
-     * @covers ::resolveICANNDomain
-     * @covers ::resolvePrivateDomain
+     * @covers ::getCookieDomain
+     * @covers ::getICANNDomain
+     * @covers ::getPrivateDomain
      * @covers ::validateDomain
      * @covers ::validateSection
      * @covers \Pdp\Domain::isResolvable
@@ -155,12 +155,12 @@ class RulesTest extends TestCase
     /**
      * @covers ::resolve
      * @covers ::validateSection
-     * @covers \Pdp\Domain::isResolvable
      * @covers ::findPublicSuffix
      * @covers ::findPublicSuffixFromSection
+     * @covers \Pdp\Domain::isKnown
+     * @covers \Pdp\Domain::isResolvable
      * @covers \Pdp\PublicSuffix::setSection
      * @covers \Pdp\PublicSuffix::isKnown
-     * @covers \Pdp\Domain::isKnown
      * @covers \Pdp\IDNAConverterTrait::parse
      */
     public function testIsSuffixValidFalse(): void
@@ -172,13 +172,13 @@ class RulesTest extends TestCase
     /**
      * @covers ::resolve
      * @covers ::validateSection
-     * @covers \Pdp\Domain::isResolvable
      * @covers ::findPublicSuffix
      * @covers ::findPublicSuffixFromSection
      * @covers \Pdp\PublicSuffix::setSection
      * @covers \Pdp\PublicSuffix::isKnown
      * @covers \Pdp\PublicSuffix::isICANN
      * @covers \Pdp\PublicSuffix::isPrivate
+     * @covers \Pdp\Domain::isResolvable
      * @covers \Pdp\Domain::withPublicSuffix
      * @covers \Pdp\Domain::isKnown
      * @covers \Pdp\Domain::isICANN
@@ -195,16 +195,16 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveCookieDomain
+     * @covers ::getCookieDomain
      * @covers ::validateDomain
      * @covers ::validateSection
-     * @covers \Pdp\Domain::isResolvable
      * @covers ::findPublicSuffix
      * @covers ::findPublicSuffixFromSection
      * @covers \Pdp\PublicSuffix::setSection
      * @covers \Pdp\PublicSuffix::isKnown
      * @covers \Pdp\PublicSuffix::isICANN
      * @covers \Pdp\PublicSuffix::isPrivate
+     * @covers \Pdp\Domain::isResolvable
      * @covers \Pdp\Domain::withPublicSuffix
      * @covers \Pdp\Domain::isKnown
      * @covers \Pdp\Domain::isICANN
@@ -221,16 +221,16 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveICANNDomain
+     * @covers ::getICANNDomain
      * @covers ::validateDomain
      * @covers ::validateSection
-     * @covers \Pdp\Domain::isResolvable
      * @covers ::findPublicSuffix
      * @covers ::findPublicSuffixFromSection
      * @covers \Pdp\PublicSuffix::setSection
      * @covers \Pdp\PublicSuffix::isKnown
      * @covers \Pdp\PublicSuffix::isICANN
      * @covers \Pdp\PublicSuffix::isPrivate
+     * @covers \Pdp\Domain::isResolvable
      * @covers \Pdp\Domain::withPublicSuffix
      * @covers \Pdp\Domain::isKnown
      * @covers \Pdp\Domain::isICANN
@@ -247,7 +247,7 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveCookieDomain
+     * @covers ::getCookieDomain
      * @covers ::validateDomain
      * @covers ::validateSection
      * @covers \Pdp\IDNAConverterTrait::parse
@@ -291,7 +291,7 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolvePrivateDomain
+     * @covers ::getPrivateDomain
      * @covers ::validateDomain
      * @covers ::validateSection
      * @covers ::findPublicSuffix
@@ -311,7 +311,7 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolvePrivateDomain
+     * @covers ::getPrivateDomain
      * @covers ::validateDomain
      * @covers ::validateSection
      * @covers ::findPublicSuffix
@@ -381,7 +381,7 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveICANNDomain
+     * @covers ::getICANNDomain
      * @covers ::validateDomain
      * @covers \Pdp\Domain::setRegistrableDomain
      * @covers \Pdp\Domain::getRegistrableDomain
@@ -399,7 +399,7 @@ class RulesTest extends TestCase
 
     /**
      * @covers ::resolve
-     * @covers ::resolveICANNDomain
+     * @covers ::getICANNDomain
      * @covers ::validateDomain
      * @covers \Pdp\IDNAConverterTrait::parse
      * @covers \Pdp\Domain::setPublicSuffix
@@ -477,8 +477,6 @@ class RulesTest extends TestCase
 
     public function invalidParseProvider(): iterable
     {
-        $long_label = implode('.', array_fill(0, 62, 'a'));
-
         return [
             'single label host' => ['localhost', Rules::ICANN_DOMAINS],
         ];
@@ -710,20 +708,20 @@ class RulesTest extends TestCase
     }
 
     /**
-     * @covers ::getCookieEffectiveTLD
-     * @covers ::getICANNEffectiveTLD
-     * @covers ::getPrivateEffectiveTLD
+     * @covers ::getCookieDomain
+     * @covers ::getICANNDomain
+     * @covers ::getPrivateDomain
      * @dataProvider effectiveTLDProvider
      * @param string $host
      * @param string $cookieETLD
      * @param string $icannETLD
      * @param string $privateETLD
      */
-    public function testEffectiveTLDResolution(string $host, string $cookieETLD, string $icannETLD, string $privateETLD): void
+    public function testGetCookieDomain(string $host, string $cookieETLD, string $icannETLD, string $privateETLD): void
     {
-        self::assertSame($cookieETLD, (string) $this->rules->getCookieEffectiveTLD($host));
-        self::assertSame($icannETLD, (string) $this->rules->getICANNEffectiveTLD($host));
-        self::assertSame($privateETLD, (string) $this->rules->getPrivateEffectiveTLD($host));
+        self::assertSame($cookieETLD, (string) $this->rules->getCookieDomain($host)->getPublicSuffix());
+        self::assertSame($icannETLD, (string) $this->rules->getICANNDomain($host)->getPublicSuffix());
+        self::assertSame($privateETLD, (string) $this->rules->getPrivateDomain($host)->getPublicSuffix());
     }
 
     public function effectiveTLDProvider(): iterable


### PR DESCRIPTION
To avoid unnecessary BC breaks with future development in v6.  We are removing unpublished public API from the `Rules` class