### PR TITLE
Adding PHP8 support to v5 using @szepeviktor fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,14 @@ matrix:
         - php: nightly
           env:
               - COLLECT_COVERAGE=false
-              - COMPOSER_ARGS="--no-interaction --no-suggest --prefer-source --ignore-platform-reqs"
+              - COMPOSER_ARGS="--no-interaction --no-suggest --prefer-source"
               - RUN_PHPSTAN=false
               - VALIDATE_CODING_STYLE=false
+          install:
+              - composer remove --no-interaction --no-update --dev "friendsofphp/php-cs-fixer"
+              - travis_retry composer require $COMPOSER_ARGS --no-update --dev "composer/composer:2.0.x-dev"
+              - travis_retry composer require $COMPOSER_ARGS --no-update --dev "phpunit/phpunit:^9.3.11"
+              - travis_retry composer update $COMPOSER_ARGS
     allow_failures:
         - php: nightly
     fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All Notable changes to `PHP Domain Parser` **5.x** series will be documented in this file
 
+## 5.7.2 - 2020-10-25
+
+### Added
+
+- None
+
+### Fixed
+
+- Added support for PHP8 see [#289](https://github.com/jeremykendall/php-domain-parser/pull/289) based on works by [@szepeviktor](https://github.com/szepeviktor)
+
+### Deprecated
+
+- None
+
+### Removed
+
+- None
+
 ## 5.7.1 - 2020-08-24
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,9 @@
         "psl"
     ],
     "require": {
-        "php": "^7.2.5",
         "ext-intl": "*",
         "ext-json": "*",
+        "php": "^7.2.5 || ^8.0",
         "psr/log": "^1.1",
         "psr/simple-cache": "^1.0.1"
     },

--- a/src/CurlHttpClient.php
+++ b/src/CurlHttpClient.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Pdp;
 
+use Throwable;
 use function curl_close;
 use function curl_errno;
 use function curl_error;
@@ -52,8 +53,13 @@ final class CurlHttpClient implements HttpClient
             CURLOPT_HTTPGET => true,
         ];
 
-        $curl = curl_init();
-        $res = @curl_setopt_array($curl, $this->options);
+        try {
+            $curl = curl_init();
+            $res = @curl_setopt_array($curl, $this->options);
+        } catch (Throwable $exception) {
+            throw new Exception('Please verify your curl additionnal options', $exception->getCode(), $exception);
+        }
+
         curl_close($curl);
         if (!$res) {
             throw new Exception('Please verify your curl additionnal options');


### PR DESCRIPTION
Adding support to PHP8 to v5 to ease migration for legacy application
based on closed PR #288  