### PR TITLE
Make Rules get methods more stricts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     },
     "scripts": {
         "phpcs": "php-cs-fixer fix -vvv --diff --dry-run --allow-risky=yes --ansi",
-        "phpstan": "phpstan analyse -l max -c phpstan.neon src --ansi",
+        "phpstan": "phpstan analyse -l max -c phpstan.neon src --ansi --memory-limit 192M",
         "phpunit": "phpunit --coverage-text",
         "test": [
             "@phpcs",

--- a/src/PublicSuffixList.php
+++ b/src/PublicSuffixList.php
@@ -17,7 +17,7 @@ interface PublicSuffixList extends DomainResolver, JsonSerializable
      * Returns PSL info for a given domain against the PSL rules for cookie domain detection.
      *
      * @throws InvalidDomainName     if the domain is invalid
-     * @throws UnableToResolveDomain if the domain or the TLD are not resolvable of not resolved
+     * @throws UnableToResolveDomain if the effective TLD can not be resolved
      */
     public function getCookieDomain(Host $host): ResolvedDomainName;
 
@@ -25,7 +25,7 @@ interface PublicSuffixList extends DomainResolver, JsonSerializable
      * Returns PSL info for a given domain against the PSL rules for ICANN domain detection.
      *
      * @throws InvalidDomainName     if the domain is invalid
-     * @throws UnableToResolveDomain if the domain or the TLD are not resolvable of not resolved
+     * @throws UnableToResolveDomain if the domain does not contain a ICANN Effective TLD
      */
     public function getICANNDomain(Host $host): ResolvedDomainName;
 
@@ -33,7 +33,7 @@ interface PublicSuffixList extends DomainResolver, JsonSerializable
      * Returns PSL info for a given domain against the PSL rules for private domain detection.
      *
      * @throws InvalidDomainName     if the domain is invalid
-     * @throws UnableToResolveDomain if the domain or the TLD are not resolvable of not resolved
+     * @throws UnableToResolveDomain if the domain does not contain a private Effective TLD
      */
     public function getPrivateDomain(Host $host): ResolvedDomainName;
 }

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -137,6 +137,9 @@ final class Rules implements PublicSuffixList
     {
         $domain = $this->validateDomain($host);
         $publicSuffix = $this->getPublicSuffix($domain, EffectiveTLD::ICANN_DOMAINS);
+        if (!$publicSuffix->isICANN()) {
+            throw UnableToResolveDomain::dueToMissingPublicSuffix($domain, EffectiveTLD::ICANN_DOMAINS);
+        }
 
         return new ResolvedDomain($domain, $publicSuffix);
     }
@@ -148,6 +151,9 @@ final class Rules implements PublicSuffixList
     {
         $domain = $this->validateDomain($host);
         $publicSuffix = $this->getPublicSuffix($domain, EffectiveTLD::PRIVATE_DOMAINS);
+        if (!$publicSuffix->isPrivate()) {
+            throw UnableToResolveDomain::dueToMissingPublicSuffix($domain, EffectiveTLD::PRIVATE_DOMAINS);
+        }
 
         return new ResolvedDomain($domain, $publicSuffix);
     }

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -135,15 +135,24 @@ final class RulesTest extends TestCase
         self::assertNull($domain->getPublicSuffix()->getContent());
     }
 
+    public function testWithICANNDomainInvalid(): void
+    {
+        $domain = 'example.invalidICANNTLD';
+
+        self::expectException(UnableToResolveDomain::class);
+        self::expectExceptionMessage('The domain "'.strtolower($domain).'" does not contain a "ICANN" TLD.');
+
+        $this->rules->getICANNDomain($domain);
+    }
+
     public function testWithPrivateDomainInvalid(): void
     {
-        $domain = $this->rules->getPrivateDomain('private.ulb.ac.be');
+        $domain = 'private.ulb.ac.be';
 
-        self::assertSame('private.ulb.ac.be', $domain->getContent());
-        self::assertFalse($domain->getPublicSuffix()->isKnown());
-        self::assertFalse($domain->getPublicSuffix()->isICANN());
-        self::assertFalse($domain->getPublicSuffix()->isPrivate());
-        self::assertSame('be', $domain->getPublicSuffix()->getContent());
+        self::expectException(UnableToResolveDomain::class);
+        self::expectExceptionMessage('The domain "'.$domain.'" does not contain a "private" TLD.');
+
+        $this->rules->getPrivateDomain($domain);
     }
 
     public function testWithPrivateDomainValid(): void
@@ -157,7 +166,7 @@ final class RulesTest extends TestCase
         self::assertSame('github.io', $domain->getPublicSuffix()->getContent());
     }
 
-    public function testWithICANNDomainInvalid(): void
+    public function testResolvingICANNDomainInvalid(): void
     {
         $domain = $this->rules->resolve('private.ulb.ac.be');
 
@@ -573,18 +582,6 @@ final class RulesTest extends TestCase
     public function effectiveTLDProvider(): iterable
     {
         return [
-            'simple TLD' => [
-                'host' => 'www.example.com',
-                'cookieETLD' => 'com',
-                'icannETLD' => 'com',
-                'privateETLD' => 'com',
-            ],
-            'complex ICANN TLD' => [
-                'host' => 'www.ulb.ac.be',
-                'cookieETLD' => 'ac.be',
-                'icannETLD' => 'ac.be',
-                'privateETLD' => 'be',
-            ],
             'private domain effective TLD' => [
                 'host' => 'myblog.blogspot.com',
                 'cookieETLD' => 'blogspot.com',

--- a/src/UnableToResolveDomain.php
+++ b/src/UnableToResolveDomain.php
@@ -10,6 +10,16 @@ class UnableToResolveDomain extends InvalidArgumentException implements Exceptio
 {
     private ?Host $domain = null;
 
+    public static function dueToMissingPublicSuffix(Host $domain, string $type): self
+    {
+        $domainType = (EffectiveTLD::PRIVATE_DOMAINS === $type) ? 'private' : 'ICANN';
+
+        $exception = new self('The domain "'.$domain->getContent().'" does not contain a "'.$domainType.'" TLD.');
+        $exception->domain = $domain;
+
+        return $exception;
+    }
+
     public static function dueToUnresolvableDomain(?Host $domain): self
     {
         $content = $domain;


### PR DESCRIPTION
Rules::get* methods are getting more strict to distinguish better their usage vs Rules::resolve and Rules::getCookieDomains.