### PR TITLE
Update IDNConversion interface and usage in the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ $domain = new Domain(''); // will throw
 
 ### Internationalization
 
-Domain names come in different format (ascii and unicode format), the package 
+Domain names support different format (ascii and unicode format), the package 
 by default will convert the domain in its ascii format for resolution against
 the public suffix source and convert it back to its unicode form if needed. 
 This is done using PHP `ext-intl` extension. As such all domain objects expose 
@@ -302,18 +302,22 @@ $asciiDomain->getSecondLevelDomain(); // returns 'xn--bb-bjab'
 $asciiDomain->toUnicode()->toString() === $unicodeDomain->toString(); //returns true
 ~~~
 
-Because the domain conversion occurs during instantiation to normalize the 
-domain name you are required to give the `IDNA_*` constants on domain 
-construction. All domain objects accept as optional parameters the 
-`$asciiIDNAOption` and the `$unicodeIDNAOption` where those variables should be
-a combination of the `IDNA_*` constants (except `IDNA_ERROR_*` constants) used 
-with the `idn_to_utf8` and `idn_to_ascii` functions from the `ext-intl` package.
+Because the domain conversion occurs during normalization of the 
+domain name you should give the `IDNA_*` constants when updating
+the domain name value. 
+
+Only the `Pdp\Domain` and the `Pdp\PublicSuffix` 
+objects accept the following optional parameters: (`$asciiIDNAOption` and
+`$unicodeIDNAOption`) to tell the underlying methods using  the `idn_to_utf8`
+and `idn_to_ascii` functions from the `ext-intl` package how to convert the 
+value to its unicode or ascii form. Those variables should be a combination of
+the `IDNA_*` constants (except `IDNA_ERROR_*` constants).
 
 ~~~php
 use Pdp\Domain;
 
 $domain = new Domain('faß.de');
-$altDomain = new Domain('faß.de', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
+$altDomain = $domain->withValue('faß.de', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
 
 /** @var  Rules $rules */
 echo $rules->resolve($domain)->toString(); // display 'fass.de'

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -96,16 +96,19 @@ $domain->value();         // can be a string or null
 
 #### Methods removed
 
-- `DomainInterface` is removed use `DomainName` instead or `ResolvedDomainName`. 
 - `__debugInfo` is removed from all classes.
+- `DomainInterface` is removed use `DomainName` instead or `ResolvedDomainName`. 
 - `Domain::isResolvable` is removed without replacement.
-- `Domain::isTransitionalDifferent` is removed without replacement. 
 - `Domain::resolve` is removed without replacement. 
 - `Domain::isTransitionalDifferent` is removed without replacement. 
+- `Domain::withAsciiIDNAOption` is removed use `Domain::withValue`. 
+- `Domain::withUnicodeIDNAOption` is removed use `Domain::withValue`. 
+- `PublicSuffix::isTransitionalDifferent` is removed without replacement. 
+- `PublicSuffix::withAsciiIDNAOption` is removed use `PublicSuffix::withValue`. 
+- `PublicSuffix::withUnicodeIDNAOption` is removed use `PublicSuffix::withValue`. 
 - `PublicSuffix::createFromDomain` is removed without replacement. 
 - `Rules::getPublicSuffix` is removed use `ResolvedDomain::getPublicSuffix` instead. 
-- IDNA related methods from `Rules` and `TopLevelDomains` classes are removed 
-if needed, use the domain objects constructors.
+- IDNA related methods from `Rules` and `TopLevelDomains` are removed.
 
 #### Methods return type changed
 

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -150,6 +150,17 @@ final class Domain extends DomainNameParser implements DomainName
         return new self($domain, $this->asciiIDNAOption, $this->unicodeIDNAOption);
     }
 
+    public function withValue(?string $domain, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOptions = IDNA_DEFAULT): self
+    {
+        if ($asciiIDNAOption === $this->asciiIDNAOption &&
+            $unicodeIDNAOptions === $this->unicodeIDNAOption &&
+            $domain === $this->domain) {
+            return $this;
+        }
+
+        return new self($domain, $asciiIDNAOption, $unicodeIDNAOptions);
+    }
+
     /**
      * Filter a subdomain to update the domain part.
      *
@@ -247,23 +258,5 @@ final class Domain extends DomainNameParser implements DomainName
         $domain = implode('.', array_reverse($labels));
 
         return new self($domain, $this->asciiIDNAOption, $this->unicodeIDNAOption);
-    }
-
-    public function withAsciiIDNAOption(int $option): self
-    {
-        if ($option === $this->asciiIDNAOption) {
-            return $this;
-        }
-
-        return new self($this->domain, $option, $this->unicodeIDNAOption);
-    }
-
-    public function withUnicodeIDNAOption(int $option): self
-    {
-        if ($option === $this->unicodeIDNAOption) {
-            return $this;
-        }
-
-        return new self($this->domain, $this->asciiIDNAOption, $option);
     }
 }

--- a/src/DomainName.php
+++ b/src/DomainName.php
@@ -11,7 +11,7 @@ use IteratorAggregate;
  * @see https://tools.ietf.org/html/rfc1123#section-2.1
  * @see https://tools.ietf.org/html/rfc5890
  */
-interface DomainName extends Host, IteratorAggregate
+interface DomainName extends Host, IteratorAggregate, IDNConversion
 {
     /**
      * Retrieves a single domain label.

--- a/src/DomainTest.php
+++ b/src/DomainTest.php
@@ -522,27 +522,15 @@ class DomainTest extends TestCase
     /**
      * @covers ::getAsciiIDNAOption
      * @covers ::getUnicodeIDNAOption
-     * @covers ::withAsciiIDNAOption
-     * @covers ::withUnicodeIDNAOption
+     * @covers ::withValue
      */
     public function testwithIDNAOptions(): void
     {
         $domain = new Domain('example.com', IDNA_DEFAULT, IDNA_DEFAULT);
 
-        self::assertSame($domain, $domain->withAsciiIDNAOption(
-            $domain->getAsciiIDNAOption()
-        ));
-
-        self::assertNotEquals($domain, $domain->withAsciiIDNAOption(
-            IDNA_NONTRANSITIONAL_TO_ASCII
-        ));
-
-        self::assertSame($domain, $domain->withUnicodeIDNAOption(
-            $domain->getUnicodeIDNAOption()
-        ));
-
-        self::assertNotEquals($domain, $domain->withUnicodeIDNAOption(
-            IDNA_NONTRANSITIONAL_TO_UNICODE
-        ));
+        self::assertSame($domain, $domain->withValue('example.com', $domain->getAsciiIDNAOption()));
+        self::assertNotEquals($domain, $domain->withValue('example.com', IDNA_NONTRANSITIONAL_TO_ASCII));
+        self::assertSame($domain, $domain->withValue('example.com', $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()));
+        self::assertNotEquals($domain, $domain->withValue('example.com', $domain->getAsciiIDNAOption(), IDNA_NONTRANSITIONAL_TO_UNICODE));
     }
 }

--- a/src/EffectiveTLD.php
+++ b/src/EffectiveTLD.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Pdp;
 
-interface EffectiveTLD extends Host, ExternalDomainName
+interface EffectiveTLD extends Host, ExternalDomainName, IDNConversion
 {
     public const ICANN_DOMAINS = 'ICANN_DOMAINS';
 

--- a/src/Host.php
+++ b/src/Host.php
@@ -12,7 +12,7 @@ use JsonSerializable;
  * @see https://tools.ietf.org/html/rfc1123#section-2.1
  * @see https://tools.ietf.org/html/rfc5890
  */
-interface Host extends Countable, JsonSerializable, IDNConversion
+interface Host extends Countable, JsonSerializable
 {
     /**
      * Returns the domain content.

--- a/src/IDNConversion.php
+++ b/src/IDNConversion.php
@@ -25,24 +25,18 @@ interface IDNConversion
     public function getUnicodeIDNAOption(): int;
 
     /**
-     * Sets conversion options for idn_to_ascii.
+     * Sets the host value with its IDNA options.
      *
      * combination of IDNA_* constants (except IDNA_ERROR_* constants).
      *
      * @see https://www.php.net/manual/en/intl.constants.php
      *
+     * This method MUST retain the state of the current instance, and return
+     * an instance with its content converted to its IDNA ASCII form
+     *
+     * @param  ?string           $value
+     * @throws CannotProcessHost if the domain can not be converted to ASCII using IDN UTS46 algorithm
      * @return static
      */
-    public function withAsciiIDNAOption(int $option): self;
-
-    /**
-     * Sets conversion options for idn_to_utf8.
-     *
-     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
-     *
-     * @see https://www.php.net/manual/en/intl.constants.php
-     *
-     * @return static
-     */
-    public function withUnicodeIDNAOption(int $option): self;
+    public function withValue(?string $value, int $asciiIDNAOption, int $unicodIDNAOption): self;
 }

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -9,27 +9,27 @@ use const IDNA_DEFAULT;
 
 final class PublicSuffix implements EffectiveTLD
 {
-    private DomainName $publicSuffix;
+    private DomainName $domain;
 
     private string $section;
 
-    private function __construct(DomainName $publicSuffix, string $section)
+    private function __construct(DomainName $domain, string $section)
     {
-        if ('' === $publicSuffix->label(0)) {
-            throw SyntaxError::dueToInvalidPublicSuffix($publicSuffix);
+        if ('' === $domain->label(0)) {
+            throw SyntaxError::dueToInvalidPublicSuffix($domain);
         }
 
-        if (null === $publicSuffix->value()) {
+        if (null === $domain->value()) {
             $section = '';
         }
 
-        $this->publicSuffix = $publicSuffix;
+        $this->domain = $domain;
         $this->section = $section;
     }
 
     public static function __set_state(array $properties): self
     {
-        return new self($properties['publicSuffix'], $properties['section']);
+        return new self($properties['domain'], $properties['section']);
     }
 
     /**
@@ -63,37 +63,37 @@ final class PublicSuffix implements EffectiveTLD
 
     public function getDomain(): DomainName
     {
-        return $this->publicSuffix;
+        return $this->domain;
     }
 
     public function count(): int
     {
-        return count($this->publicSuffix);
+        return count($this->domain);
     }
 
     public function jsonSerialize(): ?string
     {
-        return $this->publicSuffix->value();
+        return $this->domain->value();
     }
 
     public function value(): ?string
     {
-        return $this->publicSuffix->value();
+        return $this->domain->value();
     }
 
     public function toString(): string
     {
-        return $this->publicSuffix->toString();
+        return $this->domain->toString();
     }
 
     public function getAsciiIDNAOption(): int
     {
-        return $this->publicSuffix->getAsciiIDNAOption();
+        return $this->domain->getAsciiIDNAOption();
     }
 
     public function getUnicodeIDNAOption(): int
     {
-        return $this->publicSuffix->getUnicodeIDNAOption();
+        return $this->domain->getUnicodeIDNAOption();
     }
 
     public function isKnown(): bool
@@ -114,7 +114,7 @@ final class PublicSuffix implements EffectiveTLD
     public function toAscii(): self
     {
         $clone = clone $this;
-        $clone->publicSuffix = $this->publicSuffix->toAscii();
+        $clone->domain = $this->domain->toAscii();
 
         return $clone;
     }
@@ -122,32 +122,18 @@ final class PublicSuffix implements EffectiveTLD
     public function toUnicode(): self
     {
         $clone = clone $this;
-        $clone->publicSuffix = $this->publicSuffix->toUnicode();
+        $clone->domain = $this->domain->toUnicode();
 
         return $clone;
     }
 
-    public function withAsciiIDNAOption(int $option): self
+    public function withValue(?string $domain, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
     {
-        if ($option === $this->publicSuffix->getAsciiIDNAOption()) {
+        $newDomain = $this->domain->withValue($domain, $asciiIDNAOption, $unicodeIDNAOption);
+        if ($newDomain == $this->domain) {
             return $this;
         }
 
-        $clone = clone $this;
-        $clone->publicSuffix = $this->publicSuffix->withAsciiIDNAOption($option);
-
-        return $clone;
-    }
-
-    public function withUnicodeIDNAOption(int $option): self
-    {
-        if ($option === $this->publicSuffix->getUnicodeIDNAOption()) {
-            return $this;
-        }
-
-        $clone = clone $this;
-        $clone->publicSuffix = $this->publicSuffix->withUnicodeIDNAOption($option);
-
-        return $clone;
+        return new self($newDomain, $this->section);
     }
 }

--- a/src/PublicSuffixTest.php
+++ b/src/PublicSuffixTest.php
@@ -195,20 +195,9 @@ class PublicSuffixTest extends TestCase
     {
         $publicSuffix = PublicSuffix::fromUnknown('com');
 
-        self::assertSame($publicSuffix, $publicSuffix->withAsciiIDNAOption(
-            $publicSuffix->getAsciiIDNAOption()
-        ));
-
-        self::assertNotEquals($publicSuffix, $publicSuffix->withAsciiIDNAOption(
-            IDNA_NONTRANSITIONAL_TO_ASCII
-        ));
-
-        self::assertSame($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
-            $publicSuffix->getUnicodeIDNAOption()
-        ));
-
-        self::assertNotEquals($publicSuffix, $publicSuffix->withUnicodeIDNAOption(
-            IDNA_NONTRANSITIONAL_TO_UNICODE
-        ));
+        self::assertSame($publicSuffix, $publicSuffix->withValue('com', $publicSuffix->getAsciiIDNAOption()));
+        self::assertNotEquals($publicSuffix, $publicSuffix->withValue('com', IDNA_NONTRANSITIONAL_TO_ASCII));
+        self::assertSame($publicSuffix, $publicSuffix->withValue('com', $publicSuffix->getAsciiIDNAOption(), $publicSuffix->getUnicodeIDNAOption()));
+        self::assertNotEquals($publicSuffix, $publicSuffix->withValue('com', $publicSuffix->getAsciiIDNAOption(), IDNA_NONTRANSITIONAL_TO_UNICODE));
     }
 }

--- a/src/ResolvedDomainTest.php
+++ b/src/ResolvedDomainTest.php
@@ -525,26 +525,30 @@ class ResolvedDomainTest extends TestCase
         /** @var ResolvedDomain $instance */
         $instance = $domain->toAscii();
         self::assertSame(
-            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
-            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
+            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
         );
 
         /** @var ResolvedDomain $instance */
         $instance = $domain->toUnicode();
+
         self::assertSame(
-            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
-            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
+            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
         );
 
         $instance = $domain->withPublicSuffix(PublicSuffix::fromICANN('us'));
+
         self::assertSame(
-            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
-            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
+            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
         );
+
         $instance = $domain->withSubDomain(new Domain('foo'));
+
         self::assertSame(
-            [$domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()],
-            [$instance->getAsciiIDNAOption(), $instance->getUnicodeIDNAOption()]
+            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
+            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
         );
     }
 

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -556,7 +556,7 @@ final class RulesTest extends TestCase
         $resolvedByDefault = $this->rules->resolve('foo.de');
         self::assertSame(
             [IDNA_DEFAULT, IDNA_DEFAULT],
-            [$resolvedByDefault->getAsciiIDNAOption(), $resolvedByDefault->getUnicodeIDNAOption()]
+            [$resolvedByDefault->getDomain()->getAsciiIDNAOption(), $resolvedByDefault->getDomain()->getUnicodeIDNAOption()]
         );
 
         /** @var string $string */
@@ -565,8 +565,8 @@ final class RulesTest extends TestCase
         $domain = new Domain('foo.de', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
         $resolved = $rules->resolve($domain);
 
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_ASCII, $resolved->getAsciiIDNAOption());
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_UNICODE, $resolved->getUnicodeIDNAOption());
+        self::assertSame(IDNA_NONTRANSITIONAL_TO_ASCII, $resolved->getDomain()->getAsciiIDNAOption());
+        self::assertSame(IDNA_NONTRANSITIONAL_TO_UNICODE, $resolved->getDomain()->getUnicodeIDNAOption());
     }
 
     /**

--- a/src/TopLevelDomainsTest.php
+++ b/src/TopLevelDomainsTest.php
@@ -156,7 +156,7 @@ class TopLevelDomainsTest extends TestCase
 
         self::assertSame(
             [IDNA_DEFAULT, IDNA_DEFAULT],
-            [$resolved->getAsciiIDNAOption(), $resolved->getUnicodeIDNAOption()]
+            [$resolved->getDomain()->getAsciiIDNAOption(), $resolved->getDomain()->getUnicodeIDNAOption()]
         );
 
         $collection = TopLevelDomains::fromPath(
@@ -167,8 +167,8 @@ class TopLevelDomainsTest extends TestCase
         $domain = new Domain('foo.de', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
         $resolved = $collection->resolve($domain);
 
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_ASCII, $resolved->getAsciiIDNAOption());
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_UNICODE, $resolved->getUnicodeIDNAOption());
+        self::assertSame(IDNA_NONTRANSITIONAL_TO_ASCII, $resolved->getDomain()->getAsciiIDNAOption());
+        self::assertSame(IDNA_NONTRANSITIONAL_TO_UNICODE, $resolved->getDomain()->getUnicodeIDNAOption());
     }
 
     /**


### PR DESCRIPTION
The IDNConversion interface is updated
 
- the `with*IDNAOptions` methods are replaced with a single method `withValue` which sets ASCII and Unicode options at the same time
- the interface is removed from `ResolvedDomainName`