### PR TITLE
Feature/improve i18n

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,9 @@ The `Domain` **has no access**  to the domain parts or the public suffix list st
 
 - Domain objects no longer exposes the `__toString` magic methods.
 - `Domain::getContent` is renamed `Domain::value`
+- The `Domain` constructor is private. To instantiate a domain object you
+need to use on of the two named constructor `Domain::fromIDNA2008` or 
+`Domain::fromIDNA2008`.
 
 **version 5**
 ~~~php
@@ -70,7 +73,7 @@ $domain->getContent();  // can be a string or null
 
 **version 6**
 ~~~php
-$domain = new Domain('www.example.com');
+$domain = Domain::fromIDNA2008('www.example.com');
 echo $domain->toString(); // display 'www.example.com'
 $domain->value();         // can be a string or null
 ~~~ 
@@ -118,4 +121,9 @@ representation in other languages.
 
 #### The Rules object instantiation
 
-The `Rules::__construct` and the `TopLevelDomains::__construct` methods are now private.
+- `Rules::__construct` 
+- `TopLevelDomains::__construct` 
+- `Domain::__construct` 
+- `PublicSuffix::__construct` 
+
+methods are now all private.

--- a/src/DomainNameParser.php
+++ b/src/DomainNameParser.php
@@ -39,6 +39,8 @@ use const INTL_IDNA_VARIANT_UTS46;
 
 abstract class DomainNameParser
 {
+    protected const REGEXP_IDN_PATTERN = '/[^\x20-\x7f]/';
+
     /**
      * Get and format IDN conversion error message.
      */
@@ -86,9 +88,7 @@ abstract class DomainNameParser
     {
         $domain = rawurldecode($domain);
 
-        static $pattern = '/[^\x20-\x7f]/';
-
-        if (1 !== preg_match($pattern, $domain)) {
+        if (1 !== preg_match(self::REGEXP_IDN_PATTERN, $domain)) {
             return strtolower($domain);
         }
 
@@ -160,8 +160,12 @@ abstract class DomainNameParser
      *@return array<string>
      *
      */
-    final protected function parse($domain = null, int $asciiOption = IDNA_DEFAULT, int $unicodeOption = IDNA_DEFAULT): array
+    final protected function parse($domain, int $asciiOption, int $unicodeOption): array
     {
+        if ($domain instanceof ExternalDomainName) {
+            $domain = $domain->getDomain()->value();
+        }
+
         if ($domain instanceof Host) {
             $domain = $domain->value();
         }
@@ -209,8 +213,7 @@ abstract class DomainNameParser
         }
 
         // if the domain name does not contains UTF-8 chars then it is malformed
-        static $pattern = '/[^\x20-\x7f]/';
-        if (1 === preg_match($pattern, $formattedDomain)) {
+        if (1 === preg_match(self::REGEXP_IDN_PATTERN, $formattedDomain)) {
             $asciiDomain = $this->idnToAscii($domain, $asciiOption);
 
             /** @var array $labels */

--- a/src/IDNConversion.php
+++ b/src/IDNConversion.php
@@ -7,36 +7,12 @@ namespace Pdp;
 interface IDNConversion
 {
     /**
-     * Gets conversion options for idn_to_ascii.
-     *
-     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
-     *
-     * @see https://www.php.net/manual/en/intl.constants.php
+     * Tells whether IDNA Conversion is done using IDNA2008 algorithm.
      */
-    public function getAsciiIDNAOption(): int;
+    public function isIDNA2008(): bool;
 
     /**
-     * Gets conversion options for idn_to_utf8.
-     *
-     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
-     *
-     * @see https://www.php.net/manual/en/intl.constants.php
+     * Tells whether the current domain is in its ascii form.
      */
-    public function getUnicodeIDNAOption(): int;
-
-    /**
-     * Sets the host value with its IDNA options.
-     *
-     * combination of IDNA_* constants (except IDNA_ERROR_* constants).
-     *
-     * @see https://www.php.net/manual/en/intl.constants.php
-     *
-     * This method MUST retain the state of the current instance, and return
-     * an instance with its content converted to its IDNA ASCII form
-     *
-     * @param  ?string           $value
-     * @throws CannotProcessHost if the domain can not be converted to ASCII using IDN UTS46 algorithm
-     * @return static
-     */
-    public function withValue(?string $value, int $asciiIDNAOption, int $unicodIDNAOption): self;
+    public function isAscii(): bool;
 }

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -32,33 +32,24 @@ final class PublicSuffix implements EffectiveTLD
         return new self($properties['domain'], $properties['section']);
     }
 
-    /**
-     * @param mixed $publicSuffix a public suffix
-     */
-    public static function fromICANN($publicSuffix, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
+    public static function fromICANN(DomainName $domain): self
     {
-        return new self(new Domain($publicSuffix, $asciiIDNAOption, $unicodeIDNAOption), self::ICANN_DOMAINS);
+        return new self($domain, self::ICANN_DOMAINS);
     }
 
-    /**
-     * @param mixed $publicSuffix a public suffix
-     */
-    public static function fromPrivate($publicSuffix, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
+    public static function fromPrivate(DomainName $domain): self
     {
-        return new self(new Domain($publicSuffix, $asciiIDNAOption, $unicodeIDNAOption), self::PRIVATE_DOMAINS);
+        return new self($domain, self::PRIVATE_DOMAINS);
     }
 
-    /**
-     * @param mixed $publicSuffix a public suffix
-     */
-    public static function fromUnknown($publicSuffix, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
+    public static function fromUnknown(DomainName $domain): self
     {
-        return new self(new Domain($publicSuffix, $asciiIDNAOption, $unicodeIDNAOption), '');
+        return new self($domain, '');
     }
 
-    public static function fromNull(int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
+    public static function fromNull(): self
     {
-        return new self(Domain::fromNull($asciiIDNAOption, $unicodeIDNAOption), '');
+        return new self(Domain::fromNull(), '');
     }
 
     public function getDomain(): DomainName

--- a/src/PublicSuffix.php
+++ b/src/PublicSuffix.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pdp;
 
 use function count;
-use const IDNA_DEFAULT;
 
 final class PublicSuffix implements EffectiveTLD
 {
@@ -47,11 +46,6 @@ final class PublicSuffix implements EffectiveTLD
         return new self($domain, '');
     }
 
-    public static function fromNull(): self
-    {
-        return new self(Domain::fromNull(), '');
-    }
-
     public function getDomain(): DomainName
     {
         return $this->domain;
@@ -75,16 +69,6 @@ final class PublicSuffix implements EffectiveTLD
     public function toString(): string
     {
         return $this->domain->toString();
-    }
-
-    public function getAsciiIDNAOption(): int
-    {
-        return $this->domain->getAsciiIDNAOption();
-    }
-
-    public function getUnicodeIDNAOption(): int
-    {
-        return $this->domain->getUnicodeIDNAOption();
     }
 
     public function isKnown(): bool
@@ -118,13 +102,13 @@ final class PublicSuffix implements EffectiveTLD
         return $clone;
     }
 
-    public function withValue(?string $domain, int $asciiIDNAOption = IDNA_DEFAULT, int $unicodeIDNAOption = IDNA_DEFAULT): self
+    public function isAscii(): bool
     {
-        $newDomain = $this->domain->withValue($domain, $asciiIDNAOption, $unicodeIDNAOption);
-        if ($newDomain == $this->domain) {
-            return $this;
-        }
+        return $this->domain->isAscii();
+    }
 
-        return new self($newDomain, $this->section);
+    public function isIDNA2008(): bool
+    {
+        return $this->domain->isIDNA2008();
     }
 }

--- a/src/PublicSuffixTest.php
+++ b/src/PublicSuffixTest.php
@@ -17,7 +17,8 @@ class PublicSuffixTest extends TestCase
 {
     public function testInternalPhpMethod(): void
     {
-        $publicSuffix = PublicSuffix::fromICANN('ac.be');
+        $domain = new Domain('ac.be');
+        $publicSuffix = PublicSuffix::fromICANN($domain);
         $generatePublicSuffix = eval('return '.var_export($publicSuffix, true).';');
         self::assertEquals($publicSuffix, $generatePublicSuffix);
         self::assertEquals('"ac.be"', json_encode($publicSuffix));
@@ -26,7 +27,8 @@ class PublicSuffixTest extends TestCase
 
     public function testPSToUnicodeWithUrlEncode(): void
     {
-        self::assertSame('bébe', PublicSuffix::fromUnknown('b%C3%A9be')->toUnicode()->value());
+        $domain = new Domain('b%C3%A9be');
+        self::assertSame('bébe', PublicSuffix::fromUnknown($domain)->toUnicode()->value());
     }
 
     /**
@@ -35,12 +37,14 @@ class PublicSuffixTest extends TestCase
      */
     public function testSetSection(?string $publicSuffix, string $section, bool $isKnown, bool $isIcann, bool $isPrivate): void
     {
+        $domain = new Domain($publicSuffix);
+
         if ('' === $section) {
-            $ps = PublicSuffix::fromUnknown($publicSuffix);
+            $ps = PublicSuffix::fromUnknown($domain);
         } elseif ('ICANN_DOMAINS' === $section) {
-            $ps = PublicSuffix::fromICANN($publicSuffix);
+            $ps = PublicSuffix::fromICANN($domain);
         } elseif ('PRIVATE_DOMAINS' === $section) {
-            $ps = PublicSuffix::fromPrivate($publicSuffix);
+            $ps = PublicSuffix::fromPrivate($domain);
         }
 
         if (!isset($ps)) {
@@ -68,7 +72,7 @@ class PublicSuffixTest extends TestCase
     {
         self::expectException(SyntaxError::class);
 
-        PublicSuffix::fromUnknown($publicSuffix);
+        PublicSuffix::fromUnknown(new Domain($publicSuffix));
     }
 
     public function invalidPublicSuffixProvider(): iterable
@@ -83,14 +87,14 @@ class PublicSuffixTest extends TestCase
     {
         self::expectException(SyntaxError::class);
 
-        PublicSuffix::fromUnknown('a⒈com');
+        PublicSuffix::fromUnknown(new Domain('a⒈com'));
     }
 
     public function testToUnicodeThrowsException(): void
     {
         self::expectException(SyntaxError::class);
 
-        PublicSuffix::fromUnknown('xn--a-ecp.ru')->toUnicode();
+        PublicSuffix::fromUnknown(new Domain('xn--a-ecp.ru'))->toUnicode();
     }
 
     /**
@@ -99,7 +103,7 @@ class PublicSuffixTest extends TestCase
      */
     public function testConversionReturnsTheSameInstance(?string $publicSuffix): void
     {
-        $instance = PublicSuffix::fromUnknown($publicSuffix);
+        $instance = PublicSuffix::fromUnknown(new Domain($publicSuffix));
 
         self::assertEquals($instance->toUnicode(), $instance);
         self::assertEquals($instance->toAscii(), $instance);
@@ -115,7 +119,7 @@ class PublicSuffixTest extends TestCase
 
     public function testToUnicodeReturnsSameInstance(): void
     {
-        $instance = PublicSuffix::fromUnknown('食狮.公司.cn');
+        $instance = PublicSuffix::fromUnknown(new Domain('食狮.公司.cn'));
 
         self::assertEquals($instance->toUnicode(), $instance);
     }
@@ -126,7 +130,7 @@ class PublicSuffixTest extends TestCase
      */
     public function testCountable(?string $domain, int $nbLabels, array $labels): void
     {
-        $domain = PublicSuffix::fromUnknown($domain);
+        $domain = PublicSuffix::fromUnknown(new Domain($domain));
 
         self::assertCount($nbLabels, $domain);
     }
@@ -149,7 +153,8 @@ class PublicSuffixTest extends TestCase
         string $expectedAscii,
         string $expectedUnicode
     ): void {
-        $publicSuffix = PublicSuffix::fromUnknown($name, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
+        $domain = new Domain($name, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
+        $publicSuffix = PublicSuffix::fromUnknown($domain);
         self::assertSame($expectedContent, $publicSuffix->value());
         self::assertSame($expectedAscii, $publicSuffix->toAscii()->value());
         self::assertSame($expectedUnicode, $publicSuffix->toUnicode()->value());
@@ -193,7 +198,7 @@ class PublicSuffixTest extends TestCase
 
     public function testWithIDNAOptions(): void
     {
-        $publicSuffix = PublicSuffix::fromUnknown('com');
+        $publicSuffix = PublicSuffix::fromUnknown(new Domain('com'));
 
         self::assertSame($publicSuffix, $publicSuffix->withValue('com', $publicSuffix->getAsciiIDNAOption()));
         self::assertNotEquals($publicSuffix, $publicSuffix->withValue('com', IDNA_NONTRANSITIONAL_TO_ASCII));

--- a/src/ResolvedDomain.php
+++ b/src/ResolvedDomain.php
@@ -9,15 +9,12 @@ use function array_slice;
 use function count;
 use function explode;
 use function implode;
-use function preg_match;
 use function sprintf;
 use function strlen;
 use function substr;
 
 final class ResolvedDomain implements ResolvedDomainName
 {
-    private const REGEXP_IDN_PATTERN = '/[^\x20-\x7f]/';
-
     private DomainName $domain;
 
     private EffectiveTLD $publicSuffix;
@@ -46,7 +43,7 @@ final class ResolvedDomain implements ResolvedDomainName
         }
 
         if (!$domain instanceof DomainName) {
-            return new Domain($domain);
+            return Domain::fromIDNA2008($domain);
         }
 
         return $domain;
@@ -60,7 +57,9 @@ final class ResolvedDomain implements ResolvedDomainName
     private function setPublicSuffix(EffectiveTLD $publicSuffix = null): EffectiveTLD
     {
         if (null === $publicSuffix || null === $publicSuffix->value()) {
-            return PublicSuffix::fromNull();
+            $domain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008(null) : Domain::fromIDNA2003(null);
+
+            return PublicSuffix::fromUnknown($domain);
         }
 
         if (2 > count($this->domain)) {
@@ -89,17 +88,24 @@ final class ResolvedDomain implements ResolvedDomainName
      */
     private function normalize(EffectiveTLD $subject): EffectiveTLD
     {
-        $subject = $subject->withValue(
-            $subject->value(),
-            $this->domain->getAsciiIDNAOption(),
-            $this->domain->getUnicodeIDNAOption()
-        );
-
-        if (1 !== preg_match(self::REGEXP_IDN_PATTERN, $this->domain->toString())) {
-            return $subject->toAscii();
+        if ($subject->isIDNA2008() === $this->domain->isIDNA2008()) {
+            return $subject->isAscii() === $this->domain->isAscii() ? $subject : $subject->toUnicode();
         }
 
-        return $subject->toUnicode();
+        $newDomain = Domain::fromIDNA2003($subject->toUnicode()->value());
+        if ($this->domain->isAscii()) {
+            $newDomain = $newDomain->toAscii();
+        }
+
+        if ($subject->isPrivate()) {
+            return PublicSuffix::fromPrivate($newDomain);
+        }
+
+        if ($subject->isICANN()) {
+            return  PublicSuffix::fromICANN($newDomain);
+        }
+
+        return PublicSuffix::fromUnknown($newDomain);
     }
 
     /**
@@ -108,7 +114,7 @@ final class ResolvedDomain implements ResolvedDomainName
     private function setRegistrableDomain(): DomainName
     {
         if (null === $this->publicSuffix->value()) {
-            return Domain::fromNull($this->domain->getAsciiIDNAOption(), $this->domain->getUnicodeIDNAOption());
+            return $this->domain->isIDNA2008() ? Domain::fromIDNA2008(null) : Domain::fromIDNA2003(null);
         }
 
         $domain = implode('.', array_slice(
@@ -116,7 +122,9 @@ final class ResolvedDomain implements ResolvedDomainName
             count($this->domain) - count($this->publicSuffix) - 1
         ));
 
-        return new Domain($domain, $this->domain->getAsciiIDNAOption(), $this->domain->getUnicodeIDNAOption());
+        $registrableDomain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($domain) : Domain::fromIDNA2003($domain);
+
+        return $this->domain->isAscii() ? $registrableDomain->toAscii() : $registrableDomain->toUnicode();
     }
 
     /**
@@ -124,17 +132,14 @@ final class ResolvedDomain implements ResolvedDomainName
      */
     private function setSubDomain(): DomainName
     {
-        $asciiIDNAOptions = $this->domain->getAsciiIDNAOption();
-        $unicodeIDNAOptions = $this->domain->getUnicodeIDNAOption();
-
         if (null === $this->registrableDomain->value()) {
-            return Domain::fromNull($asciiIDNAOptions, $unicodeIDNAOptions);
+            return $this->domain->isIDNA2008() ? Domain::fromIDNA2008(null) : Domain::fromIDNA2003(null);
         }
 
         $nbLabels = count($this->domain);
         $nbRegistrableLabels = count($this->publicSuffix) + 1;
         if ($nbLabels === $nbRegistrableLabels) {
-            return Domain::fromNull($asciiIDNAOptions, $unicodeIDNAOptions);
+            return $this->domain->isIDNA2008() ? Domain::fromIDNA2008(null) : Domain::fromIDNA2003(null);
         }
 
         $domain = implode('.', array_slice(
@@ -143,7 +148,9 @@ final class ResolvedDomain implements ResolvedDomainName
             $nbLabels - $nbRegistrableLabels
         ));
 
-        return new Domain($domain, $asciiIDNAOptions, $unicodeIDNAOptions);
+        $subDomain = (!$this->domain->isIDNA2008()) ? Domain::fromIDNA2003($domain) : Domain::fromIDNA2008($domain);
+
+        return $this->domain->isAscii() ? $subDomain->toAscii() : $subDomain->toUnicode();
     }
 
     public function count(): int
@@ -212,7 +219,8 @@ final class ResolvedDomain implements ResolvedDomainName
             } elseif ($publicSuffix instanceof DomainName) {
                 $publicSuffix = PublicSuffix::fromUnknown($publicSuffix);
             } else {
-                $publicSuffix = PublicSuffix::fromUnknown(new Domain($publicSuffix));
+                $domain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($publicSuffix) : Domain::fromIDNA2003($publicSuffix);
+                $publicSuffix = PublicSuffix::fromUnknown($domain);
             }
         }
 
@@ -222,19 +230,15 @@ final class ResolvedDomain implements ResolvedDomainName
         }
 
         $host = implode('.', array_reverse(array_slice($this->domain->labels(), count($this->publicSuffix))));
+
         if (null === $publicSuffix->value()) {
-            return new self(
-                new Domain($host, $this->domain->getAsciiIDNAOption(), $this->domain->getUnicodeIDNAOption()),
-                null
-            );
+            $domain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($host) : Domain::fromIDNA2003($host);
+
+            return new self($domain, null);
         }
 
-        /** @var DomainName $domain */
-        $domain = new Domain(
-            $host.'.'.$publicSuffix->value(),
-            $this->domain->getAsciiIDNAOption(),
-            $this->domain->getUnicodeIDNAOption()
-        );
+        $host .= '.'.$publicSuffix->value();
+        $domain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($host) : Domain::fromIDNA2003($host);
 
         return new self($domain, $publicSuffix);
     }
@@ -249,35 +253,25 @@ final class ResolvedDomain implements ResolvedDomainName
         }
 
         if (!$subDomain instanceof DomainName) {
-            $subDomain = new Domain(
-                $subDomain,
-                $this->domain->getAsciiIDNAOption(),
-                $this->domain->getUnicodeIDNAOption()
-            );
+            $subDomain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($subDomain) : Domain::fromIDNA2003($subDomain);
         }
 
-        $subDomain = $subDomain->withValue(
-            $subDomain->value(),
-            $this->domain->getAsciiIDNAOption(),
-            $this->domain->getUnicodeIDNAOption()
-        );
-
+        $subDomain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($subDomain) : Domain::fromIDNA2003($subDomain);
         if ($this->subDomain == $subDomain) {
             return $this;
         }
 
         /** @var DomainName $subDomain */
         $subDomain = $subDomain->toAscii();
-        if (1 === preg_match(self::REGEXP_IDN_PATTERN, $this->domain->toString())) {
+        if (!$this->domain->isAscii()) {
             /** @var DomainName $subDomain */
             $subDomain = $subDomain->toUnicode();
         }
 
-        return new self(new Domain(
-            $subDomain->toString().'.'.$this->registrableDomain->toString(),
-            $this->domain->getAsciiIDNAOption(),
-            $this->domain->getUnicodeIDNAOption()
-        ), $this->publicSuffix);
+        $newDomainValue = $subDomain->toString().'.'.$this->registrableDomain->toString();
+        $newDomain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($newDomainValue) : Domain::fromIDNA2003($newDomainValue);
+
+        return new self($newDomain, $this->publicSuffix);
     }
 
     public function withSecondLevelDomain($label): self
@@ -295,10 +289,9 @@ final class ResolvedDomain implements ResolvedDomainName
             return new self($newRegistrableDomain, $this->publicSuffix);
         }
 
-        return new self(new Domain(
-            $this->subDomain->value().'.'.$newRegistrableDomain->value(),
-            $this->domain->getAsciiIDNAOption(),
-            $this->domain->getUnicodeIDNAOption()
-        ), $this->publicSuffix);
+        $newDomainValue = $this->subDomain->value().'.'.$newRegistrableDomain->value();
+        $newDomain = $this->domain->isIDNA2008() ? Domain::fromIDNA2008($newDomainValue) : Domain::fromIDNA2003($newDomainValue);
+
+        return new self($newDomain, $this->publicSuffix);
     }
 }

--- a/src/ResolvedDomainTest.php
+++ b/src/ResolvedDomainTest.php
@@ -32,7 +32,7 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(UnableToResolveDomain::class);
 
-        new ResolvedDomain(new Domain($domain), PublicSuffix::fromICANN($publicSuffix));
+        new ResolvedDomain(new Domain($domain), PublicSuffix::fromICANN(new Domain($publicSuffix)));
     }
 
     public function provideWrongConstructor(): iterable
@@ -59,7 +59,7 @@ class ResolvedDomainTest extends TestCase
 
     public function testDomainInternalPhpMethod(): void
     {
-        $domain = new ResolvedDomain(new Domain('www.ulb.ac.be'), PublicSuffix::fromICANN('ac.be'));
+        $domain = new ResolvedDomain(new Domain('www.ulb.ac.be'), PublicSuffix::fromICANN(new Domain('ac.be')));
         $generateDomain = eval('return '.var_export($domain, true).';');
         self::assertEquals($domain, $generateDomain);
         self::assertEquals('"www.ulb.ac.be"', json_encode($domain->jsonSerialize()));
@@ -103,7 +103,7 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedIDNDomain,
         ?string $expectedIDNSuffix
     ): void {
-        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN($publicSuffix);
+        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN(new Domain($publicSuffix));
 
         $domain = new ResolvedDomain(new Domain($domain), $objPublicSuffix);
         self::assertSame($expectedDomain, $domain->value());
@@ -194,7 +194,7 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedAsciiDomain,
         ?string $expectedAsciiSuffix
     ): void {
-        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN($publicSuffix);
+        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN(new Domain($publicSuffix));
 
         $domain = new ResolvedDomain(new Domain($domain), $objPublicSuffix);
         self::assertSame($expectedDomain, $domain->value());
@@ -271,27 +271,27 @@ class ResolvedDomainTest extends TestCase
     {
         return [
             'simple addition' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN('com')),
+                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
                 'subdomain' => 'www',
                 'expected' => 'www',
             ],
             'simple addition IDN (1)' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN('com')),
+                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
                 'subdomain' => new Domain('bébé'),
                 'expected' => 'xn--bb-bjab',
             ],
             'simple addition IDN (2)' => [
-                'domain' => new ResolvedDomain(new Domain('Яндекс.РФ'), PublicSuffix::fromICANN('рф')),
+                'domain' => new ResolvedDomain(new Domain('Яндекс.РФ'), PublicSuffix::fromICANN(new Domain('рф'))),
                 'subdomain' => 'bébé',
                 'expected' => 'bébé',
             ],
             'simple removal' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN('com')),
+                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
                 'subdomain' => null,
                 'expected' => null,
             ],
             'simple removal IDN' => [
-                'domain' =>  new ResolvedDomain(new Domain('bébé.Яндекс.РФ'), PublicSuffix::fromICANN('рф')),
+                'domain' =>  new ResolvedDomain(new Domain('bébé.Яндекс.РФ'), PublicSuffix::fromICANN(new Domain('рф'))),
                 'subdomain' => 'xn--bb-bjab',
                 'expected' => 'bébé',
             ],
@@ -316,7 +316,7 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(SyntaxError::class);
 
-        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN('com'));
+        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN(new Domain('com')));
 
         $domain->withSubDomain('');
     }
@@ -324,7 +324,7 @@ class ResolvedDomainTest extends TestCase
     public function testWithSubDomainFailsWithNonStringableObject(): void
     {
         self::expectException(TypeError::class);
-        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN('com'));
+        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN(new Domain('com')));
 
         $domain->withSubDomain(date_create());
     }
@@ -361,7 +361,7 @@ class ResolvedDomainTest extends TestCase
 
     public function withPublicSuffixWorksProvider(): iterable
     {
-        $base_domain = new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN('com'));
+        $base_domain = new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com')));
 
         return [
             'simple update (1)' => [
@@ -374,7 +374,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'simple update (2)' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromPrivate('github.io'),
+                'publicSuffix' => PublicSuffix::fromPrivate(new Domain('github.io')),
                 'expected' => 'github.io',
                 'isKnown' => true,
                 'isICANN' => false,
@@ -382,7 +382,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'same public suffix but PSL info is changed' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromPrivate('com'),
+                'publicSuffix' => PublicSuffix::fromPrivate(new Domain('com')),
                 'expected' => 'com',
                 'isKnown' => true,
                 'isICANN' => false,
@@ -390,7 +390,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'same public suffix but PSL info does not changed' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromICANN('com'),
+                'publicSuffix' => PublicSuffix::fromICANN(new Domain('com')),
                 'expected' => 'com',
                 'isKnown' => true,
                 'isICANN' => true,
@@ -398,15 +398,15 @@ class ResolvedDomainTest extends TestCase
             ],
             'simple update IDN (1)' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromICANN('рф'),
+                'publicSuffix' => PublicSuffix::fromICANN(new Domain('рф')),
                 'expected' => 'xn--p1ai',
                 'isKnown' => true,
                 'isICANN' => true,
                 'isPrivate' => false,
             ],
             'simple update IDN (2)' => [
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN('be')),
-                'publicSuffix' => PublicSuffix::fromICANN('xn--p1ai'),
+                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN(new Domain('be'))),
+                'publicSuffix' => PublicSuffix::fromICANN(new Domain('xn--p1ai')),
                 'expected' => 'рф',
                 'isKnown' => true,
                 'isICANN' => true,
@@ -421,7 +421,7 @@ class ResolvedDomainTest extends TestCase
                 'isPrivate' => false,
             ],
             'removing the public suffix list' => [
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN('be')),
+                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN(new Domain('be'))),
                 'publicSuffix' => null,
                 'expected' => null,
                 'isKnown' => false,
@@ -429,7 +429,7 @@ class ResolvedDomainTest extends TestCase
                 'isPrivate' => false,
             ],
             'with custom IDNA domain options' =>[
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE), PublicSuffix::fromICANN('be')),
+                'domain' => new ResolvedDomain(new Domain('www.bébé.be', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE), PublicSuffix::fromICANN(new Domain('be'))),
                 'publicSuffix' => null,
                 'expected' => null,
                 'isKnown' => false,
@@ -464,7 +464,7 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedSubDomain
     ): void {
         $host = new Domain($domainName, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
-        $resolvedDomain = new ResolvedDomain($host, PublicSuffix::fromICANN($publicSuffix));
+        $resolvedDomain = new ResolvedDomain($host, PublicSuffix::fromICANN(new Domain($publicSuffix)));
 
         self::assertSame($expectedContent, $resolvedDomain->value());
         self::assertSame($expectedAscii, $resolvedDomain->toAscii()->value());
@@ -519,7 +519,7 @@ class ResolvedDomainTest extends TestCase
     {
         $domain = new ResolvedDomain(
             new Domain('example.com', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE),
-            PublicSuffix::fromICANN('com')
+            PublicSuffix::fromICANN(new Domain('com'))
         );
 
         /** @var ResolvedDomain $instance */
@@ -537,7 +537,7 @@ class ResolvedDomainTest extends TestCase
             [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
         );
 
-        $instance = $domain->withPublicSuffix(PublicSuffix::fromICANN('us'));
+        $instance = $domain->withPublicSuffix(PublicSuffix::fromICANN(new Domain('us')));
 
         self::assertSame(
             [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
@@ -567,7 +567,7 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedSld,
         ?string $expectedHost
     ): void {
-        $domain = new ResolvedDomain(new Domain($host), PublicSuffix::fromICANN($publicSuffix));
+        $domain = new ResolvedDomain(new Domain($host), PublicSuffix::fromICANN(new Domain($publicSuffix)));
         $newDomain = $domain->withSecondLevelDomain($sld);
 
         self::assertSame($expectedSld, $newDomain->getSecondLevelDomain());

--- a/src/ResolvedDomainTest.php
+++ b/src/ResolvedDomainTest.php
@@ -7,8 +7,6 @@ namespace Pdp;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 use function date_create;
-use const IDNA_NONTRANSITIONAL_TO_ASCII;
-use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass \Pdp\ResolvedDomain
@@ -17,7 +15,7 @@ class ResolvedDomainTest extends TestCase
 {
     public function testRegistrableDomainIsNullWithFoundDomain(): void
     {
-        $domain = new ResolvedDomain(new Domain('faketld'));
+        $domain = new ResolvedDomain(Domain::fromIDNA2003('faketld'));
         self::assertNull($domain->getPublicSuffix()->value());
         self::assertNull($domain->getRegistrableDomain()->value());
         self::assertNull($domain->getSubDomain()->value());
@@ -32,7 +30,7 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(UnableToResolveDomain::class);
 
-        new ResolvedDomain(new Domain($domain), PublicSuffix::fromICANN(new Domain($publicSuffix)));
+        new ResolvedDomain(Domain::fromIDNA2003($domain), PublicSuffix::fromICANN(Domain::fromIDNA2003($publicSuffix)));
     }
 
     public function provideWrongConstructor(): iterable
@@ -59,7 +57,7 @@ class ResolvedDomainTest extends TestCase
 
     public function testDomainInternalPhpMethod(): void
     {
-        $domain = new ResolvedDomain(new Domain('www.ulb.ac.be'), PublicSuffix::fromICANN(new Domain('ac.be')));
+        $domain = new ResolvedDomain(Domain::fromIDNA2003('www.ulb.ac.be'), PublicSuffix::fromICANN(Domain::fromIDNA2003('ac.be')));
         $generateDomain = eval('return '.var_export($domain, true).';');
         self::assertEquals($domain, $generateDomain);
         self::assertEquals('"www.ulb.ac.be"', json_encode($domain->jsonSerialize()));
@@ -72,7 +70,7 @@ class ResolvedDomainTest extends TestCase
      */
     public function testCountable(?string $domain, int $nbLabels): void
     {
-        $domain = new Domain($domain);
+        $domain = Domain::fromIDNA2003($domain);
         self::assertCount($nbLabels, $domain);
     }
 
@@ -103,9 +101,9 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedIDNDomain,
         ?string $expectedIDNSuffix
     ): void {
-        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN(new Domain($publicSuffix));
+        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromUnknown(Domain::fromIDNA2003(null)) : PublicSuffix::fromICANN(Domain::fromIDNA2003($publicSuffix));
 
-        $domain = new ResolvedDomain(new Domain($domain), $objPublicSuffix);
+        $domain = new ResolvedDomain(Domain::fromIDNA2003($domain), $objPublicSuffix);
         self::assertSame($expectedDomain, $domain->value());
         self::assertSame($expectedSuffix, $domain->getPublicSuffix()->value());
 
@@ -194,9 +192,9 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedAsciiDomain,
         ?string $expectedAsciiSuffix
     ): void {
-        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromNull() : PublicSuffix::fromICANN(new Domain($publicSuffix));
+        $objPublicSuffix = (null === $publicSuffix) ? PublicSuffix::fromUnknown(Domain::fromIDNA2003(null)) : PublicSuffix::fromICANN(Domain::fromIDNA2003($publicSuffix));
 
-        $domain = new ResolvedDomain(new Domain($domain), $objPublicSuffix);
+        $domain = new ResolvedDomain(Domain::fromIDNA2003($domain), $objPublicSuffix);
         self::assertSame($expectedDomain, $domain->value());
         self::assertSame($expectedSuffix, $domain->getPublicSuffix()->value());
 
@@ -271,27 +269,33 @@ class ResolvedDomainTest extends TestCase
     {
         return [
             'simple addition' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
+                'domain' => new ResolvedDomain(
+                    Domain::fromIDNA2003('example.com'),
+                    PublicSuffix::fromICANN(Domain::fromIDNA2003('com'))
+                ),
                 'subdomain' => 'www',
                 'expected' => 'www',
             ],
             'simple addition IDN (1)' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
-                'subdomain' => new Domain('bébé'),
+                'domain' => new ResolvedDomain(
+                    Domain::fromIDNA2003('example.com'),
+                    PublicSuffix::fromICANN(Domain::fromIDNA2003('com'))
+                ),
+                'subdomain' => Domain::fromIDNA2003('bébé'),
                 'expected' => 'xn--bb-bjab',
             ],
             'simple addition IDN (2)' => [
-                'domain' => new ResolvedDomain(new Domain('Яндекс.РФ'), PublicSuffix::fromICANN(new Domain('рф'))),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2003('Яндекс.РФ'), PublicSuffix::fromICANN(Domain::fromIDNA2003('рф'))),
                 'subdomain' => 'bébé',
                 'expected' => 'bébé',
             ],
             'simple removal' => [
-                'domain' => new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com'))),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2003('example.com'), PublicSuffix::fromICANN(Domain::fromIDNA2003('com'))),
                 'subdomain' => null,
                 'expected' => null,
             ],
             'simple removal IDN' => [
-                'domain' =>  new ResolvedDomain(new Domain('bébé.Яндекс.РФ'), PublicSuffix::fromICANN(new Domain('рф'))),
+                'domain' =>  new ResolvedDomain(Domain::fromIDNA2003('bébé.Яндекс.РФ'), PublicSuffix::fromICANN(Domain::fromIDNA2003('рф'))),
                 'subdomain' => 'xn--bb-bjab',
                 'expected' => 'bébé',
             ],
@@ -302,21 +306,21 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(UnableToResolveDomain::class);
 
-        (new ResolvedDomain(new Domain(null)))->withSubDomain('www');
+        (new ResolvedDomain(Domain::fromIDNA2008(null)))->withSubDomain('www');
     }
 
     public function testWithSubDomainFailsWithOneLabelDomain(): void
     {
         self::expectException(UnableToResolveDomain::class);
 
-        (new ResolvedDomain(new Domain('localhost')))->withSubDomain('www');
+        (new ResolvedDomain(Domain::fromIDNA2003('localhost')))->withSubDomain('www');
     }
 
     public function testWithEmptySubdomain(): void
     {
         self::expectException(SyntaxError::class);
 
-        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN(new Domain('com')));
+        $domain = new ResolvedDomain(Domain::fromIDNA2003('www.example.com'), PublicSuffix::fromICANN(Domain::fromIDNA2003('com')));
 
         $domain->withSubDomain('');
     }
@@ -324,7 +328,7 @@ class ResolvedDomainTest extends TestCase
     public function testWithSubDomainFailsWithNonStringableObject(): void
     {
         self::expectException(TypeError::class);
-        $domain = new ResolvedDomain(new Domain('www.example.com'), PublicSuffix::fromICANN(new Domain('com')));
+        $domain = new ResolvedDomain(Domain::fromIDNA2003('www.example.com'), PublicSuffix::fromICANN(Domain::fromIDNA2003('com')));
 
         $domain->withSubDomain(date_create());
     }
@@ -333,7 +337,7 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(UnableToResolveDomain::class);
 
-        (new ResolvedDomain(new Domain('www.example.com')))->withSubDomain('www');
+        (new ResolvedDomain(Domain::fromIDNA2003('www.example.com')))->withSubDomain('www');
     }
 
     /**
@@ -361,7 +365,7 @@ class ResolvedDomainTest extends TestCase
 
     public function withPublicSuffixWorksProvider(): iterable
     {
-        $base_domain = new ResolvedDomain(new Domain('example.com'), PublicSuffix::fromICANN(new Domain('com')));
+        $base_domain = new ResolvedDomain(Domain::fromIDNA2003('example.com'), PublicSuffix::fromICANN(Domain::fromIDNA2003('com')));
 
         return [
             'simple update (1)' => [
@@ -374,7 +378,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'simple update (2)' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromPrivate(new Domain('github.io')),
+                'publicSuffix' => PublicSuffix::fromPrivate(Domain::fromIDNA2003('github.io')),
                 'expected' => 'github.io',
                 'isKnown' => true,
                 'isICANN' => false,
@@ -382,7 +386,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'same public suffix but PSL info is changed' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromPrivate(new Domain('com')),
+                'publicSuffix' => PublicSuffix::fromPrivate(Domain::fromIDNA2003('com')),
                 'expected' => 'com',
                 'isKnown' => true,
                 'isICANN' => false,
@@ -390,7 +394,7 @@ class ResolvedDomainTest extends TestCase
             ],
             'same public suffix but PSL info does not changed' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromICANN(new Domain('com')),
+                'publicSuffix' => PublicSuffix::fromICANN(Domain::fromIDNA2003('com')),
                 'expected' => 'com',
                 'isKnown' => true,
                 'isICANN' => true,
@@ -398,22 +402,22 @@ class ResolvedDomainTest extends TestCase
             ],
             'simple update IDN (1)' => [
                 'domain' => $base_domain,
-                'publicSuffix' => PublicSuffix::fromICANN(new Domain('рф')),
+                'publicSuffix' => PublicSuffix::fromICANN(Domain::fromIDNA2008('рф')),
                 'expected' => 'xn--p1ai',
                 'isKnown' => true,
                 'isICANN' => true,
                 'isPrivate' => false,
             ],
             'simple update IDN (2)' => [
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN(new Domain('be'))),
-                'publicSuffix' => PublicSuffix::fromICANN(new Domain('xn--p1ai')),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2003('www.bébé.be'), PublicSuffix::fromICANN(Domain::fromIDNA2003('be'))),
+                'publicSuffix' => PublicSuffix::fromICANN(Domain::fromIDNA2003('xn--p1ai')),
                 'expected' => 'рф',
                 'isKnown' => true,
                 'isICANN' => true,
                 'isPrivate' => false,
             ],
             'adding the public suffix to a single label domain' => [
-                'domain' => new ResolvedDomain(new Domain('localhost')),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2003('localhost')),
                 'publicSuffix' => 'www',
                 'expected' => 'www',
                 'isKnown' => false,
@@ -421,7 +425,7 @@ class ResolvedDomainTest extends TestCase
                 'isPrivate' => false,
             ],
             'removing the public suffix list' => [
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be'), PublicSuffix::fromICANN(new Domain('be'))),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2003('www.bébé.be'), PublicSuffix::fromICANN(Domain::fromIDNA2003('be'))),
                 'publicSuffix' => null,
                 'expected' => null,
                 'isKnown' => false,
@@ -429,7 +433,7 @@ class ResolvedDomainTest extends TestCase
                 'isPrivate' => false,
             ],
             'with custom IDNA domain options' =>[
-                'domain' => new ResolvedDomain(new Domain('www.bébé.be', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE), PublicSuffix::fromICANN(new Domain('be'))),
+                'domain' => new ResolvedDomain(Domain::fromIDNA2008('www.bébé.be'), PublicSuffix::fromICANN(Domain::fromIDNA2008('be'))),
                 'publicSuffix' => null,
                 'expected' => null,
                 'isKnown' => false,
@@ -443,7 +447,7 @@ class ResolvedDomainTest extends TestCase
     {
         self::expectException(SyntaxError::class);
 
-        (new ResolvedDomain(new Domain()))->withPublicSuffix('www');
+        (new ResolvedDomain(Domain::fromIDNA2008(null)))->withPublicSuffix('www');
     }
 
     /**
@@ -463,8 +467,8 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedRegistrable,
         ?string $expectedSubDomain
     ): void {
-        $host = new Domain($domainName, IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
-        $resolvedDomain = new ResolvedDomain($host, PublicSuffix::fromICANN(new Domain($publicSuffix)));
+        $host = Domain::fromIDNA2008($domainName);
+        $resolvedDomain = new ResolvedDomain($host, PublicSuffix::fromICANN(Domain::fromIDNA2008($publicSuffix)));
 
         self::assertSame($expectedContent, $resolvedDomain->value());
         self::assertSame($expectedAscii, $resolvedDomain->toAscii()->value());
@@ -515,43 +519,6 @@ class ResolvedDomainTest extends TestCase
         ];
     }
 
-    public function testInstanceCreationWithCustomIDNAOptions(): void
-    {
-        $domain = new ResolvedDomain(
-            new Domain('example.com', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE),
-            PublicSuffix::fromICANN(new Domain('com'))
-        );
-
-        /** @var ResolvedDomain $instance */
-        $instance = $domain->toAscii();
-        self::assertSame(
-            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
-            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
-        );
-
-        /** @var ResolvedDomain $instance */
-        $instance = $domain->toUnicode();
-
-        self::assertSame(
-            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
-            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
-        );
-
-        $instance = $domain->withPublicSuffix(PublicSuffix::fromICANN(new Domain('us')));
-
-        self::assertSame(
-            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
-            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
-        );
-
-        $instance = $domain->withSubDomain(new Domain('foo'));
-
-        self::assertSame(
-            [$domain->getDomain()->getAsciiIDNAOption(), $domain->getDomain()->getUnicodeIDNAOption()],
-            [$instance->getDomain()->getAsciiIDNAOption(), $instance->getDomain()->getUnicodeIDNAOption()]
-        );
-    }
-
     /**
      * @dataProvider withSldWorksProvider
      * @param ?string $host
@@ -567,7 +534,7 @@ class ResolvedDomainTest extends TestCase
         ?string $expectedSld,
         ?string $expectedHost
     ): void {
-        $domain = new ResolvedDomain(new Domain($host), PublicSuffix::fromICANN(new Domain($publicSuffix)));
+        $domain = new ResolvedDomain(Domain::fromIDNA2008($host), PublicSuffix::fromICANN(Domain::fromIDNA2008($publicSuffix)));
         $newDomain = $domain->withSecondLevelDomain($sld);
 
         self::assertSame($expectedSld, $newDomain->getSecondLevelDomain());

--- a/src/RootZoneDatabaseConverter.php
+++ b/src/RootZoneDatabaseConverter.php
@@ -93,7 +93,7 @@ final class RootZoneDatabaseConverter
     private function extractRootZone(string $content): string
     {
         try {
-            $tld = PublicSuffix::fromUnknown(new Domain($content))->toAscii();
+            $tld = PublicSuffix::fromUnknown(Domain::fromIDNA2008($content))->toAscii();
         } catch (CannotProcessHost $exception) {
             throw UnableToLoadRootZoneDatabase::dueToInvalidRootZoneDomain($content, $exception);
         }

--- a/src/RootZoneDatabaseConverter.php
+++ b/src/RootZoneDatabaseConverter.php
@@ -93,7 +93,7 @@ final class RootZoneDatabaseConverter
     private function extractRootZone(string $content): string
     {
         try {
-            $tld = PublicSuffix::fromUnknown($content)->toAscii();
+            $tld = PublicSuffix::fromUnknown(new Domain($content))->toAscii();
         } catch (CannotProcessHost $exception) {
             throw UnableToLoadRootZoneDatabase::dueToInvalidRootZoneDomain($content, $exception);
         }

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -109,9 +109,9 @@ final class Rules implements PublicSuffixList
                 return new ResolvedDomain($host);
             }
 
-            return new ResolvedDomain(new Domain($host));
+            return new ResolvedDomain(Domain::fromIDNA2008($host));
         } catch (SyntaxError $exception) {
-            return new ResolvedDomain(Domain::fromNull());
+            return new ResolvedDomain(Domain::fromIDNA2008(null));
         }
     }
 
@@ -169,7 +169,7 @@ final class Rules implements PublicSuffixList
         }
 
         if (!($domain instanceof DomainName)) {
-            $domain = new Domain($domain);
+            $domain = Domain::fromIDNA2008($domain);
         }
 
         if ((2 > count($domain)) || ('.' === substr($domain->toString(), -1, 1))) {
@@ -198,7 +198,8 @@ final class Rules implements PublicSuffixList
             return $icann;
         }
 
-        $publicSuffix = new Domain($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+        $topLabel = $domain->toAscii()->label(0);
+        $publicSuffix = $domain->isIDNA2008() ? Domain::fromIDNA2008($topLabel) : Domain::fromIDNA2003($topLabel);
 
         return PublicSuffix::fromUnknown($publicSuffix);
     }
@@ -232,16 +233,14 @@ final class Rules implements PublicSuffixList
         }
 
         if ([] === $matches) {
-            $publicSuffix = new Domain($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+            $topLabel = $domain->toAscii()->label(0);
+            $publicSuffix = $domain->isIDNA2008() ? Domain::fromIDNA2008($topLabel) : Domain::fromIDNA2003($topLabel);
 
             return PublicSuffix::fromUnknown($publicSuffix);
         }
 
-        $publicSuffix = new Domain(
-            implode('.', array_reverse($matches)),
-            $domain->getAsciiIDNAOption(),
-            $domain->getUnicodeIDNAOption()
-        );
+        $publicSuffixLabels = implode('.', array_reverse($matches));
+        $publicSuffix = $domain->isIDNA2008() ? Domain::fromIDNA2008($publicSuffixLabels) : Domain::fromIDNA2003($publicSuffixLabels);
 
         if (PublicSuffix::PRIVATE_DOMAINS === $section) {
             return PublicSuffix::fromPrivate($publicSuffix);

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -198,7 +198,9 @@ final class Rules implements PublicSuffixList
             return $icann;
         }
 
-        return PublicSuffix::fromUnknown($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+        $publicSuffix = new Domain($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+
+        return PublicSuffix::fromUnknown($publicSuffix);
     }
 
     /**
@@ -230,15 +232,21 @@ final class Rules implements PublicSuffixList
         }
 
         if ([] === $matches) {
-            return PublicSuffix::fromUnknown($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+            $publicSuffix = new Domain($domain->toAscii()->label(0), $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+
+            return PublicSuffix::fromUnknown($publicSuffix);
         }
 
-        $content = implode('.', array_reverse($matches));
+        $publicSuffix = new Domain(
+            implode('.', array_reverse($matches)),
+            $domain->getAsciiIDNAOption(),
+            $domain->getUnicodeIDNAOption()
+        );
 
         if (PublicSuffix::PRIVATE_DOMAINS === $section) {
-            return PublicSuffix::fromPrivate($content, $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+            return PublicSuffix::fromPrivate($publicSuffix);
         }
 
-        return PublicSuffix::fromICANN($content, $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+        return PublicSuffix::fromICANN($publicSuffix);
     }
 }

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -215,7 +215,7 @@ final class RulesTest extends TestCase
     {
         $domain = new ResolvedDomain(
             new Domain('private.ulb.ac.be'),
-            PublicSuffix::fromICANN('ac.be')
+            PublicSuffix::fromICANN(new Domain('ac.be'))
         );
 
         $newDomain = $this->rules->resolve($domain);
@@ -230,7 +230,7 @@ final class RulesTest extends TestCase
 
     public function testWithDomainInterfaceObject(): void
     {
-        $domain = PublicSuffix::fromICANN('ulb.ac.be');
+        $domain = PublicSuffix::fromICANN(new Domain('ulb.ac.be'));
 
         self::assertSame(
             'ac.be',

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -10,9 +10,6 @@ use function array_fill;
 use function dirname;
 use function file_get_contents;
 use function implode;
-use const IDNA_DEFAULT;
-use const IDNA_NONTRANSITIONAL_TO_ASCII;
-use const IDNA_NONTRANSITIONAL_TO_UNICODE;
 
 /**
  * @coversDefaultClass \Pdp\Rules
@@ -214,8 +211,8 @@ final class RulesTest extends TestCase
     public function testWithDomainObject(): void
     {
         $domain = new ResolvedDomain(
-            new Domain('private.ulb.ac.be'),
-            PublicSuffix::fromICANN(new Domain('ac.be'))
+            Domain::fromIDNA2008('private.ulb.ac.be'),
+            PublicSuffix::fromICANN(Domain::fromIDNA2008('ac.be'))
         );
 
         $newDomain = $this->rules->resolve($domain);
@@ -230,7 +227,7 @@ final class RulesTest extends TestCase
 
     public function testWithDomainInterfaceObject(): void
     {
-        $domain = PublicSuffix::fromICANN(new Domain('ulb.ac.be'));
+        $domain = PublicSuffix::fromICANN(Domain::fromIDNA2008('ulb.ac.be'));
 
         self::assertSame(
             'ac.be',
@@ -572,7 +569,7 @@ final class RulesTest extends TestCase
         $this->checkPublicSuffix('www.食狮.中国', '食狮.中国');
         $this->checkPublicSuffix('shishi.中国', 'shishi.中国');
         $this->checkPublicSuffix('中国', null);
-        $this->checkPublicSuffix('www.faß.de', 'fass.de');
+        $this->checkPublicSuffix('www.faß.de', 'faß.de'); // changed to honour IDNA2008 by default not part of the standard test
         // Same as above, but punycoded.
         $this->checkPublicSuffix('xn--85x722f.com.cn', 'xn--85x722f.com.cn');
         $this->checkPublicSuffix('xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn');
@@ -588,19 +585,15 @@ final class RulesTest extends TestCase
     public function testResolveWithIDNAOptions(): void
     {
         $resolvedByDefault = $this->rules->resolve('foo.de');
-        self::assertSame(
-            [IDNA_DEFAULT, IDNA_DEFAULT],
-            [$resolvedByDefault->getDomain()->getAsciiIDNAOption(), $resolvedByDefault->getDomain()->getUnicodeIDNAOption()]
-        );
+        self::assertTrue($resolvedByDefault->getDomain()->isIDNA2008());
 
         /** @var string $string */
         $string = file_get_contents(dirname(__DIR__).'/test_data/public_suffix_list.dat');
         $rules = Rules::fromString($string);
-        $domain = new Domain('foo.de', IDNA_NONTRANSITIONAL_TO_ASCII, IDNA_NONTRANSITIONAL_TO_UNICODE);
+        $domain = Domain::fromIDNA2008('foo.de');
         $resolved = $rules->resolve($domain);
 
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_ASCII, $resolved->getDomain()->getAsciiIDNAOption());
-        self::assertSame(IDNA_NONTRANSITIONAL_TO_UNICODE, $resolved->getDomain()->getUnicodeIDNAOption());
+        self::assertTrue($resolved->getDomain()->isIDNA2008());
     }
 
     /**

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -120,7 +120,7 @@ final class TopLevelDomains implements RootZoneDatabase
     public function getIterator()
     {
         foreach ($this->records as $tld) {
-            yield PublicSuffix::fromUnknown($tld)->toAscii();
+            yield PublicSuffix::fromUnknown((new Domain($tld))->toAscii());
         }
     }
 
@@ -186,10 +186,12 @@ final class TopLevelDomains implements RootZoneDatabase
         $label = $domain->toAscii()->label(0);
         foreach ($this as $tld) {
             if ($tld->value() === $label) {
-                return new ResolvedDomain($domain, PublicSuffix::fromUnknown($tld, $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()));
+                $publicSuffix = new Domain($tld, $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+
+                return new ResolvedDomain($domain, PublicSuffix::fromUnknown($publicSuffix));
             }
         }
 
-        return new ResolvedDomain($domain, PublicSuffix::fromNull($domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption()));
+        return new ResolvedDomain($domain, PublicSuffix::fromNull());
     }
 }

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -120,7 +120,7 @@ final class TopLevelDomains implements RootZoneDatabase
     public function getIterator()
     {
         foreach ($this->records as $tld) {
-            yield PublicSuffix::fromUnknown((new Domain($tld))->toAscii());
+            yield PublicSuffix::fromUnknown(Domain::fromIDNA2008($tld)->toAscii());
         }
     }
 
@@ -144,7 +144,7 @@ final class TopLevelDomains implements RootZoneDatabase
 
         if (!$tld instanceof DomainName) {
             try {
-                $tld = new Domain($tld);
+                $tld = Domain::fromIDNA2008($tld);
             } catch (CannotProcessHost $exception) {
                 return false;
             }
@@ -176,7 +176,7 @@ final class TopLevelDomains implements RootZoneDatabase
         }
 
         if (!$domain instanceof DomainName) {
-            $domain = new Domain($domain);
+            $domain = Domain::fromIDNA2008($domain);
         }
 
         if ((2 > count($domain)) || ('.' === substr($domain->toString(), -1, 1))) {
@@ -186,12 +186,14 @@ final class TopLevelDomains implements RootZoneDatabase
         $label = $domain->toAscii()->label(0);
         foreach ($this as $tld) {
             if ($tld->value() === $label) {
-                $publicSuffix = new Domain($tld, $domain->getAsciiIDNAOption(), $domain->getUnicodeIDNAOption());
+                $publicSuffix = $domain->isIDNA2008() ? Domain::fromIDNA2008($tld) : Domain::fromIDNA2003($tld);
 
                 return new ResolvedDomain($domain, PublicSuffix::fromUnknown($publicSuffix));
             }
         }
 
-        return new ResolvedDomain($domain, PublicSuffix::fromNull());
+        $publicSuffix = $domain->isIDNA2008() ? Domain::fromIDNA2008(null) : Domain::fromIDNA2003(null);
+
+        return new ResolvedDomain($domain, PublicSuffix::fromUnknown($publicSuffix));
     }
 }

--- a/src/TopLevelDomainsTest.php
+++ b/src/TopLevelDomainsTest.php
@@ -142,7 +142,7 @@ final class TopLevelDomainsTest extends TestCase
     {
         $resolvedDomain = new ResolvedDomain(
             new Domain('www.example.com'),
-            PublicSuffix::fromICANN('com')
+            PublicSuffix::fromICANN(new Domain('com'))
         );
 
         return [
@@ -242,7 +242,7 @@ final class TopLevelDomainsTest extends TestCase
                     return 'COM';
                 }
             }],
-            'externalDomain' => [PublicSuffix::fromICANN('com')],
+            'externalDomain' => [PublicSuffix::fromICANN(new Domain('com'))],
         ];
     }
 


### PR DESCRIPTION
- The `ext-intl` usage is now treated as an implementation detail.
- Named constructors are used instead of relying on the constructor to enable better conversion between ascii and unicode format