### PR TITLE
Fix/Resolve multi-level private domains

### DIFF
--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -134,6 +134,22 @@ final class RulesTest extends TestCase
         self::assertSame('github.io', $domain->suffix()->value());
     }
 
+
+    public function testWithMultiLevelPrivateDomain(): void
+    {
+        $domain = self::$rules->resolve('test-domain.eu.org');
+
+        self::assertFalse($domain->suffix()->isICANN());
+        self::assertTrue($domain->suffix()->isPrivate());
+        self::assertSame('eu.org', $domain->suffix()->value());
+
+        $domain = self::$rules->resolve('test-domain.lt.eu.org');
+
+        self::assertFalse($domain->suffix()->isICANN());
+        self::assertTrue($domain->suffix()->isPrivate());
+        self::assertSame('lt.eu.org', $domain->suffix()->value());
+    }
+
     public function testWithAbsoluteHostInvalid(): void
     {
         $domain = self::$rules->resolve('private.ulb.ac.be.');


### PR DESCRIPTION
## Introduction

The changes introduced with https://github.com/jeremykendall/php-domain-parser/pull/322 broke the resolution of private domains that contain valid higher-level suffixes.

For example, consider the TLD `eu.org` - it is listed as a valid private domain, but it is also a part of other valid private domains:
```
// EU.org https://eu.org/
// Submitted by Pierre Beyssac <hostmaster@eu.org>
eu.org
al.eu.org
asso.eu.org
at.eu.org
au.eu.org
...
```
After the changes in https://github.com/jeremykendall/php-domain-parser/pull/322, domains such as `test-domain.eu.org` are not recognised as private domains:
`PHP Fatal error:  Uncaught Pdp\UnableToResolveDomain: The domain "test-domain.eu.org" does not contain a "private" TLD.`

Only lower-level entries, such as `test-domain.au.eu.org` are recognised properly.

## Proposal
The easiest solution, without making any major changes, would be to have a way of checking whether a suffix is present in the valid suffix list.

Taking https://github.com/jeremykendall/php-domain-parser/issues/321 as an example, `users.scale.virtualcloud.com.br` would be marked as a valid suffix, but `virtualcloud.com.br` would not.
### Describe the new/upated/fixed feature

This PR changes the way how rules are parsed and structured. Each rule label that is the last part of a domain present in the list contains a marker which denotes a valid suffix. E.g.:
```
# eu.org
[
    org => [
        eu => [
            {MARKER}
            al => [
                {MARKER}
            ],
            asso => [
                {MARKER}
            ],
            ...
        ]
    ]
]
# users.scale.virtualcloud.com.br
[ 
    br => [
        com => [
            virtualcloud => [
                scale => [
                    users => [
                        {MARKER}
                    ]
                ]
            ]
        ]
    ]
]
```
This way we can check whether a suffix, or a part of it, is present in the list by checking if the marker is set. Both `eu.org` and `al.eu.org` have markers, meaning, both of them are valid private domain suffixes. And in the same way, only `users.scale.virtualcloud.com.br` has the marker, meaning, `virtualcloud.com.br` is not valid.

Issue: https://github.com/jeremykendall/php-domain-parser/issues/334

### Backward Incompatible Changes

This PR only modifies how the private `$rules` variable is structured and read, it shouldn't have any backward incompatible changes.

### Targeted release version

6.1.2

### PR Impact

No changes to the current public API.

## Open issues
https://github.com/jeremykendall/php-domain-parser/issues/334

