### PR TITLE
Update .gitattributes to exclude test_data/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /phpstan.neon        export-ignore
 /phpunit.xml.dist    export-ignore
 /psalm.xml           export-ignore
+/test_data/          export-ignore
 /CHANGELOG.md        export-ignore
 /UPGRADING.md        export-ignore
 /README.md           export-ignore


### PR DESCRIPTION
## Introduction

The library ships `test_data/` with composer.

## Proposal

### Describe the new/upated/fixed feature

Fixes #341.

### Backward Incompatible Changes

None.

### Targeted release version

6.1.x

### PR Impact

None.

## Open issues

None.