### PR TITLE
#361 Adding the ability to use absolute domain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
     linux_tests:
         name: PHP on ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.composer-flags }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 php: ['8.1', '8.2', '8.3', '8.4']
@@ -32,7 +32,7 @@ jobs:
               id: composer-cache
               run: |
                   echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-            - uses: actions/cache@v3
+            - uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ matrix.stability }}-${{ matrix.flags }}-${{ hashFiles('**/composer.lock') }}

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/src')
 ;
@@ -7,8 +9,9 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 
 return $config
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'none'],
         'global_namespace_import' => [
@@ -16,23 +19,18 @@ return $config
             'import_constants' => true,
             'import_functions' => true,
         ],
-        'list_syntax' => ['syntax' => 'short'],
         'new_with_parentheses' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_empty_phpdoc' => true,
         'no_empty_comment' => true,
         'no_leading_import_slash' => true,
-        'no_superfluous_phpdoc_tags' => [
-            'allow_mixed' => true,
-            'remove_inheritdoc' => true,
-            'allow_unused_params' => false,
-        ],
+        'no_superfluous_phpdoc_tags' => true,
         'no_trailing_comma_in_singleline' => true,
         'no_unused_imports' => true,
         'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'phpdoc_add_missing_param_annotation' => ['only_untyped' => true],
-        'phpdoc_align' => true,
+        'phpdoc_align' => ['align' => 'left'],
         'phpdoc_no_empty_return' => true,
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
@@ -47,5 +45,6 @@ return $config
         'trailing_comma_in_multiline' => true,
         'trim_array_spaces' => true,
         'whitespace_after_comma_in_array' => true,
+        'yoda_style' => true,
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All Notable changes to `PHP Domain Parser` starting from the **5.x** series will be documented in this file
 
+## [6.4.0] - 2025-04-22
+
+### Added
+
+- `DomainName::withRootLabel`, `DomainName::withoutRootLabel`, `DomainName::isAbsolute` methods to handle absolute domain names.
+
+### Fixed
+
+- Absolute domain name can now also be resolved by the package see issue [#361](https://github.com/jeremykendall/php-domain-parser/issues/361) prior to this release an exception was thrown.
+- Since we no longer support PHP7 type hint and return type are improved.
+
+### Deprecated
+
+- None
+
+### Removed
+
+- None
+
 ## [6.3.0] - 2023-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ composer require jeremykendall/php-domain-parser:^6.0
 
 You need:
 
-- **PHP >= 7.4** but the latest stable version of PHP is recommended
-- the `intl` extension
+- **PHP >= 8.1** but the latest stable version of PHP is recommended
 - a copy of the [Public Suffix List](https://publicsuffix.org/) data and/or a copy of the [IANA Top Level Domain List](https://www.iana.org/domains/root/files). Please refer to the [Managing external data source section](#managing-the-package-external-resources) for more information when using this package in production.
+
+Handling of an IDN host requires the presence of the `intl` extension or
+a polyfill for the `intl` IDN functions like the `symfony/polyfill-intl-idn`
+otherwise an exception will be thrown when attempting to validate or interact
+with such a host.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "psr/http-factory": "^1.1.0",
         "psr/simple-cache": "^1.0.1 || ^2.0.0",
         "symfony/cache": "^v5.0.0 || ^6.4.16",
-        "symfony/var-dumper": "^7.2"
+        "symfony/var-dumper": "^v6.4.18 || ^7.2"
     },
     "suggest": {
         "psr/http-client-implementation": "To use the storage functionality which depends on PSR-18",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "phpunit/phpunit": "^10.5.15 || ^11.5.1",
         "psr/http-factory": "^1.1.0",
         "psr/simple-cache": "^1.0.1 || ^2.0.0",
-        "symfony/cache": "^v5.0.0 || ^6.4.16"
+        "symfony/cache": "^v5.0.0 || ^6.4.16",
+        "symfony/var-dumper": "^7.2"
     },
     "suggest": {
         "psr/http-client-implementation": "To use the storage functionality which depends on PSR-18",

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-filter": "*",
-        "ext-intl": "*"
+        "ext-filter": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.65.0",
@@ -61,7 +60,9 @@
         "psr/http-client-implementation": "To use the storage functionality which depends on PSR-18",
         "psr/http-factory-implementation": "To use the storage functionality which depends on PSR-17",
         "psr/simple-cache-implementation": "To use the storage functionality which depends on PSR-16",
-        "league/uri": "To parse URL and validate host"
+        "league/uri": "To parse and extract the host from an URL using a RFC3986/RFC3987 URI parser",
+        "rowbot/url": "To parse and extract the host from an URL using a  WHATWG URL parser",
+        "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
     },
     "autoload": {
         "psr-4": {

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -6,6 +6,7 @@ namespace Pdp;
 
 use Iterator;
 use Stringable;
+
 use const FILTER_FLAG_IPV4;
 use const FILTER_VALIDATE_IP;
 
@@ -158,5 +159,28 @@ final class Domain implements DomainName
     public function slice(int $offset, ?int $length = null): self
     {
         return $this->newInstance($this->registeredName->slice($offset, $length));
+    }
+
+    public function withRootLabel(): self
+    {
+        if ('' === $this->label(0)) {
+            return $this;
+        }
+
+        return $this->append('');
+    }
+
+    public function withoutRootLabel(): self
+    {
+        if ('' === $this->label(0)) {
+            return $this->slice(1);
+        }
+
+        return $this;
+    }
+
+    public function isAbsolute(): bool
+    {
+        return '' === $this->label(0);
     }
 }

--- a/src/DomainName.php
+++ b/src/DomainName.php
@@ -14,6 +14,10 @@ use Stringable;
  * @see https://tools.ietf.org/html/rfc5890
  *
  * @extends IteratorAggregate<string>
+ *
+ * @method bool isAbsolute() tells whether the domain is absolute or not.
+ * @method self withRootLabel() returns an instance with its Root label. (see https://tools.ietf.org/html/rfc3986#section-3.2.2)
+ * @method self withoutRootLabel() returns an instance without its Root label. (see https://tools.ietf.org/html/rfc3986#section-3.2.2)
  */
 interface DomainName extends Host, IteratorAggregate
 {
@@ -120,4 +124,6 @@ interface DomainName extends Host, IteratorAggregate
      * If $length is null it returns all elements from $offset to the end of the Domain.
      */
     public function slice(int $offset, ?int $length = null): self;
+
+
 }

--- a/src/DomainTest.php
+++ b/src/DomainTest.php
@@ -6,8 +6,6 @@ namespace Pdp;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use stdClass;
-use TypeError;
 
 final class DomainTest extends TestCase
 {
@@ -288,12 +286,6 @@ final class DomainTest extends TestCase
                 'expected' => 'www.shop.example.com',
             ],
         ];
-    }
-
-    public function testWithLabelFailsWithTypeError(): void
-    {
-        $this->expectException(TypeError::class);
-        Domain::fromIDNA2008('example.com')->withLabel(1, new stdClass()); /* @phpstan-ignore-line */
     }
 
     public function testWithLabelFailsWithInvalidKey(): void

--- a/src/Idna.php
+++ b/src/Idna.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pdp;
 
 use UnexpectedValueException;
+
 use function defined;
 use function function_exists;
 use function idn_to_ascii;
@@ -12,6 +13,7 @@ use function idn_to_utf8;
 use function preg_match;
 use function rawurldecode;
 use function strtolower;
+
 use const INTL_IDNA_VARIANT_UTS46;
 
 /**

--- a/src/IdnaInfo.php
+++ b/src/IdnaInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pdp;
 
 use function array_filter;
+
 use const ARRAY_FILTER_USE_KEY;
 
 /**

--- a/src/IdnaInfoTest.php
+++ b/src/IdnaInfoTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pdp;
 
 use PHPUnit\Framework\TestCase;
+
 use function var_export;
 
 final class IdnaInfoTest extends TestCase

--- a/src/PublicSuffixList.php
+++ b/src/PublicSuffixList.php
@@ -9,7 +9,7 @@ interface PublicSuffixList extends DomainNameResolver
     /**
      * Returns PSL info for a given domain against the PSL rules for cookie domain detection.
      *
-     * @throws SyntaxError           if the domain is invalid
+     * @throws SyntaxError if the domain is invalid
      * @throws UnableToResolveDomain if the effective TLD can not be resolved
      */
     public function getCookieDomain(Host $host): ResolvedDomainName;
@@ -17,7 +17,7 @@ interface PublicSuffixList extends DomainNameResolver
     /**
      * Returns PSL info for a given domain against the PSL rules for ICANN domain detection.
      *
-     * @throws SyntaxError           if the domain is invalid
+     * @throws SyntaxError if the domain is invalid
      * @throws UnableToResolveDomain if the domain does not contain a ICANN Effective TLD
      */
     public function getICANNDomain(Host $host): ResolvedDomainName;
@@ -25,7 +25,7 @@ interface PublicSuffixList extends DomainNameResolver
     /**
      * Returns PSL info for a given domain against the PSL rules for private domain detection.
      *
-     * @throws SyntaxError           if the domain is invalid
+     * @throws SyntaxError if the domain is invalid
      * @throws UnableToResolveDomain if the domain does not contain a private Effective TLD
      */
     public function getPrivateDomain(Host $host): ResolvedDomainName;

--- a/src/RegisteredName.php
+++ b/src/RegisteredName.php
@@ -6,6 +6,7 @@ namespace Pdp;
 
 use Iterator;
 use Stringable;
+
 use function array_count_values;
 use function array_keys;
 use function array_reverse;
@@ -19,6 +20,7 @@ use function ksort;
 use function preg_match;
 use function rawurldecode;
 use function strtolower;
+
 use const FILTER_FLAG_IPV4;
 use const FILTER_VALIDATE_IP;
 
@@ -358,5 +360,28 @@ final class RegisteredName implements DomainName
         }
 
         return new self($this->type, [] === $labels ? null : implode('.', array_reverse($labels)));
+    }
+
+    public function withRootLabel(): self
+    {
+        if ('' === $this->label(0)) {
+            return $this;
+        }
+
+        return $this->append('');
+    }
+
+    public function withoutRootLabel(): self
+    {
+        if ('' === $this->label(0)) {
+            return $this->slice(1);
+        }
+
+        return $this;
+    }
+
+    public function isAbsolute(): bool
+    {
+        return '' === $this->label(0);
     }
 }

--- a/src/ResolvedDomain.php
+++ b/src/ResolvedDomain.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pdp;
 
 use Stringable;
+
 use function count;
 
 final class ResolvedDomain implements ResolvedDomainName
@@ -34,7 +35,7 @@ final class ResolvedDomain implements ResolvedDomainName
     {
         $domain = self::setDomainName($domain);
 
-        return new self($domain, Suffix::fromICANN($domain->slice(0, $suffixLength)));
+        return new self($domain, Suffix::fromICANN($domain->withoutRootLabel()->slice(0, $suffixLength)));
     }
 
     /**
@@ -44,7 +45,7 @@ final class ResolvedDomain implements ResolvedDomainName
     {
         $domain = self::setDomainName($domain);
 
-        return new self($domain, Suffix::fromPrivate($domain->slice(0, $suffixLength)));
+        return new self($domain, Suffix::fromPrivate($domain->withoutRootLabel()->slice(0, $suffixLength)));
     }
 
     /**
@@ -54,7 +55,7 @@ final class ResolvedDomain implements ResolvedDomainName
     {
         $domain = self::setDomainName($domain);
 
-        return new self($domain, Suffix::fromIANA($domain->label(0)));
+        return new self($domain, Suffix::fromIANA($domain->withoutRootLabel()->label(0)));
     }
 
     /**
@@ -118,11 +119,15 @@ final class ResolvedDomain implements ResolvedDomainName
         }
 
         $length = count($this->suffix);
+        $offset = 0;
+        if ($this->domain->isAbsolute()) {
+            $offset = 1;
+        }
 
         return [
-            'registrableDomain' => $this->domain->slice(0, $length + 1),
-            'secondLevelDomain' => $this->domain->slice($length, 1),
-            'subDomain' => RegisteredName::fromIDNA2008($this->domain->value())->slice($length + 1),
+            'registrableDomain' => $this->domain->slice($offset, $length + 1),
+            'secondLevelDomain' => $this->domain->slice($length + $offset, 1),
+            'subDomain' => RegisteredName::fromIDNA2008($this->domain->value())->slice($length + 1 + $offset),
         ];
     }
 

--- a/src/ResolvedDomainTest.php
+++ b/src/ResolvedDomainTest.php
@@ -7,6 +7,7 @@ namespace Pdp;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+
 use function date_create;
 
 final class ResolvedDomainTest extends TestCase
@@ -397,7 +398,7 @@ final class ResolvedDomainTest extends TestCase
                 'isICANN' => false,
                 'isPrivate' => false,
             ],
-            'with custom IDNA domain options' =>[
+            'with custom IDNA domain options' => [
                 'domain' => ResolvedDomain::fromICANN('www.bébé.be', 1),
                 'publicSuffix' => null,
                 'expected' => null,

--- a/src/ResolvedDomainTest.php
+++ b/src/ResolvedDomainTest.php
@@ -6,9 +6,6 @@ namespace Pdp;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use TypeError;
-
-use function date_create;
 
 final class ResolvedDomainTest extends TestCase
 {
@@ -299,13 +296,6 @@ final class ResolvedDomainTest extends TestCase
         $this->expectException(SyntaxError::class);
 
         ResolvedDomain::fromICANN('www.example.com', 1)->withSubDomain('');
-    }
-
-    public function testItCanThrowsDuringSubDomainChangesIfTheSubDomainIsNotStringable(): void
-    {
-        $this->expectException(TypeError::class);
-
-        ResolvedDomain::fromICANN('www.example.com', 1)->withSubDomain(date_create()); /* @phpstan-ignore-line */
     }
 
     #[DataProvider('withPublicSuffixWorksProvider')]

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -152,10 +152,7 @@ final class Rules implements PublicSuffixList
         return new self($properties['rules']);
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host a type that supports instantiating a Domain from.
-     */
-    public function resolve($host): ResolvedDomainName
+    public function resolve(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         try {
             return $this->getCookieDomain($host);
@@ -166,10 +163,7 @@ final class Rules implements PublicSuffixList
         }
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host the domain value
-     */
-    public function getCookieDomain($host): ResolvedDomainName
+    public function getCookieDomain(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         $domain = $this->validateDomain($host);
         [$suffixLength, $section] = $this->resolveSuffix($domain->withoutRootLabel(), self::UNKNOWN_DOMAINS);
@@ -181,10 +175,7 @@ final class Rules implements PublicSuffixList
         };
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host a type that supports instantiating a Domain from.
-     */
-    public function getICANNDomain($host): ResolvedDomainName
+    public function getICANNDomain(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         $domain = $this->validateDomain($host);
         [$suffixLength, $section] = $this->resolveSuffix($domain, self::ICANN_DOMAINS);
@@ -195,10 +186,7 @@ final class Rules implements PublicSuffixList
         return ResolvedDomain::fromICANN($domain, $suffixLength);
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host a type that supports instantiating a Domain from.
-     */
-    public function getPrivateDomain($host): ResolvedDomainName
+    public function getPrivateDomain(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         $domain = $this->validateDomain($host);
         [$suffixLength, $section] = $this->resolveSuffix($domain, self::PRIVATE_DOMAINS);
@@ -215,7 +203,7 @@ final class Rules implements PublicSuffixList
      * @throws SyntaxError If the domain is invalid
      * @throws UnableToResolveDomain If the domain can not be resolved
      */
-    private function validateDomain(int|DomainNameProvider|Host|string|Stringable|null $domain): DomainName
+    private function validateDomain(DomainNameProvider|Host|Stringable|string|int|null $domain): DomainName
     {
         if ($domain instanceof DomainNameProvider) {
             $domain = $domain->domain();

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -7,6 +7,7 @@ namespace Pdp;
 use SplFileObject;
 use SplTempFileObject;
 use Stringable;
+
 use function array_pop;
 use function explode;
 use function preg_match;
@@ -42,7 +43,7 @@ final class Rules implements PublicSuffixList
      *
      * @param null|resource $context
      *
-     * @throws UnableToLoadResource         If the rules can not be loaded from the path
+     * @throws UnableToLoadResource If the rules can not be loaded from the path
      * @throws UnableToLoadPublicSuffixList If the rules contain in the resource are invalid
      */
     public static function fromPath(string $path, $context = null): self
@@ -104,8 +105,8 @@ final class Rules implements PublicSuffixList
      * A copy of the Apache License, Version 2.0, is provided with this
      * distribution
      *
-     * @param array<array>  $list      Initially an empty array, this eventually becomes the array representation of a
-     *                                 Public Suffix List section
+     * @param array<array> $list Initially an empty array, this eventually becomes the array representation of a
+     *                           Public Suffix List section
      * @param array<string> $ruleParts One line (rule) from the Public Suffix List exploded on '.', or the remaining
      *                                 portion of that array during recursion
      *
@@ -171,7 +172,7 @@ final class Rules implements PublicSuffixList
     public function getCookieDomain($host): ResolvedDomainName
     {
         $domain = $this->validateDomain($host);
-        [$suffixLength, $section] = $this->resolveSuffix($domain, self::UNKNOWN_DOMAINS);
+        [$suffixLength, $section] = $this->resolveSuffix($domain->withoutRootLabel(), self::UNKNOWN_DOMAINS);
 
         return match (true) {
             self::ICANN_DOMAINS === $section => ResolvedDomain::fromICANN($domain, $suffixLength),
@@ -211,7 +212,7 @@ final class Rules implements PublicSuffixList
     /**
      * Assert the domain is valid and is resolvable.
      *
-     * @throws SyntaxError           If the domain is invalid
+     * @throws SyntaxError If the domain is invalid
      * @throws UnableToResolveDomain If the domain can not be resolved
      */
     private function validateDomain(int|DomainNameProvider|Host|string|Stringable|null $domain): DomainName
@@ -222,10 +223,6 @@ final class Rules implements PublicSuffixList
 
         if (!$domain instanceof DomainName) {
             $domain = Domain::fromIDNA2008($domain);
-        }
-
-        if ('' === $domain->label(0)) {
-            throw UnableToResolveDomain::dueToUnresolvableDomain($domain);
         }
 
         return $domain;

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -7,6 +7,7 @@ namespace Pdp;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+
 use function array_fill;
 use function dirname;
 use function file_get_contents;
@@ -27,7 +28,7 @@ final class RulesTest extends TestCase
     public function testCreateFromPath(): void
     {
         $context = stream_context_create([
-            'http'=> [
+            'http' => [
                 'method' => 'GET',
                 'header' => "Accept-language: en\r\nCookie: foo=bar\r\n",
             ],
@@ -129,10 +130,10 @@ final class RulesTest extends TestCase
         $domain = self::$rules->resolve('private.ulb.ac.be.');
 
         self::assertSame('private.ulb.ac.be.', $domain->value());
-        self::assertFalse($domain->suffix()->isKnown());
-        self::assertFalse($domain->suffix()->isICANN());
+        self::assertTrue($domain->suffix()->isKnown());
+        self::assertTrue($domain->suffix()->isICANN());
         self::assertFalse($domain->suffix()->isPrivate());
-        self::assertNull($domain->suffix()->value());
+        self::assertSame('ac.be', $domain->suffix()->value());
     }
 
     public function testWithICANNDomainInvalid(): void

--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -6,7 +6,6 @@ namespace Pdp;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use TypeError;
 
 use function array_fill;
 use function dirname;
@@ -65,13 +64,6 @@ final class RulesTest extends TestCase
         $domain = self::$rules->resolve('COM');
 
         self::assertFalse($domain->suffix()->isKnown());
-    }
-
-    public function testThrowsTypeErrorOnWrongInput(): void
-    {
-        $this->expectException(TypeError::class);
-
-        self::$rules->resolve(date_create());  /* @phpstan-ignore-line */
     }
 
     public function testIsSuffixValidFalse(): void

--- a/src/Storage/PublicSuffixListPsr16Cache.php
+++ b/src/Storage/PublicSuffixListPsr16Cache.php
@@ -11,6 +11,7 @@ use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use Stringable;
 use Throwable;
+
 use function md5;
 use function strtolower;
 

--- a/src/Storage/PublicSuffixListPsr16CacheTest.php
+++ b/src/Storage/PublicSuffixListPsr16CacheTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Runner\ErrorHandler;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
+
 use function dirname;
 
 final class PublicSuffixListPsr16CacheTest extends TestCase
@@ -81,7 +82,7 @@ final class PublicSuffixListPsr16CacheTest extends TestCase
 
     public function testItReturnsFalseIfItCantCacheAPublicSuffixListInstance(): void
     {
-        $exception = new class('Something went wrong.', 0) extends RuntimeException implements CacheException {
+        $exception = new class ('Something went wrong.', 0) extends RuntimeException implements CacheException {
         };
         $cache = self::createStub(CacheInterface::class);
         $cache->method('set')->will(self::throwException($exception));
@@ -94,13 +95,13 @@ final class PublicSuffixListPsr16CacheTest extends TestCase
 
     public function testItWillThrowIfItCantCacheAPublicSuffixListInstance(): void
     {
-        $exception = new class('Something went wrong.', 0) extends RuntimeException {
+        $exception = new class ('Something went wrong.', 0) extends RuntimeException {
         };
         $cache = self::createStub(CacheInterface::class);
         $cache->method('set')->will(self::throwException($exception));
 
         $psl = Rules::fromPath(dirname(__DIR__, 2).'/test_data/public_suffix_list.dat');
-        $pslCache = new PublicSuffixListPsr16Cache($cache, 'pdp_', new class() {
+        $pslCache = new PublicSuffixListPsr16Cache($cache, 'pdp_', new class () {
             public function __toString(): string
             {
                 return '1 DAY';

--- a/src/Storage/PublicSuffixListPsr18ClientTest.php
+++ b/src/Storage/PublicSuffixListPsr18ClientTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+
 use function dirname;
 use function file_get_contents;
 
@@ -21,7 +22,7 @@ final class PublicSuffixListPsr18ClientTest extends TestCase
 {
     public function testIsCanReturnAPublicSuffixListInstance(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 /** @var string $body */
@@ -30,7 +31,7 @@ final class PublicSuffixListPsr18ClientTest extends TestCase
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);
@@ -45,14 +46,14 @@ final class PublicSuffixListPsr18ClientTest extends TestCase
 
     public function testItWillThrowIfTheClientCanNotConnectToTheRemoteURI(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 throw new ConnectException('foobar', $request, null);
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);
@@ -68,14 +69,14 @@ final class PublicSuffixListPsr18ClientTest extends TestCase
 
     public function testItWillThrowIfTheReturnedStatusCodeIsNotOK(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 return new Response(404);
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);

--- a/src/Storage/RulesStorageTest.php
+++ b/src/Storage/RulesStorageTest.php
@@ -7,13 +7,14 @@ namespace Pdp\Storage;
 use Pdp\PublicSuffixList;
 use Pdp\Rules;
 use PHPUnit\Framework\TestCase;
+
 use function dirname;
 
 final class RulesStorageTest extends TestCase
 {
     public function testIsCanReturnAPublicSuffixListInstanceFromCache(): void
     {
-        $cache = new class() implements PublicSuffixListCache {
+        $cache = new class () implements PublicSuffixListCache {
             public function fetch(string $uri): ?PublicSuffixList
             {
                 return Rules::fromPath(dirname(__DIR__, 2).'/test_data/public_suffix_list.dat');
@@ -30,7 +31,7 @@ final class RulesStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements PublicSuffixListClient {
+        $client = new class () implements PublicSuffixListClient {
             public function get(string $uri): PublicSuffixList
             {
                 return Rules::fromPath(dirname(__DIR__, 2).'/test_data/public_suffix_list.dat');
@@ -45,7 +46,7 @@ final class RulesStorageTest extends TestCase
 
     public function testIsCanReturnAPublicSuffixListInstanceFromTheInnerStorage(): void
     {
-        $cache = new class() implements PublicSuffixListCache {
+        $cache = new class () implements PublicSuffixListCache {
             public function fetch(string $uri): ?PublicSuffixList
             {
                 return null;
@@ -62,7 +63,7 @@ final class RulesStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements PublicSuffixListClient {
+        $client = new class () implements PublicSuffixListClient {
             public function get(string $uri): PublicSuffixList
             {
                 return Rules::fromPath(dirname(__DIR__, 2).'/test_data/public_suffix_list.dat');
@@ -77,7 +78,7 @@ final class RulesStorageTest extends TestCase
 
     public function testIsCanDeleteAPublicSuffixListInstanceFromTheInnerStorage(): void
     {
-        $cache = new class() implements PublicSuffixListCache {
+        $cache = new class () implements PublicSuffixListCache {
             public function fetch(string $uri): ?PublicSuffixList
             {
                 return null;
@@ -94,7 +95,7 @@ final class RulesStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements PublicSuffixListClient {
+        $client = new class () implements PublicSuffixListClient {
             public function get(string $uri): PublicSuffixList
             {
                 return Rules::fromPath(dirname(__DIR__, 2).'/test_data/public_suffix_list.dat');

--- a/src/Storage/TimeToLive.php
+++ b/src/Storage/TimeToLive.php
@@ -10,7 +10,9 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use Stringable;
 use Throwable;
+
 use function filter_var;
+
 use const FILTER_VALIDATE_INT;
 
 /**

--- a/src/Storage/TimeToLiveTest.php
+++ b/src/Storage/TimeToLiveTest.php
@@ -76,7 +76,7 @@ final class TimeToLiveTest extends TestCase
         ];
 
         yield 'stringable object' => [
-            'input' => new class() {
+            'input' => new class () {
                 public function __toString(): string
                 {
                     return '2345';

--- a/src/Storage/TopLevelDomainListPsr16Cache.php
+++ b/src/Storage/TopLevelDomainListPsr16Cache.php
@@ -11,6 +11,7 @@ use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use Stringable;
 use Throwable;
+
 use function md5;
 use function strtolower;
 

--- a/src/Storage/TopLevelDomainListPsr16CacheTest.php
+++ b/src/Storage/TopLevelDomainListPsr16CacheTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Runner\ErrorHandler;
 use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
+
 use function dirname;
 
 final class TopLevelDomainListPsr16CacheTest extends TestCase
@@ -82,7 +83,7 @@ final class TopLevelDomainListPsr16CacheTest extends TestCase
 
     public function testItReturnsFalseIfItCantCacheATopLevelDomainListInstance(): void
     {
-        $exception = new class('Something went wrong.', 0) extends RuntimeException implements CacheException {
+        $exception = new class ('Something went wrong.', 0) extends RuntimeException implements CacheException {
         };
         $cache = self::createStub(CacheInterface::class);
         $cache->method('set')->will(self::throwException($exception));
@@ -95,7 +96,7 @@ final class TopLevelDomainListPsr16CacheTest extends TestCase
 
     public function testItThrowsIfItCantCacheATopLevelDomainListInstance(): void
     {
-        $exception = new class('Something went wrong.', 0) extends RuntimeException {
+        $exception = new class ('Something went wrong.', 0) extends RuntimeException {
         };
         $cache = self::createStub(CacheInterface::class);
         $cache->method('set')->will(self::throwException($exception));

--- a/src/Storage/TopLevelDomainListPsr18ClientTest.php
+++ b/src/Storage/TopLevelDomainListPsr18ClientTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+
 use function dirname;
 use function file_get_contents;
 
@@ -21,7 +22,7 @@ final class TopLevelDomainListPsr18ClientTest extends TestCase
 {
     public function testIsCanReturnARootZoneDatabaseInstance(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 /** @var string $body */
@@ -31,7 +32,7 @@ final class TopLevelDomainListPsr18ClientTest extends TestCase
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);
@@ -46,14 +47,14 @@ final class TopLevelDomainListPsr18ClientTest extends TestCase
 
     public function testItWillThrowIfTheClientCanNotConnectToTheRemoteURI(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 throw new ConnectException('foobar', $request, null);
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);
@@ -69,14 +70,14 @@ final class TopLevelDomainListPsr18ClientTest extends TestCase
 
     public function testItWillThrowIfTheReturnedStatusCodeIsNotOK(): void
     {
-        $client = new class() implements ClientInterface {
+        $client = new class () implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 return new Response(404);
             }
         };
 
-        $requestFactory = new class() implements RequestFactoryInterface {
+        $requestFactory = new class () implements RequestFactoryInterface {
             public function createRequest(string $method, $uri): RequestInterface
             {
                 return new Request($method, $uri);

--- a/src/Storage/TopLevelDomainsStorageTest.php
+++ b/src/Storage/TopLevelDomainsStorageTest.php
@@ -7,13 +7,14 @@ namespace Pdp\Storage;
 use Pdp\TopLevelDomainList;
 use Pdp\TopLevelDomains;
 use PHPUnit\Framework\TestCase;
+
 use function dirname;
 
 final class TopLevelDomainsStorageTest extends TestCase
 {
     public function testIsCanReturnARootZoneDatabaseInstanceFromCache(): void
     {
-        $cache = new class() implements TopLevelDomainListCache {
+        $cache = new class () implements TopLevelDomainListCache {
             public function fetch(string $uri): ?TopLevelDomainList
             {
                 return TopLevelDomains::fromPath(dirname(__DIR__, 2).'/test_data/tlds-alpha-by-domain.txt');
@@ -30,7 +31,7 @@ final class TopLevelDomainsStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements TopLevelDomainListClient {
+        $client = new class () implements TopLevelDomainListClient {
             public function get(string $uri): TopLevelDomainList
             {
                 return TopLevelDomains::fromPath(dirname(__DIR__, 2).'/test_data/tlds-alpha-by-domain.txt');
@@ -44,7 +45,7 @@ final class TopLevelDomainsStorageTest extends TestCase
 
     public function testIsCanReturnARootZoneDatabaseInstanceFromTheInnerStorage(): void
     {
-        $cache = new class() implements TopLevelDomainListCache {
+        $cache = new class () implements TopLevelDomainListCache {
             public function fetch(string $uri): ?TopLevelDomainList
             {
                 return null;
@@ -61,7 +62,7 @@ final class TopLevelDomainsStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements TopLevelDomainListClient {
+        $client = new class () implements TopLevelDomainListClient {
             public function get(string $uri): TopLevelDomainList
             {
                 return TopLevelDomains::fromPath(dirname(__DIR__, 2).'/test_data/tlds-alpha-by-domain.txt');
@@ -75,7 +76,7 @@ final class TopLevelDomainsStorageTest extends TestCase
 
     public function testIsCanDeleteARootZoneDatabaseInstanceFromTheInnerStorage(): void
     {
-        $cache = new class() implements TopLevelDomainListCache {
+        $cache = new class () implements TopLevelDomainListCache {
             public function fetch(string $uri): ?TopLevelDomainList
             {
                 return null;
@@ -92,7 +93,7 @@ final class TopLevelDomainsStorageTest extends TestCase
             }
         };
 
-        $client = new class() implements TopLevelDomainListClient {
+        $client = new class () implements TopLevelDomainListClient {
             public function get(string $uri): TopLevelDomainList
             {
                 return TopLevelDomains::fromPath(dirname(__DIR__, 2).'/test_data/tlds-alpha-by-domain.txt');

--- a/src/Suffix.php
+++ b/src/Suffix.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pdp;
 
 use Stringable;
+
 use function count;
 use function in_array;
 

--- a/src/SuffixTest.php
+++ b/src/SuffixTest.php
@@ -6,6 +6,7 @@ namespace Pdp;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
 use function json_encode;
 
 final class SuffixTest extends TestCase

--- a/src/TopLevelDomainList.php
+++ b/src/TopLevelDomainList.php
@@ -24,7 +24,7 @@ interface TopLevelDomainList extends Countable, DomainNameResolver, IteratorAggr
      */
     public function lastUpdated(): DateTimeImmutable;
 
-    
+
     public function count(): int;
 
     /**
@@ -40,7 +40,7 @@ interface TopLevelDomainList extends Countable, DomainNameResolver, IteratorAggr
     /**
      * Returns PSL info for a given domain against the PSL rules for ICANN domain detection.
      *
-     * @throws SyntaxError           if the domain is invalid
+     * @throws SyntaxError if the domain is invalid
      * @throws UnableToResolveDomain if the domain does not contain a IANA Effective TLD
      */
     public function getIANADomain(Host $host): ResolvedDomainName;

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -9,6 +9,7 @@ use Iterator;
 use SplFileObject;
 use SplTempFileObject;
 use Stringable;
+
 use function count;
 use function in_array;
 use function preg_match;
@@ -34,7 +35,7 @@ final class TopLevelDomains implements TopLevelDomainList
      *
      * @param null|resource $context
      *
-     * @throws UnableToLoadResource           If the rules can not be loaded from the path
+     * @throws UnableToLoadResource If the rules can not be loaded from the path
      * @throws UnableToLoadTopLevelDomainList If the content is invalid or can not be correctly parsed and converted
      */
     public static function fromPath(string $path, $context = null): self
@@ -185,7 +186,7 @@ final class TopLevelDomains implements TopLevelDomainList
     /**
      * Assert the domain is valid and is resolvable.
      *
-     * @throws SyntaxError           If the domain is invalid
+     * @throws SyntaxError If the domain is invalid
      * @throws UnableToResolveDomain If the domain can not be resolved
      */
     private function validateDomain(int|DomainNameProvider|Host|string|Stringable|null $domain): DomainName

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -11,7 +11,6 @@ use SplTempFileObject;
 use Stringable;
 
 use function count;
-use function in_array;
 use function preg_match;
 use function trim;
 
@@ -172,7 +171,7 @@ final class TopLevelDomains implements TopLevelDomainList
     {
         try {
             $domain = $this->validateDomain($host);
-            if ($this->containsTopLevelDomain($domain)) {
+            if ($this->containsTopLevelDomain($domain->withoutRootLabel())) {
                 return ResolvedDomain::fromIANA($domain);
             }
             return ResolvedDomain::fromUnknown($domain);
@@ -199,8 +198,7 @@ final class TopLevelDomains implements TopLevelDomainList
             $domain = Domain::fromIDNA2008($domain);
         }
 
-        $label = $domain->label(0);
-        if (in_array($label, [null, ''], true)) {
+        if (null === $domain->label(0)) {
             throw UnableToResolveDomain::dueToUnresolvableDomain($domain);
         }
 
@@ -212,13 +210,10 @@ final class TopLevelDomains implements TopLevelDomainList
         return isset($this->records[$domain->toAscii()->label(0)]);
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host a domain in a type that can be converted into a DomainInterface instance
-     */
-    public function getIANADomain($host): ResolvedDomainName
+    public function getIANADomain(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         $domain = $this->validateDomain($host);
-        if (!$this->containsTopLevelDomain($domain)) {
+        if (!$this->containsTopLevelDomain($domain->withoutRootLabel())) {
             throw UnableToResolveDomain::dueToMissingSuffix($domain, 'IANA');
         }
 

--- a/src/TopLevelDomains.php
+++ b/src/TopLevelDomains.php
@@ -164,10 +164,7 @@ final class TopLevelDomains implements TopLevelDomainList
         yield from array_keys($this->records);
     }
 
-    /**
-     * @param int|DomainNameProvider|Host|string|Stringable|null $host a type that supports instantiating a Domain from.
-     */
-    public function resolve($host): ResolvedDomainName
+    public function resolve(DomainNameProvider|Host|Stringable|string|int|null $host): ResolvedDomainName
     {
         try {
             $domain = $this->validateDomain($host);
@@ -188,7 +185,7 @@ final class TopLevelDomains implements TopLevelDomainList
      * @throws SyntaxError If the domain is invalid
      * @throws UnableToResolveDomain If the domain can not be resolved
      */
-    private function validateDomain(int|DomainNameProvider|Host|string|Stringable|null $domain): DomainName
+    private function validateDomain(DomainNameProvider|Host|Stringable|string|int|null $domain): DomainName
     {
         if ($domain instanceof DomainNameProvider) {
             $domain = $domain->domain();

--- a/src/TopLevelDomainsTest.php
+++ b/src/TopLevelDomainsTest.php
@@ -9,7 +9,6 @@ use DateTimeZone;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Stringable;
-use TypeError;
 
 use function dirname;
 
@@ -187,13 +186,6 @@ EOF;
         ];
     }
 
-    public function testTopLevelDomainThrowsTypeError(): void
-    {
-        $this->expectException(TypeError::class);
-
-        self::$topLevelDomains->getIANADomain(new DateTimeImmutable()); /* @phpstan-ignore-line */
-    }
-
     public function testTopLevelDomainWithInvalidDomain(): void
     {
         $this->expectException(SyntaxError::class);
@@ -212,8 +204,8 @@ EOF;
     {
         $result = self::$topLevelDomains->resolve('example.com.');
         self::assertSame('example.com.', $result->value());
-        self::assertFalse($result->suffix()->isIANA());
-        self::assertNull($result->suffix()->value());
+        self::assertTrue($result->suffix()->isIANA());
+        self::assertSame('com', $result->suffix()->value());
     }
 
     public function testTopLevelDomainWithUnResolvableDomain(): void
@@ -221,6 +213,13 @@ EOF;
         $this->expectException(UnableToResolveDomain::class);
 
         self::$topLevelDomains->getIANADomain('localhost');
+    }
+
+    public function testTopLevelDomainWithUnResolvableDomain2(): void
+    {
+        $this->expectException(UnableToResolveDomain::class);
+
+        self::$topLevelDomains->getIANADomain('localhost.');
     }
 
     public function testResolveWithUnResolvableDomain(): void

--- a/src/TopLevelDomainsTest.php
+++ b/src/TopLevelDomainsTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Stringable;
 use TypeError;
+
 use function dirname;
 
 final class TopLevelDomainsTest extends TestCase
@@ -24,7 +25,7 @@ final class TopLevelDomainsTest extends TestCase
     public function testCreateFromPath(): void
     {
         $context = stream_context_create([
-            'http'=> [
+            'http' => [
                 'method' => 'GET',
                 'header' => "Accept-language: en\r\nCookie: foo=bar\r\n",
             ],
@@ -176,7 +177,7 @@ EOF;
             'Unicode domain (1)' => ['الاعلى-للاتصالات.قطر'],
             'Unicode domain (2)' => ['кто.рф'],
             'Unicode domain (3)' => ['Deutsche.Vermögensberatung.vermögensberater'],
-            'object with __toString method' => [new class() {
+            'object with __toString method' => [new class () {
                 public function __toString(): string
                 {
                     return 'www.இந.இந்தியா';
@@ -269,7 +270,7 @@ EOF;
             'Unicode TLD (3)' => ['рф'],
             'Unicode TLD (4)' => ['இந்தியா'],
             'Unicode TLD (5)' => ['vermögensberater'],
-            'object with __toString method' => [new class() {
+            'object with __toString method' => [new class () {
                 public function __toString(): string
                 {
                     return 'COM';
@@ -296,7 +297,7 @@ EOF;
             'invalid IDN to ASCII' => ['XN--TTT'],
             'invalid IDN to ASCII with leading dot' => ['.XN--TTT'],
             'null' => [null],
-            'object with __toString method' => [new class() {
+            'object with __toString method' => [new class () {
                 public function __toString(): string
                 {
                     return 'COMMM';


### PR DESCRIPTION
Resolve issue #361 by adding:

- `DomainName::withRootLabel();`
- `DomainName::withoutRootLabel();`
- `DomainName::isAbsolute();`

The resolution API does not change but the `resolve` now can also resolve absolute domain:

```php
<?php

$result = $publicSuffixList->resolve('private.ulb.ac.be.');
$result->suffix()->toString();                     // returns 'ac.be'
$result->domain()->toString();                     // returns 'private.ulb.ac.be.'
$result->registrableDomain()->toString();          // returns 'ulb.ac.be'
$result->secondLevelDomain()->toString();          // returns 'ulb'
$result->subDomain()->toString();                  // returns 'private'
$result->domain()->isAbsolute();                   // returns true
$result->domain()->withoutRootLabel()->toString(); // returns 'private.ulb.ac.be'
```
