### PR TITLE
Fix #363 - domain and subdomain wildcard

### DIFF
--- a/src/RulesTest.php
+++ b/src/RulesTest.php
@@ -565,4 +565,39 @@ final class RulesTest extends TestCase
         self::assertTrue($domain->suffix()->isPrivate());
         self::assertSame('lt.eu.org', $domain->suffix()->value());
     }
+
+    #[DataProvider('privateDomainWithWildcardProvider')]
+    public function testWithPrivateDomainThatHasWildcardSubdomain(string $inputDomain, string $expectedSuffix): void
+    {
+        $domain = self::$rules->getPrivateDomain($inputDomain);
+
+        self::assertSame($expectedSuffix, $domain->suffix()->value());
+        self::assertFalse($domain->suffix()->isICANN());
+        self::assertTrue($domain->suffix()->isPrivate());
+    }
+
+    /**
+     * @return iterable<string, array{inputDomain: string, expectedSuffix: string}>
+     */
+    public static function privateDomainWithWildcardProvider(): iterable
+    {
+        return [
+            'appspot subdomain' => [
+                'inputDomain' => 'test-domain.de.r.appspot.com',
+                'expectedSuffix' => 'de.r.appspot.com',
+            ],
+            'appspot root domain' => [
+                'inputDomain' => 'test-domain.appspot.com',
+                'expectedSuffix' => 'appspot.com',
+            ],
+            'qcx subdomain' => [
+                'inputDomain' => 'test-domain.de.sys.qcx.io',
+                'expectedSuffix' => 'de.sys.qcx.io',
+            ],
+            'qcx root domain' => [
+                'inputDomain' => 'test-domain.qcx.io',
+                'expectedSuffix' => 'qcx.io',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
## Introduction

Discovered a bug in #363 in resolving private domains that also have a subdomain wildcard.

## Proposal

### Describe the new/upated/fixed feature

When a rule is added, we check whether a rule-path to it already exists.
If it does and it is the outermost rule (`[] === $list[$rule]`), we add a special marker which indicates that there is a rule for this part before adding the further path.
The choice of the marker is quite random (`?`), but it is based on the characters allowed in urls and what is already used in the [list entry format](https://github.com/publicsuffix/list/wiki/Format#entry-specification).

When resolving the `getPublicSuffixLengthFromSection()`, before terminating when iteratively matching the domain labels comes to a halt (no more labels to match), before checking whether there are `hasRemainingRules()` we check for the special marker.
When recursing here, the `hasRemainingRules` would always be true, as there is another rule further down the array.

I've worked up from adding the special marker for every rule, but that doubled the memory usage from ~2 to ~4MB.
So only adding it, before a new rule is added.
This should always work, due to the [right to left sorting](https://github.com/publicsuffix/list/wiki/Format#right-to-left-sorting).

### Backward Incompatible Changes

There should be no BC breaks here.

### Targeted release version

6.3.2
I'll verify if i can target older versions.

### PR Impact

No API changes
Only the structure of the private rules array is modified slightly.
Fixes a bug

## Open issues

to be discussed:
- extracting the checks in `addRule` into static methods for readability
- choice of marker character